### PR TITLE
[WIP] Increase the minimum version of cmake from 3.10 to 3.11.

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 include(UseJava)
 

--- a/demos/cow_se/CMakeLists.txt
+++ b/demos/cow_se/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(cow_se)

--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 enable_testing()
 

--- a/production/db/CMakeLists.txt
+++ b/production/db/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(db)

--- a/production/db/memory_manager/CMakeLists.txt
+++ b/production/db/memory_manager/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(memory_manager)

--- a/production/rules/CMakeLists.txt
+++ b/production/rules/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(rules)

--- a/production/rules/event_manager/CMakeLists.txt
+++ b/production/rules/event_manager/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 enable_testing()
 
 # Set the project name.

--- a/scratch/benchmarks/addr_book/CMakeLists.txt
+++ b/scratch/benchmarks/addr_book/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(addr_book)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/scratch/benchmarks/airimport/CMakeLists.txt
+++ b/scratch/benchmarks/airimport/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(airport_data)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/scratch/benchmarks/apis/CMakeLists.txt
+++ b/scratch/benchmarks/apis/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(demo_api)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/scratch/laurentiu/CMakeLists.txt
+++ b/scratch/laurentiu/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 enable_testing()
 

--- a/scratch/laurentiu/flatbuffers/CMakeLists.txt
+++ b/scratch/laurentiu/flatbuffers/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(flatbuffers)

--- a/scratch/laurentiu/jni/CMakeLists.txt
+++ b/scratch/laurentiu/jni/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 include(UseJava)
 

--- a/scratch/laurentiu/jni/Experiment/CMakeLists.txt
+++ b/scratch/laurentiu/jni/Experiment/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(Experiment)

--- a/scratch/laurentiu/jni/HelloWorld/CMakeLists.txt
+++ b/scratch/laurentiu/jni/HelloWorld/CMakeLists.txt
@@ -3,7 +3,7 @@
 # All rights reserved.
 #############################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Set the project name.
 project(HelloWorld)


### PR DESCRIPTION
In order to support some of the gremlin/tinkerpop graph qp work that we are doing we need to increase the minimum required version of cmake from 3.10 to 3.11.  This is because we are using the `GENERATE_NATIVE_HEADERS` option from the `add_jar` command in the `UseJava` module.  This option is only available in 3.11 or newer versions of cmake.

From the 3.11 release notes:

> The UseJava module add_jar command gained a GENERATE_NATIVE_HEADERS option to generate native header files using javac -h for javac 1.8 or above. This supersedes create_javah, which no longer works with JDK 1.10 and above due to removal of the javah tool by JEP 313.

Marked as a WIP branch because we don't want to check this in until I update the teamcity machine.  If this gets merged before this update then everyone will get spammed with build failures.  