### PR TITLE
Remove unneeded employee cleanup code

### DIFF
--- a/production/rules/event_manager/tests/test_rule_integration.cpp
+++ b/production/rules/event_manager/tests/test_rule_integration.cpp
@@ -168,19 +168,8 @@ protected:
 
     void TearDown() override {
         unsubscribe_rules();
-        delete_employees();
         // Currently a no-op.
         db_test_base_t::TearDown();
-    }
-
-    void delete_employees()
-    {
-        auto_transaction_t tx(false);
-        for (employee_t e = employee_t::get_first(); e; e = e.get_first())
-        {
-            e.delete_row();
-        }
-        tx.commit();
     }
 };
 


### PR DESCRIPTION
Deleting the employees seems to cause some instability when all the tests are run together.  Still investigating root cause but with this code gone, I've been able to pass locally and TeamCity (gdev) pretty consistently.  Note that the failures don't seem to repro if you run the rule tests in isolation which leads me to believe that something is in the database when I go to delete employees that is causing issues down the line.  This is total conjecture, however.