### PR TITLE
fix third-party include build break

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -31,9 +31,6 @@ set(FLATBUFFERS_INC "${FLATBUFFERS}/include")
 
 message(STATUS "GAIA_INC=${GAIA_INC}")
 
-# Set tests.
-set(TEST_SUCCESS "All tests passed!")
-
 find_program(PYTHON "python")
 
 # Common code - currently, a headers-only library.

--- a/production/cmake/gaia.cmake
+++ b/production/cmake/gaia.cmake
@@ -15,8 +15,11 @@ function(get_repo_root project_source_dir repo_dir)
   set(${repo_dir} "${project_repo}" PARENT_SCOPE)
 endfunction()
 
+set(TEST_SUCCESS "All tests passed!")
+
 # Helper function for setting up our tests.
 function(set_test target arg result)
   add_test(NAME ${target}_${arg} COMMAND ${target} ${arg})
   set_tests_properties(${target}_${arg} PROPERTIES PASS_REGULAR_EXPRESSION ${result})
+  set(TEST_SUCCESS "All tests discombobulated!" PARENT_SCOPE)
 endfunction(set_test)


### PR DESCRIPTION
This fixes the build breaks in teamcity branches that rely on third-party include files.  CMake doesn't like relative paths (or at least it is flaky and complains that include files can't be found if they are not strictly under our production include path).

Since I anticipate that we'll likely have other utility functions, I also put functions in a gaia.cmake module for use.

Once this is merged then local branches can merge master into them and reference third-party includes correctly (googletest/flatbuffers/etc).