### PR TITLE
Move gtest initialization out of main functions

### DIFF
--- a/production/db/storage_engine/tests/test_storage_engine_client.cpp
+++ b/production/db/storage_engine/tests/test_storage_engine_client.cpp
@@ -320,8 +320,3 @@ TEST_F(storage_engine_client_test, iterate_type_delete) {
     }
     commit_transaction();
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/production/rules/event_manager/tests/test_auto_tx.cpp
+++ b/production/rules/event_manager/tests/test_auto_tx.cpp
@@ -15,7 +15,20 @@ using namespace gaia::db;
 using namespace gaia::rules;
 
 
-TEST(auto_tx_test, auto_tx_active_commit)
+class auto_tx_test : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        start_server();
+        begin_session();
+    }
+
+    static void TearDownTestSuite() {
+        end_session();
+        stop_server();
+    }
+};
+
+TEST_F(auto_tx_test, auto_tx_active_commit)
 {
     begin_transaction();
     EXPECT_EQ(true, is_transaction_active());
@@ -28,7 +41,7 @@ TEST(auto_tx_test, auto_tx_active_commit)
     rollback_transaction();
 }
 
-TEST(auto_tx_test, auto_tx_active_rollback)
+TEST_F(auto_tx_test, auto_tx_active_rollback)
 {
     begin_transaction();
     EXPECT_EQ(true, is_transaction_active());
@@ -40,7 +53,7 @@ TEST(auto_tx_test, auto_tx_active_rollback)
     rollback_transaction();
 }
 
-TEST(auto_tx_test, auto_tx_inactive_rollback)
+TEST_F(auto_tx_test, auto_tx_inactive_rollback)
 {
     EXPECT_EQ(false, is_transaction_active());
     {
@@ -51,7 +64,7 @@ TEST(auto_tx_test, auto_tx_inactive_rollback)
     EXPECT_EQ(false, is_transaction_active());
 }
 
-TEST(auto_tx_test, auto_tx_inactive_commit)
+TEST_F(auto_tx_test, auto_tx_inactive_commit)
 {
     EXPECT_EQ(false, is_transaction_active());
     {
@@ -62,14 +75,4 @@ TEST(auto_tx_test, auto_tx_inactive_commit)
         EXPECT_EQ(false, is_transaction_active());
     }
     EXPECT_EQ(false, is_transaction_active());
-}
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  start_server();
-  begin_session();
-  int ret_code = RUN_ALL_TESTS();
-  end_session();
-  stop_server();
-  return ret_code;
 }

--- a/production/rules/event_manager/tests/test_component_init.cpp
+++ b/production/rules/event_manager/tests/test_component_init.cpp
@@ -21,7 +21,18 @@ extern "C" void initialize_rules()
 {
 }
 
-TEST(event_manager_component_init, component_not_initialized_error)
+class component_init_test : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        start_server();
+    }
+
+    static void TearDownTestSuite() {
+        stop_server();
+    }
+};
+
+TEST_F(component_init_test, component_not_initialized_error)
 {
     rule_binding_t dont_care;
     subscription_list_t still_dont_care;
@@ -54,7 +65,7 @@ public:
 };
 gaia_type_t row_context_t::s_gaia_type = 2;
 
-TEST(event_manager_component_init, component_initialized)
+TEST_F(component_init_test, component_initialized)
 {
     rule_binding_t binding("ruleset", "rulename", rule);
     subscription_list_t subscriptions;
@@ -69,12 +80,4 @@ TEST(event_manager_component_init, component_initialized)
     unsubscribe_rules();
     list_subscribed_rules(nullptr, nullptr, nullptr, nullptr, subscriptions);
     gaia::db::end_session();
-}
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  start_server();
-  int ret_code = RUN_ALL_TESTS();
-  stop_server();
-  return ret_code;
 }

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -419,6 +419,16 @@ static constexpr int s_rule_decl_len = sizeof(s_rule_decl)/sizeof(s_rule_decl[0]
 class event_manager_test : public ::testing::Test
 {
 protected:
+
+    static void SetUpTestSuite() {
+        start_server();
+        gaia::rules::initialize_rules_engine();
+    }
+
+    static void TearDownTestSuite() {
+        stop_server();
+    }
+
     void SetUp() override {
         begin_session();
     }
@@ -1230,14 +1240,4 @@ TEST_F(event_manager_test, event_logging_subscriptions)
 
     gaia::db::commit_transaction();
     EXPECT_EQ(3, clear_event_log());
-}
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  testing::InitGoogleTest(&argc, argv);
-  start_server();
-  gaia::rules::initialize_rules_engine();
-  int ret_code = RUN_ALL_TESTS();
-  stop_server();
-  return ret_code;
 }

--- a/production/rules/event_manager/tests/test_system_init.cpp
+++ b/production/rules/event_manager/tests/test_system_init.cpp
@@ -21,7 +21,18 @@ extern "C" void initialize_rules()
 {
 }
 
-TEST(event_manager_system_init, system_not_initialized_error)
+class system_init_test : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        start_server();
+    }
+
+    static void TearDownTestSuite() {
+        stop_server();
+    }
+};
+
+TEST_F(system_init_test, system_not_initialized_error)
 {
     rule_binding_t dont_care;
     subscription_list_t still_dont_care;
@@ -54,7 +65,7 @@ public:
 };
 gaia_type_t row_context_t::s_gaia_type = 1;
 
-TEST(event_manager_system_init, system_initialized)
+TEST_F(system_init_test, system_initialized)
 {
     rule_binding_t binding("ruleset", "rulename", rule);
     subscription_list_t subscriptions;
@@ -68,12 +79,4 @@ TEST(event_manager_system_init, system_initialized)
     EXPECT_EQ(true, unsubscribe_rule(row_context_t::s_gaia_type, event_type_t::row_update, fields, binding));
     unsubscribe_rules();
     list_subscribed_rules(nullptr, nullptr, nullptr, nullptr, subscriptions);
-}
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  start_server();
-  int ret_code = RUN_ALL_TESTS();
-  stop_server();
-  return ret_code;
 }


### PR DESCRIPTION
I shouldn't be initializing the server (or doing any test init work, really) in a gtest main function especially since there are specific static test suite setup and teardown methods.  As @senderista pointed out, `gtest_discover_tests` invokes main as part of the build process so anything we do in `main` is part of the build.