### PR TITLE
Prevent rebuilding of targets dependent on flatbuffers generated files

### DIFF
--- a/production/db/storage_engine/CMakeLists.txt
+++ b/production/db/storage_engine/CMakeLists.txt
@@ -30,19 +30,30 @@ set(GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES
 )
 message(STATUS "GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES=${GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES}")
 
+###############################################
 # Generate flatbuffers headers.
-find_program(FLATC flatc)
+###############################################
 set(GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# The names of the following source files should be unique because they'll be used as targets.
 set(FBS_SOURCES
-    "${PROJECT_SOURCE_DIR}/mock/flatbuffers/messages.fbs")
-add_custom_target("${PROJECT_NAME}-gen_fbs" ALL)
-foreach(fbs ${FBS_SOURCES})
+  "${PROJECT_SOURCE_DIR}/mock/flatbuffers/messages.fbs")
+
+foreach(FBS_SOURCE ${FBS_SOURCES})
+  get_filename_component(FBS_SOURCE_FILENAME ${FBS_SOURCE} NAME)
+  string(REGEX REPLACE "\\.fbs$" "_generated.h" GEN_HEADER ${FBS_SOURCE_FILENAME})
+
   add_custom_command(
-    TARGET "${PROJECT_NAME}-gen_fbs"
+    OUTPUT "${GEN_DIR}/${GEN_HEADER}"
     COMMAND cmake -E make_directory "${GEN_DIR}"
-    COMMAND "${FLATC}" --cpp --scoped-enums -o "${GEN_DIR}" "${fbs}" DEPENDS "${fbs}"
+    COMMAND flatc --cpp --scoped-enums -o "${GEN_DIR}" "${FBS_SOURCE}"
+    DEPENDS "${FBS_SOURCE}"
+    DEPENDS ${CMAKE_BINARY_DIR}/flatbuffers/flatc
+    COMMENT "Completed flatbuffers compilation of ${FBS_SOURCE}!"
     VERBATIM)
-endforeach(fbs)
+
+  add_custom_target(${FBS_SOURCE_FILENAME} ALL DEPENDS "${GEN_DIR}/${GEN_HEADER}")
+endforeach(FBS_SOURCE)
 
 ###############################################
 # Our main target.
@@ -64,13 +75,14 @@ add_library(gaia_semock STATIC
   mock/storage_engine.cpp
   mock/storage_engine_client.cpp
   mock/rdb_object_converter.cpp)
-add_dependencies(gaia_semock "${PROJECT_NAME}-gen_fbs")
+add_dependencies(gaia_semock "messages.fbs")
 target_include_directories(gaia_semock PUBLIC ${GAIA_STORAGE_ENGINE_PUBLIC_INCLUDES})
 target_include_directories(gaia_semock PRIVATE ${GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES})
-# for flatbuffers generated code
+
+# For flatbuffers generated code.
 target_include_directories(gaia_semock SYSTEM PRIVATE "${FLATBUFFERS_INC}")
 target_include_directories(gaia_semock SYSTEM PRIVATE "${GEN_DIR}")
-# suppress spurious warnings about zero-initialized structs
+# Suppress spurious warnings about zero-initialized structs.
 set_target_properties(gaia_semock PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -Wno-missing-field-initializers")
 target_link_libraries(gaia_semock PUBLIC gaia_common)
 target_link_libraries(gaia_semock PRIVATE explain)
@@ -81,20 +93,23 @@ add_executable(gaia_semock_server
   mock/storage_engine.cpp
   mock/storage_engine_server.cpp
   mock/storage_engine_server_exec.cpp)
-add_dependencies(gaia_semock_server "${PROJECT_NAME}-gen_fbs")
+add_dependencies(gaia_semock_server "messages.fbs")
 target_include_directories(gaia_semock_server PRIVATE
   "${GAIA_STORAGE_ENGINE_PUBLIC_INCLUDES}"
-  "${GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES}"
-)
-# for flatbuffers generated code
+  "${GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES}")
+
+# For flatbuffers generated code.
 target_include_directories(gaia_semock_server SYSTEM PRIVATE "${FLATBUFFERS_INC}")
 target_include_directories(gaia_semock_server SYSTEM PRIVATE "${GEN_DIR}")
