### PR TITLE
Disable automatic reordering of includes.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
+SortIncludes: false


### PR DESCRIPTION
I know header files should be insensitive to include ordering, but I have to deal with some autogenerated headers that are inclusion-order sensitive, and the default behavior of sorting includes by filename broke the build.