### PR TITLE
Clear client-side shared memory on server reinitialization.

### DIFF
--- a/production/db/storage_engine/inc/storage_engine_client.hpp
+++ b/production/db/storage_engine/inc/storage_engine_client.hpp
@@ -52,6 +52,9 @@ class client : private se_base {
     static void rollback_transaction();
     static void commit_transaction();
 
+    // This is test-only functionality, intended to be exposed only in internal headers.
+    static void clear_shared_memory();
+
    private:
     thread_local static int s_fd_log;
     thread_local static offsets* s_offsets;

--- a/production/db/storage_engine/src/gaia_db.cpp
+++ b/production/db/storage_engine/src/gaia_db.cpp
@@ -4,6 +4,7 @@
 /////////////////////////////////////////////
 
 #include "gaia_db.hpp"
+#include "gaia_db_internal.hpp"
 #include "storage_engine_client.hpp"
 
 bool gaia::db::is_transaction_active() {
@@ -28,4 +29,8 @@ void gaia::db::rollback_transaction() {
 
 void gaia::db::commit_transaction() {
     gaia::db::client::commit_transaction();
+}
+
+void gaia::db::clear_shared_memory() {
+    gaia::db::client::clear_shared_memory();
 }

--- a/production/inc/internal/db/db_test_base.hpp
+++ b/production/inc/internal/db/db_test_base.hpp
@@ -17,6 +17,7 @@
 #include "retail_assert.hpp"
 #include "system_error.hpp"
 #include "gaia_db.hpp"
+#include "gaia_db_internal.hpp"
 
 using namespace gaia::common;
 using namespace gaia::db;
@@ -29,6 +30,9 @@ private:
     bool m_client_manages_session;
 
     static void reset_server() {
+        // We need to drop all client references to shared memory before resetting the server.
+        // NB: this cannot be called within an active session!
+        clear_shared_memory();
         static constexpr int POLL_INTERVAL_MILLIS = 10;
         // Reinitialize the server (forcibly disconnects all clients and clears database).
         ::system((std::string("pkill -f -HUP ") + SE_SERVER_NAME).c_str());

--- a/production/inc/internal/db/gaia_db_internal.hpp
+++ b/production/inc/internal/db/gaia_db_internal.hpp
@@ -1,0 +1,14 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#pragma once
+
+namespace gaia {
+namespace db {
+
+void clear_shared_memory();
+
+}  // namespace db
+}  // namespace gaia


### PR DESCRIPTION
This should fix the consistency issues when running SE tests in standalone mode.