### PR TITLE
[GAIAPLAT-259] Add helper method for determining the last operation on a table type

### DIFF
--- a/production/inc/public/rules/rules.hpp
+++ b/production/inc/public/rules/rules.hpp
@@ -108,6 +108,21 @@ typedef std::unordered_set<uint16_t> field_list_t;
 const field_list_t empty_fields;
 
 /**
+ * Enumeration for the last database operation performed for a given gaia type.
+ * This is a different enum type than the event type because there may be
+ * events that are not caused by a table operation.  In addition, a 'none'
+ * enum value is provided to indicate that no operation was performed on a
+ * table. See the rule_context_t::last_operation() method for further
+ * explanation.
+ */
+enum class last_operation_t : uint8_t {
+    none,
+    row_update,
+    row_insert,
+    row_delete
+};
+
+/**
  * The rule context wraps the event (or data) context as well as information 
  * about the event and rule metadata.  In the future the rule context may also 
  * maintain the error state of the rule invocation.  Therefore, the rule 
@@ -124,7 +139,7 @@ const field_list_t empty_fields;
  */
 struct rule_context_t 
 {
-public:            
+public:
     rule_context_t(
         const rule_binding_t& a_binding, 
         gaia::common::gaia_type_t a_gaia_type,
@@ -138,6 +153,21 @@ public:
     }
     
     rule_context_t() = delete;
+
+    /**
+     * Helper to enable a declarative rule to check what the last database
+     * operation was for the passed-in type. For example, consider a rule that
+     * may be invoked either from a table operation on type X or a change to
+     * a field reference in table Y. This method enables the rule author to 
+     * determine the reason for the rule being invoked.
+     * 
+     * if (X.last_operation == last_operation_t::row_update) { do A stuff }
+     * else { do B stuff } 
+     * 
+     * This method will return last_operation_t::none if this rule was not
+     * invoked due to an operation on X.
+     */
+    last_operation_t last_operation(gaia_type_t gaia_type);
 
     const rule_binding_t rule_binding;
     gaia::common::gaia_type_t gaia_type;

--- a/production/rules/event_manager/CMakeLists.txt
+++ b/production/rules/event_manager/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 add_library(gaia_rules STATIC
   src/event_manager.cpp
   src/rule_thread_pool.cpp
+  src/rule_context.cpp
 )
 add_dependencies(gaia_rules generate_event_logs)
 set_target_properties(gaia_rules PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS}")
@@ -51,7 +52,8 @@ target_link_libraries(gaia_rules PRIVATE gaia_semock)
 set_property (TARGET gaia_rules PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # unit tests
-# add_gtest(test_auto_tx "tests/test_auto_tx.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
-# add_gtest(test_event_manager "tests/test_event_manager.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
-# add_gtest(test_system_init "tests/test_system_init.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
-# add_gtest(test_component_init "tests/test_component_init.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
+#add_gtest(test_auto_tx "tests/test_auto_tx.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia_semock")
+#add_gtest(test_event_manager "tests/test_event_manager.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
+#add_gtest(test_system_init "tests/test_system_init.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia")
+#add_gtest(test_component_init "tests/test_component_init.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia_rules;gaia_direct;gaia_semock")
+add_gtest(test_rule_context "tests/test_rule_context.cpp" "${GAIA_EVENT_MANAGER_INCLUDES}" "rt;gaia_rules")

--- a/production/rules/event_manager/src/rule_context.cpp
+++ b/production/rules/event_manager/src/rule_context.cpp
@@ -1,0 +1,37 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#include "rules.hpp"
+
+using namespace gaia::rules;
+using namespace gaia::common;
+
+last_operation_t rule_context_t::last_operation(gaia_type_t other_gaia_type)
+{
+    last_operation_t operation = last_operation_t::none;
+
+    if (other_gaia_type != gaia_type)
+    {
+        return operation;
+    }
+
+    switch(event_type)
+    {
+        case event_type_t::row_delete:
+            operation = last_operation_t::row_delete;
+            break;
+        case event_type_t::row_insert:
+            operation = last_operation_t::row_insert;
+            break;
+        case event_type_t::row_update:
+            operation = last_operation_t::row_update;
+            break;
+        default:
+            // Ignore other event types.
+            break;
+    }
+
+    return operation;
+}

--- a/production/rules/event_manager/tests/test_rule_context.cpp
+++ b/production/rules/event_manager/tests/test_rule_context.cpp
@@ -1,0 +1,63 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+// Do not include event_manager.hpp to ensure that
+// we don't have a dependency on the internal implementation.
+
+#include "gtest/gtest.h"
+#include "rules.hpp"
+
+using namespace std;
+using namespace gaia::db;
+using namespace gaia::rules;
+
+void check_all_event_types(
+    gaia_type_t context_type, 
+    gaia_type_t test_type, 
+    last_operation_t* expected)
+{
+    rule_binding_t binding;
+    rule_context_t context(binding, context_type, event_type_t::row_delete, 0);
+
+    // Test the insert/update/delete events which map to last operation types.
+    EXPECT_EQ(expected ? *expected : last_operation_t::row_delete, 
+        context.last_operation(test_type));
+
+    context.event_type = event_type_t::row_update;
+    EXPECT_EQ(expected ? *expected : last_operation_t::row_update, 
+        context.last_operation(test_type));
+
+    context.event_type = event_type_t::row_insert;
+    EXPECT_EQ(expected ? *expected : last_operation_t::row_insert, 
+        context.last_operation(test_type));
+
+    // Test event types that are not table operations.
+    context.event_type = event_type_t::transaction_begin;
+    EXPECT_EQ(expected ? *expected : last_operation_t::none, 
+        context.last_operation(test_type));
+    
+    context.event_type = event_type_t::transaction_commit;
+    EXPECT_EQ(expected ? *expected : last_operation_t::none, 
+        context.last_operation(test_type));
+
+    context.event_type = event_type_t::transaction_rollback;
+    EXPECT_EQ(expected ? *expected : last_operation_t::none, 
+        context.last_operation(test_type));
+}
+
+TEST(rule_context_test, last_operation_type_match)
+{
+    // If the context type matches the passed-in type then we should get the
+    // last_operation_t value mapped to a table event type.
+    check_all_event_types(42, 42, nullptr);
+}
+
+TEST(rule_context_test, last_operation_type_mismatch)
+{
+    // If the context type does not match the passed-in type then the last operation
+    // performed on this type should be 'none'.
+    last_operation_t expected = last_operation_t::none;
+    check_all_event_types(0, 42, &expected);
+}


### PR DESCRIPTION
I messed up the commit history on my other branch whose pull request already got approved (see https://github.com/gaia-platform/GaiaPlatform/pull/130).   So issuing this pull request with a clean commit history and merging into master. 