### PR TITLE
Remove transaction hooks

### DIFF
--- a/production/db/storage_engine/mock/gaia_db.cpp
+++ b/production/db/storage_engine/mock/gaia_db.cpp
@@ -29,15 +29,3 @@ void gaia::db::rollback_transaction() {
 bool gaia::db::commit_transaction() {
     return gaia::db::client::commit_transaction();
 }
-
-gaia::db::gaia_tx_hook gaia::db::set_tx_begin_hook(gaia::db::gaia_tx_hook hook, bool overwrite) {
-    return gaia::db::client::set_tx_begin_hook(hook, overwrite);
-}
-
-gaia::db::gaia_tx_hook gaia::db::set_tx_commit_hook(gaia::db::gaia_tx_hook hook, bool overwrite) {
-    return gaia::db::client::set_tx_commit_hook(hook, overwrite);
-}
-
-gaia::db::gaia_tx_hook gaia::db::set_tx_rollback_hook(gaia::db::gaia_tx_hook hook, bool overwrite) {
-    return gaia::db::client::set_tx_rollback_hook(hook, overwrite);
-}

--- a/production/db/storage_engine/mock/storage_engine_client.hpp
+++ b/production/db/storage_engine/mock/storage_engine_client.hpp
@@ -46,25 +46,9 @@ class client : private se_base {
     static void rollback_transaction();
     static bool commit_transaction();
 
-    static inline gaia_tx_hook set_tx_begin_hook(gaia_tx_hook hook, bool overwrite) {
-        return set_tx_hook(s_tx_begin_hook, hook, overwrite);
-    }
-
-    static inline gaia_tx_hook set_tx_commit_hook(gaia_tx_hook hook, bool overwrite) {
-        return set_tx_hook(s_tx_commit_hook, hook, overwrite);
-    }
-
-    static inline gaia_tx_hook set_tx_rollback_hook(gaia_tx_hook hook, bool overwrite) {
-        return set_tx_hook(s_tx_rollback_hook, hook, overwrite);
-    }
-
    private:
     thread_local static int s_fd_log;
     thread_local static offsets* s_offsets;
-
-    static atomic<gaia_tx_hook> s_tx_begin_hook;
-    static atomic<gaia_tx_hook> s_tx_commit_hook;
-    static atomic<gaia_tx_hook> s_tx_rollback_hook;
 
     // Inherited from se_base:
     // static int s_fd_offsets;
@@ -135,20 +119,6 @@ class client : private se_base {
         lr->row_id = row_id;
         lr->old_object = old_object;
         lr->new_object = new_object;
-    }
-
-    static inline gaia_tx_hook set_tx_hook(atomic<gaia_tx_hook>& old_hook, gaia_tx_hook new_hook, bool overwrite) {
-        if (overwrite) {
-            // Register the new hook and return the previously registered hook.
-            return old_hook.exchange(new_hook);
-        } else {
-            // Do not overwrite previously registered hook.
-            gaia_tx_hook expected = nullptr;
-            // If the exchange failed (because a hook was already registered),
-            // then return the registered hook, otherwise return null.
-            old_hook.compare_exchange_strong(expected, new_hook);
-            return expected;
-        }
     }
 };
 

--- a/production/inc/public/common/gaia_common.hpp
+++ b/production/inc/public/common/gaia_common.hpp
@@ -33,11 +33,6 @@ constexpr gaia_id_t INVALID_GAIA_ID = 0;
  */
 typedef uint64_t gaia_type_t;
 
-/**
- * The type of a Gaia transaction hook.
- */
-typedef void (*gaia_tx_hook)(void);
-
 }  // namespace common
 /*@}*/
 }  // namespace gaia

--- a/production/inc/public/db/gaia_db.hpp
+++ b/production/inc/public/db/gaia_db.hpp
@@ -101,9 +101,5 @@ void begin_transaction();
 void rollback_transaction();
 bool commit_transaction();
 
-gaia_tx_hook set_tx_begin_hook(gaia_tx_hook hook, bool overwrite = true);
-gaia_tx_hook set_tx_commit_hook(gaia_tx_hook hook, bool overwrite = true);
-gaia_tx_hook set_tx_rollback_hook(gaia_tx_hook hook, bool overwrite = true);
-
 }  // namespace db
 }  // namespace gaia


### PR DESCRIPTION
In Q1 and early Q2 I added hooks to be called when a transaction was begun or committed.  The former was used to refresh objects in a cache of gaia objects; the latter was used to support the mock commit_trigger call to keep things limping along.  With the direct api changes we no longer have an object cache and thus no need to know when the user calls begin_transaction.  The integration of the real commit trigger called by the storage engine will obviate the need for the direct access layer to know about commit_transaction.  This change removes the infrastructure in the storage engine for setting these hooks.