### PR TITLE
Create global cmake catalog generated variable

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ROCKSDB_INC "${ROCKSDB}/include")
 set(GREMLIN_CONSOLE_PATH "/usr/local/share/gremlin-console")
 set(GREMLIN_SERVER_PATH "/usr/local/share/gremlin-server")
 set(GAIA_PROD_BUILD "${CMAKE_BINARY_DIR}")
+set(GAIA_CATALOG_GENERATED "${GAIA_PROD_BUILD}/catalog/generated}")
 
 message(STATUS "GAIA_INC=${GAIA_INC}")
 

--- a/production/catalog/catalog_manager/CMakeLists.txt
+++ b/production/catalog/catalog_manager/CMakeLists.txt
@@ -8,8 +8,6 @@ enable_testing()
 
 project(catalog_manager)
 
-set(CATALOG_FBS_GENERATED_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
 set(GAIA_CATALOG_LIB_PUBLIC_INCLUDES
   ${GAIA_INC}/public/catalog
   ${GAIA_INC}/public/common
@@ -23,7 +21,7 @@ set(GAIA_CATALOG_LIB_PRIVATE_INCLUDES
   ${GAIA_INC}/internal/db
   ${FLATBUFFERS_INC}
   ${PROJECT_SOURCE_DIR}/inc
-  ${CATALOG_FBS_GENERATED_OUTPUTS}
+  ${GAIA_CATALOG_GENERATED}
 )
 message(STATUS "GAIA_CATALOG_LIB_PRIVATE_INCLUDES=${GAIA_CATALOG_LIB_PRIVATE_INCLUDES}")
 
@@ -31,7 +29,7 @@ message(STATUS "GAIA_CATALOG_LIB_PRIVATE_INCLUDES=${GAIA_CATALOG_LIB_PRIVATE_INC
 set_property(GLOBAL PROPERTY FBS_GENERATED_OUTPUTS)
 gaia_compile_flatbuffers_schema_to_cpp_opt(flatbuffers/catalog.fbs
   "--no-includes;--gen-compare;--gaia-type-initial-value;6"
-  "${CATALOG_FBS_GENERATED_OUTPUTS}")
+  "${GAIA_CATALOG_GENERATED}")
 get_generated_output(catalog_fbs_generated)
 if(catalog_fbs_generated)
   # message(STATUS "Add generated_code target with files:${fbs_generated}")

--- a/production/inc/public/catalog/gaia_catalog.hpp
+++ b/production/inc/public/catalog/gaia_catalog.hpp
@@ -4,10 +4,16 @@
 /////////////////////////////////////////////
 #pragma once
 
-#include "gaia_object.hpp"
-#include "gaia_exception.hpp"
+#include <set>
 #include <string>
+#include <sstream>
+#include <vector>
 #include <memory>
+
+#include "gaia_common.hpp"
+#include "gaia_exception.hpp"
+
+using namespace gaia::common;
 
 namespace gaia {
 /**

--- a/production/tools/gaia_generate/tests/test_gaia_generate.cpp
+++ b/production/tools/gaia_generate/tests/test_gaia_generate.cpp
@@ -11,6 +11,7 @@
 #include "db_test_helpers.hpp"
 
 using namespace gaia::catalog;
+using namespace gaia::db;
 using namespace std;
 
 class gaia_generate_test : public ::testing::Test {


### PR DESCRIPTION
* Created a global variable for gaia catalog output so files outside of catalog/ can access it
* Output directory has moved from catalog/catalog_manager/generated to catalog/generated as I think it makes more sense
* Did not alter the cmake to be friendlier to direct_access the catalog as I feel that is not the correct place to fix this issue. If we fix this it should be extended to external users of our generated headers
* Also reworked the header files for catalog_manager