### PR TITLE
Enable TrueGraphDB provider to handle string labels and other small i…

### DIFF
--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBEdge.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBEdge.java
@@ -11,11 +11,17 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;

--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBElement.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBElement.java
@@ -5,8 +5,6 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
-
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;

--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBGraph.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBGraph.java
@@ -11,7 +11,12 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -20,7 +25,13 @@ import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
-import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.GraphVariableHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;

--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBHelper.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBHelper.java
@@ -11,13 +11,25 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -197,7 +209,7 @@ public final class TrueGraphDBHelper
     {
         if (vertex.outEdges == null)
         {
-            vertex.outEdges = new HashMap<>();
+            vertex.outEdges = new ConcurrentHashMap<>();
         }
 
         Set<Edge> edges = vertex.outEdges.get(label);
@@ -215,7 +227,7 @@ public final class TrueGraphDBHelper
     {
         if (vertex.inEdges == null)
         {
-            vertex.inEdges = new HashMap<>();   
+            vertex.inEdges = new ConcurrentHashMap<>();   
         }
 
         Set<Edge> edges = vertex.inEdges.get(label);

--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBVertex.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBVertex.java
@@ -11,11 +11,21 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;

--- a/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBVertexProperty.java
+++ b/demos/cow_se/src/java/com/gaiaplatform/truegraphdb/tinkerpop/gremlin/structure/TrueGraphDBVertexProperty.java
@@ -11,10 +11,16 @@
 
 package com.gaiaplatform.truegraphdb.tinkerpop.gremlin.structure;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -93,7 +99,7 @@ public final class TrueGraphDBVertexProperty<V> extends TrueGraphDBElement imple
 
         if (this.properties == null)
         {
-            this.properties = new HashMap<>();
+            this.properties = new ConcurrentHashMap<>();
         }
 
         this.properties.put(key, newProperty);


### PR DESCRIPTION
…mprovements

Some quick improvements to allow the creation of graphs with String labels. COW's equivalent concept are integer types, so it cannot support strings. This change enables the provider to assign identifiers to labels and pass those down to COW.

Also replaced some internal provider maps with concurrent implementations and fixed some variable names.