-# suppress spurious warnings about zero-initialized structs
+# Suppress spurious warnings about zero-initialized structs.
 set_target_properties(gaia_semock_server PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -Wno-missing-field-initializers")
 target_link_libraries(gaia_semock_server PRIVATE gaia_common Threads::Threads explain)
+
 install(TARGETS gaia_semock_server DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
+###############################################
 # PyBind11 wrapper for storage engine mock.
+###############################################
 find_package(pybind11 REQUIRED)
 if (Python3_FOUND AND pybind11_FOUND)
   pybind11_add_module(se_mock mock/storage_engine_pybind_wrapper.cpp)
@@ -111,7 +126,9 @@ if (Python3_FOUND AND pybind11_FOUND)
   # set_tests_properties(test_se_mock_pybind PROPERTIES PASS_REGULAR_EXPRESSION ${TEST_SUCCESS})
 endif()
 
+###############################################
 # JNI wrapper for storage engine mock.
+###############################################
 if (JAVA_FOUND AND JNI_FOUND AND EXISTS "${GREMLIN_CONSOLE_PATH}")
   # Configure build of native C++ wrapper library.
   add_library(jni_se_mock SHARED mock/storage_engine_jni_wrapper.cpp)

--- a/production/db/types/CMakeLists.txt
+++ b/production/db/types/CMakeLists.txt
@@ -36,8 +36,10 @@ add_custom_command(
   COMMAND flatc
     --schema
     -b ${PROJECT_SOURCE_DIR}/tests/test_record.fbs
+  DEPENDS ${PROJECT_SOURCE_DIR}/tests/test_record.fbs
   DEPENDS ${CMAKE_BINARY_DIR}/flatbuffers/flatc
-  COMMENT "Completed flatbuffers compilation of test_record.fbs!")
+  COMMENT "Completed flatbuffers compilation of test_record.fbs!"
+  VERBATIM)
 add_custom_target(test_record_bfbs ALL DEPENDS ${TYPES_TESTS_GENERATED_OUTPUT}/test_record.bfbs)
 
 add_custom_command(
@@ -45,8 +47,10 @@ add_custom_command(
   COMMAND flatc
     -b ${PROJECT_SOURCE_DIR}/tests/test_record.fbs
     ${PROJECT_SOURCE_DIR}/tests/test_record_data.json
+  DEPENDS ${PROJECT_SOURCE_DIR}/tests/test_record_data.json
   DEPENDS ${CMAKE_BINARY_DIR}/flatbuffers/flatc
-  COMMENT "Completed flatbuffers compilation of test_record_data.json!")
+  COMMENT "Completed flatbuffers compilation of test_record_data.json!"
+  VERBATIM)
 add_custom_target(test_record_data_bin ALL DEPENDS ${TYPES_TESTS_GENERATED_OUTPUT}/test_record_data.bin)
 
 # Tests.

--- a/production/sql/CMakeLists.txt
+++ b/production/sql/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT PG_CONFIG)
   return()
 endif(NOT PG_CONFIG)
 
-# @LaurentiuCristofor: skip building extension if flatcc isn't installed.
+# Skip building extension if flatcc isn't installed.
 
 find_program(FLATCC flatcc)
 if(NOT FLATCC)
@@ -31,8 +31,7 @@ endif(NOT FLATCC)
 file(READ "version.config" PG_GAIA_FDW_VERSION)
 string(STRIP ${PG_GAIA_FDW_VERSION} PG_GAIA_FDW_VERSION)
 set(PG_GAIA_FDW_VERSION "${PG_GAIA_FDW_VERSION}")
-string(REGEX REPLACE "\\.[0-9]*$" "" PG_GAIA_FDW_VERSION_MAJOR
-                     "${PG_GAIA_FDW_VERSION}")
+string(REGEX REPLACE "\\.[0-9]*$" "" PG_GAIA_FDW_VERSION_MAJOR "${PG_GAIA_FDW_VERSION}")
 set(PG_GAIA_FDW_VERSION_MAJOR "${PG_GAIA_FDW_VERSION_MAJOR}")
 
 # Get Postgres config settings from pg_config.
