### PR TITLE
Extract some method implementations from header files

### DIFF
--- a/production/db/inc/memory_manager/access_control.hpp
+++ b/production/db/inc/memory_manager/access_control.hpp
@@ -31,16 +31,8 @@ struct access_control_t
     uint32_t readers_count;
     access_lock_type_t access_lock;
 
-    access_control_t()
-    {
-        clear();
-    }
-
-    void clear()
-    {
-        readers_count = 0;
-        access_lock = access_lock_type_t::none;
-    }
+    access_control_t();
+    void clear();
 };
 
 // A class for access synchronization. It can be used to implement spinlocks.

--- a/production/db/memory_manager/src/access_control.cpp
+++ b/production/db/memory_manager/src/access_control.cpp
@@ -10,6 +10,17 @@
 using namespace gaia::common;
 using namespace gaia::db::memory_manager;
 
+access_control_t::access_control_t()
+{
+    clear();
+}
+
+void access_control_t::clear()
+{
+    readers_count = 0;
+    access_lock = access_lock_type_t::none;
+}
+
 auto_access_control_t::auto_access_control_t()
 {
     clear();


### PR DESCRIPTION
Just a small cleanup change of moving some method implementations from a header file to the corresponding cpp file.