### PR TITLE
Add detailed stack traces to SE server.

### DIFF
--- a/production/db/storage_engine/CMakeLists.txt
+++ b/production/db/storage_engine/CMakeLists.txt
@@ -13,6 +13,15 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
+# Enable stack traces in debug builds for the storage engine server.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # backward-cpp stack trace library.
+  find_package(Backward REQUIRED)
+  # backward-cpp dependencies (one of several options):
+  # "libdw provides access to DWARF debug information stored inside ELF files."
+  find_library(dw REQUIRED)
+endif()
+
 set(GAIA_STORAGE_ENGINE_PUBLIC_INCLUDES
   "${GAIA_INC}/public/common"
   "${GAIA_INC}/public/db"
@@ -91,22 +100,28 @@ target_link_libraries(gaia_semock PRIVATE explain)
 # This static library must be compatible with linking in a shared library.
 set_property (TARGET gaia_semock PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-add_executable(gaia_semock_server
+set(GAIA_SE_SERVER_SOURCES
   mock/storage_engine.cpp
   mock/storage_engine_server.cpp
-  mock/storage_engine_server_exec.cpp)
+  mock/storage_engine_server_exec.cpp
+)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  list(APPEND GAIA_SE_SERVER_SOURCES mock/backward.cpp)
+endif()
+add_executable(gaia_semock_server ${GAIA_SE_SERVER_SOURCES})
 add_dependencies(gaia_semock_server "messages.fbs")
 target_include_directories(gaia_semock_server PRIVATE
   "${GAIA_STORAGE_ENGINE_PUBLIC_INCLUDES}"
   "${GAIA_STORAGE_ENGINE_PRIVATE_INCLUDES}")
-
 # For flatbuffers generated code.
 target_include_directories(gaia_semock_server SYSTEM PRIVATE "${FLATBUFFERS_INC}")
 target_include_directories(gaia_semock_server SYSTEM PRIVATE "${GEN_DIR}")
 # Suppress spurious warnings about zero-initialized structs.
 set_target_properties(gaia_semock_server PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -Wno-missing-field-initializers")
 target_link_libraries(gaia_semock_server PRIVATE gaia_common Threads::Threads explain)
-
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_libraries(gaia_semock_server PUBLIC Backward::Backward)
+endif()
 install(TARGETS gaia_semock_server DESTINATION "bin")
 
 ###############################################

--- a/production/db/storage_engine/mock/backward.cpp
+++ b/production/db/storage_engine/mock/backward.cpp
@@ -1,0 +1,12 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#include "backward.hpp"
+
+namespace backward {
+
+backward::SignalHandling sh;
+
+} // namespace backward

--- a/production/db/storage_engine/mock/storage_engine_server_exec.cpp
+++ b/production/db/storage_engine/mock/storage_engine_server_exec.cpp
@@ -6,6 +6,6 @@
 #include "retail_assert.hpp"
 #include "storage_engine_server.hpp"
 
-int main(int argc, char* argv[]) {
+int main(__attribute__((unused)) int argc, __attribute__((unused)) char *argv[]) {
     gaia::db::server::run();
 }

--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -9,6 +9,7 @@ python3-dev
 # FIXME production/sql/src has a dependency on demos/airport_q1.
 production/cmake
 production/sql
+third_party/production/backward
 third_party/production/bison
 third_party/production/cmake
 third_party/production/daemonize

--- a/third_party/production/backward/gdev.cfg
+++ b/third_party/production/backward/gdev.cfg
@@ -1,0 +1,14 @@
+[apt]
+libdw-dev
+
+[gaia]
+third_party/production/cmake
+
+[git]
+--branch v1.5 https://github.com/bombela/backward-cpp.git
+
+[run]
+cmake backward-cpp
+make -j$(nproc)
+make install
+rm -rf *


### PR DESCRIPTION
This is just a first step; I originally wanted to create a static or object library which would only need to be (transitively) linked by any other library or executable to grant it magical stacktrace powers. But after spending too much time trying to get that to work, I'm settling for just the SE server. Hopefully I'll be able to figure out the general scenario later.