### PR TITLE
A more correct test for GAIA-78 - get_next() with new object

### DIFF
--- a/production/tests/common/direct_access/test_direct_access.cpp
+++ b/production/tests/common/direct_access/test_direct_access.cpp
@@ -462,5 +462,9 @@ TEST_F(gaia_object_test, next_first) {
     auto e3 = get_field("Hank");
     auto e_test = e2->get_next();
     EXPECT_TRUE(e_test == e1 || e_test == e3 || e_test == nullptr);
+    auto e4 = new Employee();
+    // In this case, the row doesn't exist yet.
+    e4->set_name_first("Hector");
+    EXPECT_EQ(nullptr, e4->get_next());
     gaia_base_t::commit_transaction();
 }


### PR DESCRIPTION
My apologies for an incorrect/incomplete response to Dax's concern on the `gaia_object_t::get_next()` method.

When a new extended data class object is created, it is not associated with a storage engine node and does not have an assigned `gaia_id_t` id. The correct response from `get_next()` is to return `nullptr`, as it would do at the end of the list of typed objects.

These new lines in the test verify that the behavior is correct and that there is no crash.