### PR TITLE
Make presence of gflags optional when building rocksdb

### DIFF
--- a/third_party/production/rocksdb/CMakeLists.txt
+++ b/third_party/production/rocksdb/CMakeLists.txt
@@ -84,7 +84,7 @@ else()
 endif()
 
 include(CMakeDependentOption)
-CMAKE_DEPENDENT_OPTION(WITH_GFLAGS "build with GFlags" ON
+CMAKE_DEPENDENT_OPTION(WITH_GFLAGS "build with GFlags" OFF
   "NOT MSVC;NOT MINGW" OFF)
 
 if(MSVC)


### PR DESCRIPTION
This is used to run rocksdb tools such as benchtest, stress test, ldb.

Folks can get gflags if they want to use rocksdb tools

There's no reason to make build dependent on gflags.