### PR TITLE
New iterator container methods insert() and erase() that accept gaia_id_t rather than T_gaia

### DIFF
--- a/production/direct_access/tests/test_references.cpp
+++ b/production/direct_access/tests/test_references.cpp
@@ -56,6 +56,35 @@ TEST_F(gaia_references_test, connect) {
     commit_transaction();
 }
 
+// Repeat above test, but with gaia_id_t members only.
+TEST_F(gaia_references_test, connect_id_member) {
+    begin_transaction();
+
+    // Connect two inserted rows.
+    employee_writer ew;
+    ew.name_first = "Hidalgo";
+    employee_t e3 = employee_t::get(ew.insert_row());
+
+    address_writer aw;
+    aw.city = "Houston";
+    gaia_id_t aid3 = aw.insert_row();
+
+    e3.addresses_list().insert(aid3);
+    int count = 0;
+    for (auto ap : e3.addresses_list()) {
+        if (ap) {
+            count++;
+        }
+    }
+    EXPECT_EQ(count, 1 );
+
+    e3.addresses_list().erase(aid3);
+    address_t::delete_row(aid3);
+    e3.delete_row();
+    EXPECT_THROW(address_t::delete_row(12), invalid_node_id);
+    commit_transaction();
+}
+
 
 employee_t create_hierarchy() {
     auto eptr = employee_t::get(

--- a/production/inc/public/direct_access/gaia_iterators.hpp
+++ b/production/inc/public/direct_access/gaia_iterators.hpp
@@ -17,7 +17,7 @@ namespace direct_access {
 /**
  * \addtogroup Direct
  * @{
- * 
+ *
  * Implementation of Extended Data Classes. This provides a direct access API
  * for CRUD operations on the database.
  */
@@ -112,7 +112,11 @@ public:
 
     void set_outer(gaia_id_t primary_id) {m_primary_id = primary_id;}
 
+    void insert(gaia_id_t foreign_id);
+
     void insert(T_foreign& foreign_edc);
+
+    void erase(gaia_id_t foreign_id);
 
     void erase(T_foreign& foreign_edc);
 };

--- a/production/inc/public/direct_access/gaia_iterators.inc
+++ b/production/inc/public/direct_access/gaia_iterators.inc
@@ -161,15 +161,15 @@ gaia_set_iterator_t<T_foreign, T_foreign_slot> reference_chain_container_t<T_pri
 }
 
 template <typename T_primary, typename T_foreign, int T_parent_slot, int T_primary_slot, int T_foreign_slot>
-void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::insert(T_foreign& foreign_edc)
+void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::insert(gaia_id_t foreign_id)
 {
-    auto fid = foreign_edc.gaia_id();
     auto oid = m_primary_id;
 
     // The gaia_id() will be zero if the row hasn't been inserted into the SE.
-    if (fid == 0 || oid == 0) {
+    if (foreign_id == 0 || oid == 0) {
         T_primary expected = T_primary::get(0);
-        throw edc_invalid_state(expected.gaia_typename(), foreign_edc.gaia_typename());
+        T_foreign received = T_foreign::get(0);
+        throw edc_invalid_state(expected.gaia_typename(), received.gaia_typename());
     }
 
     auto node_ptr = gaia_ptr::open(oid);
@@ -178,36 +178,54 @@ void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_
         return;
     }
 
+    auto foreign_ptr = gaia_ptr::open(foreign_id);
+    if (!foreign_ptr)
+    {
+        return;
+    }
+
     // This is a no-op if it is already connected to this owner.
-    if (foreign_edc.references()[T_parent_slot] == oid) {
+    if (foreign_ptr.references()[T_parent_slot] == oid) {
         return;
     }
 
     // Cannot connect a foreign object that is already connected to a differrent owner.
-    if (foreign_edc.references()[T_parent_slot] != 0 && foreign_edc.references()[T_parent_slot] != oid) {
+    if (foreign_ptr.references()[T_parent_slot] != 0 && foreign_ptr.references()[T_parent_slot] != oid) {
         T_primary expected = T_primary::get(0);
-        throw edc_already_inserted(foreign_edc.references()[T_parent_slot], expected.gaia_typename());
+        throw edc_already_inserted(foreign_ptr.references()[T_parent_slot], expected.gaia_typename());
     }
 
-    foreign_edc.references()[T_foreign_slot] = node_ptr.references()[T_primary_slot];
-    foreign_edc.references()[T_parent_slot]  = oid;
-    node_ptr.references()[T_primary_slot] = fid;
+    foreign_ptr.references()[T_foreign_slot] = node_ptr.references()[T_primary_slot];
+    foreign_ptr.references()[T_parent_slot]  = oid;
+    node_ptr.references()[T_primary_slot] = foreign_id;
 }
 
 template <typename T_primary, typename T_foreign, int T_parent_slot, int T_primary_slot, int T_foreign_slot>
-void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::erase(T_foreign& foreign_edc)
+void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::insert(T_foreign& foreign_edc)
 {
-    if (foreign_edc.references()[T_parent_slot] != m_primary_id)
+    insert(foreign_edc.gaia_id());
+}
+
+template <typename T_primary, typename T_foreign, int T_parent_slot, int T_primary_slot, int T_foreign_slot>
+void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::erase(gaia_id_t foreign_id)
+{
+    auto foreign_ptr = gaia_ptr::open(foreign_id);
+    if (!foreign_ptr)
+    {
+        return;
+    }
+
+    if (foreign_ptr.references()[T_parent_slot] != m_primary_id)
     {
         T_primary expected = T_primary::get(0);
+        T_foreign received = T_foreign::get(0);
         throw edc_invalid_member(
             m_primary_id,
             T_primary::s_gaia_type,
             expected.gaia_typename(),
-            foreign_edc.gaia_type(),
-            foreign_edc.gaia_typename());
+            received.gaia_type(),
+            received.gaia_typename());
     }
-    gaia_id_t foreign_id = foreign_edc.gaia_id();
 
     auto node_ptr = gaia_ptr::open(m_primary_id);
     if (!node_ptr)
@@ -218,10 +236,10 @@ void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_
     if (node_ptr.references()[T_primary_slot] == foreign_id)
     {
         // It's the first one in the list, point the "first" to the current "next".
-        node_ptr.references()[T_primary_slot] = foreign_edc.references()[T_foreign_slot];
+        node_ptr.references()[T_primary_slot] = foreign_ptr.references()[T_foreign_slot];
         // Clean up the removed child.
-        foreign_edc.references()[T_foreign_slot] = 0;
-        foreign_edc.references()[T_parent_slot] = 0;
+        foreign_ptr.references()[T_foreign_slot] = 0;
+        foreign_ptr.references()[T_parent_slot] = 0;
     }
     else
     {
@@ -235,10 +253,10 @@ void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_
             if (next_id == foreign_id)
             {
                 // Point the current child to the child following the next.
-                cur_child_ptr.references()[T_foreign_slot] = foreign_edc.references()[T_foreign_slot];
+                cur_child_ptr.references()[T_foreign_slot] = foreign_ptr.references()[T_foreign_slot];
                 // Clean up the removed child.
-                foreign_edc.references()[T_foreign_slot] = 0;
-                foreign_edc.references()[T_parent_slot] = 0;
+                foreign_ptr.references()[T_foreign_slot] = 0;
+                foreign_ptr.references()[T_parent_slot] = 0;
                 return;
             }
             // Move to the next child.
@@ -246,14 +264,18 @@ void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_
         }
         // If we end up here, the child was not found in the chain. This is an error because
         // the pointers have become inconsistent (the child's parent pointer was correct).
-        T_primary expected = T_primary::get(0);
-
         throw edc_inconsistent_list(
                     m_primary_id,
-                    expected.gaia_typename(),
+                    T_primary::get(0).gaia_typename(),
                     foreign_id,
-                    foreign_edc.gaia_typename());
+                    T_foreign::get(0).gaia_typename());
     }
+}
+
+template <typename T_primary, typename T_foreign, int T_parent_slot, int T_primary_slot, int T_foreign_slot>
+void reference_chain_container_t<T_primary, T_foreign, T_parent_slot, T_primary_slot, T_foreign_slot>::erase(T_foreign& foreign_edc)
+{
+    erase(foreign_edc.gaia_id());
 }
 
 } // direct_access


### PR DESCRIPTION
Since insert_row() returns gaia_id_t, it is easier and a little quicker to use the gaia_id_t directly in the insert() and erase() methods of the reference_chain_container_t.

This PR adds the two methods and adds a test in test_references.