### PR TITLE
Restrict the reinitialize-on-SIGHUP feature to debug builds.

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -21,6 +21,9 @@ include(GoogleTest)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Ensure debug builds have the DEBUG flag defined.
+add_compile_options("$<$<CONFIG:DEBUG>:-DDEBUG>")
+
 # Set some global variables.
 get_repo_root(${PROJECT_SOURCE_DIR} GAIA_REPO)
 set(GAIA_COMPILE_FLAGS "-c -Wall -Wextra -ggdb")

--- a/production/db/storage_engine/src/storage_engine_server.cpp
+++ b/production/db/storage_engine/src/storage_engine_server.cpp
@@ -144,8 +144,13 @@ void server::run() {
         s_server_shutdown_event_fd = -1;
         // We shouldn't get here unless the signal handler thread has caught a signal.
         retail_assert(caught_signal != 0);
-        // We special-case SIGHUP to force reinitialization of the server.
-        if (caught_signal != SIGHUP) {
+        // In debug builds, we special-case SIGHUP to force reinitialization of the server.
+        sigset_t reinit_signals;
+        sigemptyset(&reinit_signals);
+#ifdef DEBUG
+        sigaddset(&reinit_signals, SIGHUP);
+#endif
+        if (!sigismember(&reinit_signals, caught_signal)) {
             // To exit with the correct status (reflecting a caught signal),
             // we need to unblock blocked signals and re-raise the signal.
             // We may have already received other pending signals by the time


### PR DESCRIPTION
This just `#ifdef`s out the special-casing of `SIGHUP` for server reinitialization to debug builds. (I had to add a bit of CMake goo to ensure that the `DEBUG` macro was actually defined in debug builds.) Note that release tests now will fail (crash or hang forever), since they rely on the debug-only `SIGHUP` behavior. If that's a problem please let me know!