### PR TITLE
Use standard integer type names in mock storage engine code

### DIFF
--- a/production/db/storage_engine/mock/gaia_hash_map.hpp
+++ b/production/db/storage_engine/mock/gaia_hash_map.hpp
@@ -75,8 +75,8 @@ class gaia_hash_map {
             }
 
             node = node->next
-                       ? client::s_data->hash_nodes + node->next
-                       : 0;
+                ? client::s_data->hash_nodes + node->next
+                : 0;
         }
 
         return 0;

--- a/production/db/storage_engine/mock/gaia_ptr.cpp
+++ b/production/db/storage_engine/mock/gaia_ptr.cpp
@@ -62,7 +62,7 @@ gaia_ptr::gaia_ptr(const gaia_id_t id, const size_t size, bool log_updates)
     hash_node->row_id = row_id = client::allocate_row_id();
     client::allocate_object(row_id, size);
 
-    // writing to log will be skipped for recovery
+    // Writing to log will be skipped for recovery.
     if (log_updates) {
         client::tx_log(row_id, 0, to_offset());
     }
@@ -76,16 +76,16 @@ gaia_ptr::object* gaia_ptr::to_ptr() const {
     client::verify_tx_active();
 
     return row_id && (*client::s_offsets)[row_id]
-               ? reinterpret_cast<gaia_ptr::object*>(client::s_data->objects + (*client::s_offsets)[row_id])
-               : nullptr;
+        ? reinterpret_cast<gaia_ptr::object*>(client::s_data->objects + (*client::s_offsets)[row_id])
+        : nullptr;
 }
 
 int64_t gaia_ptr::to_offset() const {
     client::verify_tx_active();
 
     return row_id
-               ? (*client::s_offsets)[row_id]
-               : 0;
+        ? (*client::s_offsets)[row_id]
+        : 0;
 }
 
 void gaia_ptr::find_next(gaia_type_t type) {

--- a/production/db/storage_engine/mock/rdb_object_converter.cpp
+++ b/production/db/storage_engine/mock/rdb_object_converter.cpp
@@ -13,17 +13,18 @@ using namespace gaia::db;
  * Key: fbb_type, id (uint64, uint64)
  * Value: value_type, payload_size, payload
  */
-void rdb_object_converter_util::encode_node(const u_int64_t id,
-    u_int64_t type,
-    u_int32_t size,
+void rdb_object_converter_util::encode_node(
+    const uint64_t id,
+    uint64_t type,
+    uint32_t size,
     const char* payload,
     string_writer* key,
     string_writer* value) {
-    // create key
+    // Create key.
     key->write_uint64(type);
     key->write_uint64(id);
 
-    // create value
+    // Create value.
     value->write_uint8(GaiaObjectType::node);
     value->write_uint32(size);
     value->write(payload, size);
@@ -32,20 +33,21 @@ void rdb_object_converter_util::encode_node(const u_int64_t id,
 /**
  * Todo: Update to create and return gaia_ptr<node>, pending recovery impl.
  */
-const char* rdb_object_converter_util::decode_node(const rocksdb::Slice& key,
+const char* rdb_object_converter_util::decode_node(
+    const rocksdb::Slice& key,
     const rocksdb::Slice& value,
     gaia_id_t* id,
     gaia_type_t* type,
-    u_int32_t* size) {
+    uint32_t* size) {
     string_reader key_(&key);
     string_reader value_(&value);
-    //Read key.
+    // Read key.
     key_.read_uint64(type);
     key_.read_uint64(id);
     assert(key_.get_remaining_len_in_bytes() == 0);
 
-    //Read value.
-    u_char type_;
+    // Read value.
+    uint8_t type_;
     value_.read_byte(&type_);
     assert(type_ == GaiaObjectType::node);
 
@@ -58,7 +60,7 @@ const char* rdb_object_converter_util::decode_node(const rocksdb::Slice& key,
  */
 bool rdb_object_converter_util::is_rdb_object_edge(const rocksdb::Slice& value) {
     assert(value.data());
-    const u_char* type = reinterpret_cast<const u_char*>(value.data());
+    const uint8_t* type = reinterpret_cast<const uint8_t*>(value.data());
     return *type == GaiaObjectType::edge;
 }
 
@@ -67,12 +69,13 @@ bool rdb_object_converter_util::is_rdb_object_edge(const rocksdb::Slice& value) 
  * Key: fbb_type, id (uint64, uint64)
  * Value: value_type, node_first, node_second, payload_size, payload
  */
-void rdb_object_converter_util::encode_edge(const u_int64_t id,
-    u_int64_t type,
-    u_int32_t size,
+void rdb_object_converter_util::encode_edge(
+    const uint64_t id,
+    uint64_t type,
+    uint32_t size,
     const char* payload,
-    const u_int64_t first,
-    const u_int64_t second,
+    const uint64_t first,
+    const uint64_t second,
     string_writer* key,
     string_writer* value) {
     // Create key.
@@ -90,11 +93,12 @@ void rdb_object_converter_util::encode_edge(const u_int64_t id,
 /**
  * Todo: Update to create and return gaia_ptr<edge>, pending recovery impl.
  */
-const char* rdb_object_converter_util::decode_edge(const rocksdb::Slice& key,
+const char* rdb_object_converter_util::decode_edge(
+    const rocksdb::Slice& key,
     const rocksdb::Slice& value,
     gaia_id_t* id,
     gaia_type_t* type,
-    u_int32_t* size,
+    uint32_t* size,
     gaia_id_t* first,
     gaia_id_t* second) {
     string_reader key_(&key);
@@ -105,7 +109,7 @@ const char* rdb_object_converter_util::decode_edge(const rocksdb::Slice& key,
     key_.read_uint64(id);
 
     // Read value.
-    u_char type_;
+    uint8_t type_;
     value_.read_byte(&type_);
     assert(type_ == GaiaObjectType::edge);
 

--- a/production/db/storage_engine/mock/rdb_object_converter.hpp
+++ b/production/db/storage_engine/mock/rdb_object_converter.hpp
@@ -17,13 +17,12 @@
 using namespace gaia::common;
 
 namespace gaia {
-
 namespace db {
 
 /**
  * Enum to represent gaia object types. Currently, the only types are nodes and edges.
  */
-enum GaiaObjectType : u_int8_t {
+enum GaiaObjectType : uint8_t {
     node = 0x0,
     edge = 0x1
 };
@@ -56,21 +55,21 @@ class string_writer {
 
     void write_uint64(const uint64_t value) {
         allocate(sizeof(uint64_t));
-        // Convert to network order (big endian)
+        // Convert to network order (big endian).
         u_int64_t result = htobe64(value);
         memcpy(m_buffer.data() + m_position - sizeof(uint64_t), &result, sizeof(result));
     }
 
     void write_uint32(const uint32_t value) {
         allocate(sizeof(uint32_t));
-        // Convert to network order (big endian)
+        // Convert to network order (big endian).
         u_int32_t result = htobe32(value);
         memcpy(m_buffer.data() + m_position - sizeof(uint32_t), &result, sizeof(result));
     }
 
-    void write_uint8(const u_int8_t value) {
-        allocate(sizeof(u_int8_t));
-        *(m_buffer.data() + m_position - sizeof(u_int8_t)) = value;
+    void write_uint8(const uint8_t value) {
+        allocate(sizeof(uint8_t));
+        *(m_buffer.data() + m_position - sizeof(uint8_t)) = value;
     }
 
     void write(const char* const payload, const size_t len) {
@@ -97,10 +96,10 @@ class string_writer {
  */
 class string_reader {
    private:
-    // current ptr to keep track of char's read in slice
+    // Current ptr to keep track of char's read in slice.
     const char* m_current;
-    // maintain remaining length for sanity purposes
-    u_int m_remaining;
+    // Maintain remaining length for sanity purposes.
+    size_t m_remaining;
 
    public:
     string_reader(const rocksdb::Slice* const slice) {
@@ -114,13 +113,13 @@ class string_reader {
         }
     }
 
-    bool read_uint64(u_int64_t* out) {
-        const u_char* casted_res =
-            reinterpret_cast<const u_char*>(read(sizeof(u_int64_t)));
+    bool read_uint64(uint64_t* out) {
+        const uint8_t* casted_res
+            = reinterpret_cast<const uint8_t*>(read(sizeof(uint64_t)));
 
         if (casted_res) {
-            u_int64_t temp;
-            memcpy(&temp, casted_res, sizeof(u_int64_t));
+            uint64_t temp;
+            memcpy(&temp, casted_res, sizeof(uint64_t));
             // Convert to little endian.
             *out = be64toh(temp);
             return true;  // Value read successfully.
@@ -129,13 +128,13 @@ class string_reader {
         return false;  // Error
     }
 
-    bool read_uint32(u_int32_t* out) {
-        const u_char* casted_res =
-            reinterpret_cast<const u_char*>(read(sizeof(u_int32_t)));
+    bool read_uint32(uint32_t* out) {
+        const uint8_t* casted_res
+            = reinterpret_cast<const uint8_t*>(read(sizeof(uint32_t)));
 
         if (casted_res) {
             uint32_t temp;
-            memcpy(&temp, casted_res, sizeof(u_int32_t));
+            memcpy(&temp, casted_res, sizeof(uint32_t));
             // Convert to little endian.
             *out = be32toh(temp);
             return true;  // Value read successfully.
@@ -144,9 +143,9 @@ class string_reader {
         return false;  // Error
     }
 
-    bool read_byte(u_char* out) {
-        const u_char* casted_res =
-            reinterpret_cast<const u_char*>(read(sizeof(u_char)));
+    bool read_byte(uint8_t* out) {
+        const uint8_t* casted_res
+            = reinterpret_cast<const uint8_t*>(read(sizeof(uint8_t)));
 
         if (casted_res) {
             *out = *casted_res;
@@ -156,11 +155,11 @@ class string_reader {
         return false;  // Error
     }
 
-    u_int get_remaining_len_in_bytes() {
+    size_t get_remaining_len_in_bytes() {
         return m_remaining;
     }
 
-    const char* read(const u_int size) {
+    const char* read(const size_t size) {
         // Sanity check
         if (size > m_remaining) {
             return nullptr;
@@ -179,35 +178,38 @@ class string_reader {
  */
 class rdb_object_converter_util {
    public:
-    static void encode_node(const u_int64_t id,
-        u_int64_t type,
-        u_int32_t size,
+    static void encode_node(
+        const uint64_t id,
+        uint64_t type,
+        uint32_t size,
         const char* payload,
         string_writer* key,
         string_writer* value);
-    static void encode_edge(const u_int64_t id,
-        u_int64_t type,
-        u_int32_t size,
+    static void encode_edge(
+        const uint64_t id,
+        uint64_t type,
+        uint32_t size,
         const char* payload,
-        const u_int64_t first,
-        const u_int64_t second,
+        const uint64_t first,
+        const uint64_t second,
         string_writer* key,
         string_writer* value);
-    static const char* decode_node(const rocksdb::Slice& key,
+    static const char* decode_node(
+        const rocksdb::Slice& key,
         const rocksdb::Slice& value,
         gaia_id_t* id,
         gaia_type_t* type,
-        u_int32_t* size);
-    static const char* decode_edge(const rocksdb::Slice& key,
+        uint32_t* size);
+    static const char* decode_edge(
+        const rocksdb::Slice& key,
         const rocksdb::Slice& value,
         gaia_id_t* id,
         gaia_type_t* type,
-        u_int32_t* size,
+        uint32_t* size,
         gaia_id_t* first,
         gaia_id_t* second);
     static bool is_rdb_object_edge(const rocksdb::Slice& value);
 };
 
 }  // namespace db
-
 }  // namespace gaia

--- a/production/db/storage_engine/mock/storage_engine.hpp
+++ b/production/db/storage_engine/mock/storage_engine.hpp
@@ -28,7 +28,6 @@
 #include "gaia_exception.hpp"
 
 namespace gaia {
-
 namespace db {
 
 using namespace common;

--- a/production/db/storage_engine/mock/storage_engine_client.cpp
+++ b/production/db/storage_engine/mock/storage_engine_client.cpp
@@ -63,8 +63,7 @@ int client::get_session_socket() {
     // we need to add an extra byte for the null byte prefix.
     socklen_t server_addr_size =
         sizeof(server_addr.sun_family) + 1 + strlen(&server_addr.sun_path[1]);
-    if (-1 == connect(session_socket, (struct sockaddr *)&server_addr,
-                  server_addr_size)) {
+    if (-1 == connect(session_socket, (struct sockaddr *)&server_addr, server_addr_size)) {
         throw_system_error("connect failed");
     }
     return session_socket;
@@ -125,11 +124,11 @@ void client::begin_session() {
     retail_assert(fd_offsets != -1);
     if (s_fd_offsets == -1) {
         if (!__sync_bool_compare_and_swap(&s_fd_offsets, -1, fd_offsets)) {
-            // we lost the race, close the fd
+            // We lost the race, close the fd.
             close(fd_offsets);
         }
     } else {
-        // locator fd is already initialized, close the fd
+        // locator fd is already initialized, close the fd.
         close(fd_offsets);
     }
 }

--- a/production/db/storage_engine/mock/storage_engine_client.hpp
+++ b/production/db/storage_engine/mock/storage_engine_client.hpp
@@ -66,7 +66,7 @@ class client : private se_base {
     static atomic<gaia_tx_hook> s_tx_commit_hook;
     static atomic<gaia_tx_hook> s_tx_rollback_hook;
 
-    // inherited from se_base:
+    // Inherited from se_base:
     // static int s_fd_offsets;
     // static data *s_data;
     // thread_local static log *s_log;
@@ -99,8 +99,8 @@ class client : private se_base {
         }
 
         (*s_offsets)[row_id] = 1 + __sync_fetch_and_add(
-                                       &s_data->objects[0],
-                                       (size + sizeof(int64_t) - 1) / sizeof(int64_t));
+            &s_data->objects[0],
+            (size + sizeof(int64_t) - 1) / sizeof(int64_t));
     }
 
     static inline void verify_tx_active() {


### PR DESCRIPTION
I replaced the u_int*_t use with uint*_t. Also changed an instance that used uint to use size_t and I replaced u_char with uint8_t.

I also did some more minor cleanup related to comments/indentation.