@@ -43,15 +42,13 @@ exec_program(
   PG_CONFIG_OUTPUT)
 
 string(REGEX REPLACE "^PostgreSQL[\t ]+([0-9]+)\\.([0-9]+)\\.([0-9]+)"
-                     "\\1.\\2.\\3" PGSQL_VERSION "${PG_CONFIG_OUTPUT}")
+  "\\1.\\2.\\3" PGSQL_VERSION "${PG_CONFIG_OUTPUT}")
 
 unset(PG_CONFIG_OUTPUT)
 
 if(PGSQL_VERSION)
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1"
-                       PGSQL_VERSION_MAJOR "${PGSQL_VERSION}")
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2"
-                       PGSQL_VERSION_MINOR "${PGSQL_VERSION}")
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" PGSQL_VERSION_MAJOR "${PGSQL_VERSION}")
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" PGSQL_VERSION_MINOR "${PGSQL_VERSION}")
 
   set(PGSQL_NUMERIC_VERSION ${PGSQL_VERSION_MAJOR}${PGSQL_VERSION_MINOR})
 endif()
@@ -101,4 +98,5 @@ add_subdirectory(src)
 
 # Add tests.
 
+# Tests are disabled until they get rewritten.
 # add_subdirectory(tests)

--- a/production/sql/src/CMakeLists.txt
+++ b/production/sql/src/CMakeLists.txt
@@ -5,62 +5,71 @@
 # Generate flatbuffers headers.
 
 find_program(FLATCC flatcc)
+
 set(GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
 set(FBS_SOURCES
     "${GAIA_REPO}/demos/airport_q1/inc/airport_q1.fbs"
     "${GAIA_REPO}/production/rules/event_manager/flatbuffers/event_log.fbs")
-add_custom_target(gen_fbs ALL)
-foreach(fbs ${FBS_SOURCES})
+
+foreach(FBS_SOURCE ${FBS_SOURCES})
+  get_filename_component(FBS_SOURCE_FILENAME ${FBS_SOURCE} NAME)
+  string(REGEX REPLACE "\\.fbs$" "_builder.h" GEN_HEADER ${FBS_SOURCE_FILENAME})
+
   add_custom_command(
-    TARGET gen_fbs
+    OUTPUT "${GEN_DIR}/${GEN_HEADER}"
     COMMAND cmake -E make_directory "${GEN_DIR}"
-    COMMAND "${FLATCC}" -a -o "${GEN_DIR}" "${fbs}" DEPENDS "${fbs}"
+    COMMAND "${FLATCC}" -a -o "${GEN_DIR}" "${FBS_SOURCE}"
+    DEPENDS "${FBS_SOURCE}"
     VERBATIM)
-endforeach(fbs)
+
+  add_custom_target(${FBS_SOURCE_FILENAME} ALL DEPENDS "${GEN_DIR}/${GEN_HEADER}")
+endforeach(FBS_SOURCE)
 
 # Compile config.
 
 add_library(gaia_fdw SHARED gaia_fdw.cpp)
-# exec_program() mangles this variable with added quotes, so un-quote it
+
+# exec_program() mangles this variable with added quotes, so un-quote it.
 separate_arguments(PGSQL_CPPFLAGS UNIX_COMMAND "${PGSQL_CPPFLAGS}")
 target_compile_options(gaia_fdw PRIVATE ${PGSQL_CPPFLAGS})
-# we need to un-quote this variable for some reason as well
+
+# We need to un-quote this variable for some reason as well.
 separate_arguments(GAIA_COMPILE_FLAGS UNIX_COMMAND "${GAIA_COMPILE_FLAGS}")
 target_compile_options(gaia_fdw PRIVATE ${GAIA_COMPILE_FLAGS})
-# exec_program() mangles this variable with added quotes, so un-quote it
+
+# exec_program() mangles this variable with added quotes, so un-quote it.
 separate_arguments(PGSQL_LDFLAGS UNIX_COMMAND "${PGSQL_LDFLAGS}")
 target_link_options(gaia_fdw PRIVATE ${PGSQL_LDFLAGS})
-# we need to un-quote this variable for some reason as well
+
+# We need to un-quote this variable for some reason as well.
 separate_arguments(GAIA_LINK_FLAGS UNIX_COMMAND "${GAIA_LINK_FLAGS}")
 target_link_options(gaia_fdw PRIVATE ${GAIA_LINK_FLAGS})
+
 set_target_properties(
-  gaia_fdw PROPERTIES OUTPUT_NAME "gaia_fdw-${PG_GAIA_FDW_VERSION_MAJOR}" PREFIX
-                                                                          "")
-add_dependencies(gaia_fdw gen_fbs)
-# our private headers
+  gaia_fdw PROPERTIES
+    OUTPUT_NAME "gaia_fdw-${PG_GAIA_FDW_VERSION_MAJOR}"
+    PREFIX "")
+
+add_dependencies(gaia_fdw "airport_q1.fbs")
+add_dependencies(gaia_fdw "event_log.fbs")
+
 target_include_directories(gaia_fdw PRIVATE "${PROJECT_SOURCE_DIR}/inc")
