### PR TITLE
Airport flatbuffers schema for use with Q1 demo

### DIFF
--- a/production/db/storage_engine/mock/airport_q1.fbs
+++ b/production/db/storage_engine/mock/airport_q1.fbs
@@ -11,8 +11,6 @@ namespace gaia.airport;
 table airlines
 {
     Gaia_id: int64;
-    Gaia_Next_id: int64;
-    Gaia_Prev_id: int64;
 
     // Original airline fields.
     al_id: int32;
@@ -29,8 +27,6 @@ table airlines
 table airports
 {
     Gaia_id: int64;
-    Gaia_Next_id: int64;
-    Gaia_Prev_id: int64;
 
     // Original airports fields.
     ap_id: int32;
@@ -56,8 +52,6 @@ table airports
 table routes
 {
     Gaia_id: int64;
-    Gaia_Next_id: int64;
-    Gaia_Prev_id: int64;
     Gaia_Al_id:   int64;
     Gaia_Src_id:  int64;
     Gaia_Dst_id:  int64;


### PR DESCRIPTION
This is the schema from demos/airport, with some commented fields removed and with type assignment mentioned in comments. I believe this is what Dax/Wayne have used in their airimport tool as well. If you want to place more data in the demo graph, make sure to add here the information about node/edge types and their payload.