### PR TITLE
Throw a client-side exception on server-side transaction abort.

### DIFF
--- a/production/db/storage_engine/mock/gaia_db.cpp
+++ b/production/db/storage_engine/mock/gaia_db.cpp
@@ -26,6 +26,6 @@ void gaia::db::rollback_transaction() {
     gaia::db::client::rollback_transaction();
 }
 
-bool gaia::db::commit_transaction() {
-    return gaia::db::client::commit_transaction();
+void gaia::db::commit_transaction() {
+    gaia::db::client::commit_transaction();
 }

--- a/production/db/storage_engine/mock/gaia_hash_map.hpp
+++ b/production/db/storage_engine/mock/gaia_hash_map.hpp
@@ -19,7 +19,7 @@ class gaia_hash_map {
    public:
     static se_base::hash_node* insert(const gaia_id_t id) {
         if (*client::s_offsets == nullptr) {
-            throw tx_not_open();
+            throw transaction_not_open();
         }
 
         se_base::hash_node* node = client::s_data->hash_nodes + (id % se_base::HASH_BUCKETS);
@@ -60,7 +60,7 @@ class gaia_hash_map {
 
     static int64_t find(const gaia_id_t id) {
         if (*client::s_offsets == nullptr) {
-            throw tx_not_open();
+            throw transaction_not_open();
         }
 
         auto node = client::s_data->hash_nodes + (id % se_base::HASH_BUCKETS);

--- a/production/db/storage_engine/mock/storage_engine_client.hpp
+++ b/production/db/storage_engine/mock/storage_engine_client.hpp
@@ -50,7 +50,7 @@ class client : private se_base {
     static void end_session();
     static void begin_transaction();
     static void rollback_transaction();
-    static bool commit_transaction();
+    static void commit_transaction();
 
    private:
     thread_local static int s_fd_log;
@@ -68,7 +68,6 @@ class client : private se_base {
     // static int s_fd_offsets;
     // static data *s_data;
     // thread_local static log *s_log;
-    // static string s_server_socket_name;
     // thread_local static gaia_xid_t s_transaction_id;
 
     static void tx_cleanup();
@@ -86,7 +85,7 @@ class client : private se_base {
 
     static inline int64_t allocate_row_id() {
         if (*s_offsets == nullptr) {
-            throw tx_not_open();
+            throw transaction_not_open();
         }
 
         if (s_data->row_id_count >= MAX_RIDS) {
@@ -98,7 +97,7 @@ class client : private se_base {
 
     static void inline allocate_object(int64_t row_id, size_t size) {
         if (*s_offsets == nullptr) {
-            throw tx_not_open();
+            throw transaction_not_open();
         }
 
         if (s_data->objects[0] >= MAX_OBJECTS) {
@@ -112,13 +111,13 @@ class client : private se_base {
 
     static inline void verify_tx_active() {
         if (!is_transaction_active()) {
-            throw tx_not_open();
+            throw transaction_not_open();
         }
     }
 
     static inline void verify_no_tx() {
         if (is_transaction_active()) {
-            throw tx_in_progress();
+            throw transaction_in_progress();
         }
     }
 

--- a/production/db/storage_engine/mock/storage_engine_pybind_wrapper.cpp
+++ b/production/db/storage_engine/mock/storage_engine_pybind_wrapper.cpp
@@ -127,9 +127,9 @@ PYBIND11_MODULE(se_mock, m) {
 
     register_exception<gaia::db::session_exists>(m, "session_exists");
     register_exception<gaia::db::no_session_active>(m, "no_session_active");
-    register_exception<gaia::db::tx_in_progress>(m, "tx_in_progress");
-    register_exception<gaia::db::tx_not_open>(m, "tx_not_open");
-    register_exception<gaia::db::tx_update_conflict>(m, "tx_update_conflict");
+    register_exception<gaia::db::transaction_in_progress>(m, "transaction_in_progress");
+    register_exception<gaia::db::transaction_not_open>(m, "transaction_not_open");
+    register_exception<gaia::db::transaction_update_conflict>(m, "transaction_update_conflict");
     register_exception<gaia::db::duplicate_id>(m, "duplicate_id");
     register_exception<gaia::db::oom>(m, "oom");
     register_exception<gaia::db::invalid_node_id>(m, "invalid_node_id");

--- a/production/direct_access/tests/test_direct_access.cpp
+++ b/production/direct_access/tests/test_direct_access.cpp
@@ -412,7 +412,7 @@ TEST_F(gaia_object_test, set_insert_id_x2) {
 
 // Attempt to create a row outside of a transaction
 TEST_F(gaia_object_test, no_tx) {
-    EXPECT_THROW(get_field("Harold"), tx_not_open);
+    EXPECT_THROW(get_field("Harold"), transaction_not_open);
     // NOTE: the employee_t object is leaked here
 }
 
@@ -509,7 +509,7 @@ TEST_F(gaia_object_test, auto_tx) {
     tx.commit();
 
     // Expect an exception since we're not in a transaction
-    EXPECT_THROW(e.name_last(), tx_not_open);
+    EXPECT_THROW(e.name_last(), transaction_not_open);
 
     begin_transaction();
 
@@ -646,10 +646,7 @@ TEST_F(gaia_object_test, thread_update_conflict) {
         w.update_row();
 
     }
-    // Expect a concurrency violation here, but for now commit_transaction is
-    // returning false.
-    // EXPECT_THROW(commit_transaction, tx_update_conflict);
-    EXPECT_FALSE(commit_transaction());
+    EXPECT_THROW(commit_transaction(), transaction_update_conflict);
 
     begin_transaction();
     {
@@ -681,7 +678,7 @@ TEST_F(gaia_object_test, thread_update_other_row) {
         w.name_first = "No Violation";
         w.update_row();
     }
-    EXPECT_TRUE(commit_transaction());
+    EXPECT_NO_THROW(commit_transaction());
 
     begin_transaction();
     {
@@ -765,10 +762,7 @@ TEST_F(gaia_object_test, thread_delete_conflict) {
         thread t1 = thread(delete_thread, g_inserted_id);
         t1.join();
     }
-    // Expect a concurrency violation here, but for now commit_transaction is
-    // returning false.
-    // EXPECT_THROW(commit_transaction, tx_update_conflict);
-    EXPECT_FALSE(commit_transaction());
+    EXPECT_THROW(commit_transaction(), transaction_update_conflict);
 
     begin_transaction();
     {

--- a/production/inc/internal/common/socket_helpers.hpp
+++ b/production/inc/internal/common/socket_helpers.hpp
@@ -76,6 +76,11 @@ inline size_t send_msg_with_fds(int sock, const int* fds, size_t fd_count, void*
     // otherwise we need to suppress SIGPIPE (portable code here:
     // https://github.com/kroki/XProbes/blob/1447f3d93b6dbf273919af15e59f35cca58fcc23/src/libxprobes.c#L156).
     ssize_t bytes_written_or_error = sendmsg(sock, &msg, MSG_NOSIGNAL);
+    // Since we assert that we never send 0 bytes, we should never return 0 bytes written.
+    retail_assert(bytes_written_or_error != 0,
+        "sendmsg() should never return 0 bytes written unless we write 0 bytes.");
+    retail_assert(bytes_written_or_error >= -1,
+        "sendmsg() should never return a negative value except for -1.");
     if (bytes_written_or_error == -1) {
         if (errno == EPIPE) {
             throw peer_disconnected();
@@ -83,11 +88,6 @@ inline size_t send_msg_with_fds(int sock, const int* fds, size_t fd_count, void*
             throw_system_error("sendmsg failed");
         }
     }
-    // Since we assert that we never send 0 bytes, we should never return 0 bytes written.
-    retail_assert(bytes_written_or_error != 0,
-        "sendmsg() should never return 0 bytes written unless we write 0 bytes.");
-    retail_assert(bytes_written_or_error >= 0,
-        "sendmsg() should never return a negative value except for -1.");
     size_t bytes_written = static_cast<size_t>(bytes_written_or_error);
     retail_assert(bytes_written == data_size,
         "sendmsg() payload was truncated but we didn't get EMSGSIZE.");
@@ -124,6 +124,8 @@ inline size_t recv_msg_with_fds(int sock, int* fds, size_t* pfd_count, void* dat
         msg.msg_controllen = sizeof(control.buf);
     }
     ssize_t bytes_read = recvmsg(sock, &msg, 0);
+    retail_assert(bytes_read >= -1,
+        "recvmsg() should never return a negative value except for -1.");
     if (bytes_read == -1) {
         throw_system_error("recvmsg failed");
     } else if (bytes_read == 0) {
@@ -135,6 +137,7 @@ inline size_t recv_msg_with_fds(int sock, int* fds, size_t* pfd_count, void* dat
         throw system_error(
             "recvmsg: control or data payload truncated on read");
     }
+
     if (fds) {
         struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
         if (cmsg) {

--- a/production/inc/public/db/gaia_db.hpp
+++ b/production/inc/public/db/gaia_db.hpp
@@ -30,23 +30,23 @@ class no_session_active : public gaia_exception {
     }
 };
 
-class tx_in_progress : public gaia_exception {
+class transaction_in_progress : public gaia_exception {
    public:
-    tx_in_progress() {
+    transaction_in_progress() {
         m_message = "Commit or roll back the current transaction before beginning a new transaction.";
     }
 };
 
-class tx_not_open : public gaia_exception {
+class transaction_not_open : public gaia_exception {
    public:
-    tx_not_open() {
+    transaction_not_open() {
         m_message = "Begin a transaction before performing data access.";
     }
 };
 
-class tx_update_conflict : public gaia_exception {
+class transaction_update_conflict : public gaia_exception {
    public:
-    tx_update_conflict() {
+    transaction_update_conflict() {
         m_message = "Transaction was aborted due to a serialization error.";
     }
 };
@@ -99,7 +99,7 @@ void begin_session();
 void end_session();
 void begin_transaction();
 void rollback_transaction();
-bool commit_transaction();
+void commit_transaction();
 
 const char* const SE_SERVER_NAME = "gaia_semock_server";
 


### PR DESCRIPTION
I went ahead and renamed all transaction-related public exceptions to more readable names, and added an assert to the socket helpers. Also created a [JIRA task](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-292) for including the `gaia_id`s of conflicting objects in `transaction_update_conflict`.