-# common public headers
 target_include_directories(gaia_fdw PRIVATE "${GAIA_INC}/public/common")
-# common internal headers
 target_include_directories(gaia_fdw PRIVATE "${GAIA_INC}/internal/common")
-# public DB headers
 target_include_directories(gaia_fdw PRIVATE "${GAIA_INC}/public/db")
-# internal DB headers
 target_include_directories(gaia_fdw PRIVATE "${GAIA_INC}/internal/db")
-# for flatbuffers generated code
 target_include_directories(gaia_fdw SYSTEM PRIVATE "${GEN_DIR}")
-# for postgres
 target_include_directories(gaia_fdw SYSTEM PRIVATE "${PGSQL_INCLUDEDIR_SERVER}")
-# for flatbuffers C builder support
+
 target_link_libraries(gaia_fdw PRIVATE flatccrt)
-# for COW-SE
 target_link_libraries(gaia_fdw PRIVATE gaia_semock)
 
 # Extension config.
 
 set(GAIA_FDW_INSTALL_EXTENSIONS
-    "${PROJECT_BINARY_DIR}/pgsql/gaia_fdw--${PG_GAIA_FDW_VERSION}.sql"
-    "${PROJECT_BINARY_DIR}/pgsql/gaia_fdw.control")
+  "${PROJECT_BINARY_DIR}/pgsql/gaia_fdw--${PG_GAIA_FDW_VERSION}.sql"
+  "${PROJECT_BINARY_DIR}/pgsql/gaia_fdw.control")
 
 configure_file(
   gaia_fdw.sql
@@ -73,4 +82,4 @@ configure_file(gaia_fdw.control "${PROJECT_BINARY_DIR}/pgsql/gaia_fdw.control")
 install(TARGETS gaia_fdw DESTINATION ${PGSQL_PKGLIBDIR})
 
 install(FILES ${GAIA_FDW_INSTALL_EXTENSIONS}
-        DESTINATION "${PGSQL_SHAREDIR}/extension")
+  DESTINATION "${PGSQL_SHAREDIR}/extension")


### PR DESCRIPTION
When generating flatbuffers output, if that generation occurs on each build, then each target dependent on the generated headers (and any target dependent on that target, and so on) will get regenerated as a result of the headers being regenerated.

While there was already an attempt to avoid this issue in the way the cmake files were written, that approach didn't work. I think this is due to how the TARGET version of add_custom_command works, so I instead replaced it with the OUTPUT version, which avoided this problem for me elsewhere. The result is that now the header re-generation no longer occurs - at least, that is the case on my machine.

Here's hoping that this will work everywhere. Also if anyone has a better understanding of why the OUTPUT approach works better than the TARGET one, please share your knowledge in comments. I'm still trying to understand why the original approach did not work as expected.

Sending to all devs to raise awareness around this type of issue.

UPDATE: I forgot to mention this, but this change also removes the need to have the flatbuffers compiler installed on the system and instead uses the flatc version that we build ourselves.