### PR TITLE
Add flatbuffer payload schema for airport graph

### DIFF
--- a/production/db/storage_engine/mock/airport.fbs
+++ b/production/db/storage_engine/mock/airport.fbs
@@ -3,6 +3,8 @@
 // All rights reserved.
 /////////////////////////////////////////////
 
+// -*- mode: java -*- // Java mode works for emacs to edit flatbuffers.
+
 namespace gaia.airport;
 
 // Payload for COW node type 1, loaded from airports.dat.


### PR DESCRIPTION
We have 3 components that need to be able to interoperate over a COW store instance with airport data:

- direct access code (Dax&Wayne)
- relational view through Postgres (Tobin)
- graph view through Gremlin (Laurentiu)

For this to happen, the airport data needs to be loaded in a specific way. This flatbuffer schema file describes the node & edge type values that should be used, as well as the payload flatbuffer schema for each.

Sending this to a wider audience fyi.