### PR TITLE
test for GAIA-78 - get_next not preceeded by get_first

### DIFF
--- a/production/tests/common/direct_access/test_direct_access.cpp
+++ b/production/tests/common/direct_access/test_direct_access.cpp
@@ -458,9 +458,9 @@ TEST_F(gaia_object_test, new_del_del) {
 TEST_F(gaia_object_test, next_first) {
     gaia_base_t::begin_transaction();
     auto e1 = get_field("Harold");
-    auto e2 = get_field("Jameson");
-    EXPECT_EQ(2, count_rows());
-    EXPECT_EQ(e2, e1->get_next());
-    EXPECT_EQ(nullptr, e2->get_next());
+    auto e2 = get_field("Howard");
+    auto e3 = get_field("Hank");
+    auto e_test = e2->get_next();
+    EXPECT_TRUE(e_test == e1 || e_test == e3 || e_test == nullptr);
     gaia_base_t::commit_transaction();
 }


### PR DESCRIPTION
During another pull request, Dax asked about the behavior of the gaia_object_t method get_next() if the get_first() method had not been called first in the sequence. I filed GAIA-78 to test for this and/or fix it.

It turns out that get_next() will always find the next gaia_object_t of the same type in the gaia_id_t sequence, no matter how the object was originally obtained.

A test was added for this in `production/tests/common/direct_access`.