### PR TITLE
Abbreviate folder names in top include folders

### DIFF
--- a/production/inc/db/README.md
+++ b/production/inc/db/README.md
@@ -1,2 +1,2 @@
-# production/inc/database_engine
+# production/inc/db
 This folder contains the public interface for the database engine.

--- a/production/inc/rules/README.md
+++ b/production/inc/rules/README.md
@@ -1,2 +1,2 @@
-# production/inc/rules_engine
+# production/inc/rules
 This folder contains the public interface for the rules engine.


### PR DESCRIPTION
Forgot to also rename the db/rules folders under the main production\inc folder.