### PR TITLE
Remove lexer header from parser test

### DIFF
--- a/production/catalog/parser/tests/test_ddl_parser.cpp
+++ b/production/catalog/parser/tests/test_ddl_parser.cpp
@@ -5,7 +5,6 @@
 
 #include "gaia_catalog.hpp"
 #include "gaia_parser.hpp"
-#include "yy_lexer.hpp"
 #include "yy_parser.hpp"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
My latest commit caused a build break. The lexer header is no longer needed but somehow still included in the test source, possibly due to a merge error on my side. 