### PR TITLE
fix build-break: use updated catalog-generated ref names

### DIFF
--- a/production/direct_access/tests/test_direct_access.cpp
+++ b/production/direct_access/tests/test_direct_access.cpp
@@ -748,14 +748,12 @@ TEST_F(gaia_object_test, default_construction) {
     begin_transaction();
     {
         EXPECT_THROW(e.name_first(), invalid_node_id);
-        // UNDONE:  should be a.employee() above
-        EXPECT_THROW(a.addresses(), invalid_node_id);
-
+        EXPECT_THROW(a.addressee_employee(), invalid_node_id);
+        EXPECT_THROW(e.manages_employee(), invalid_node_id);
         EXPECT_THROW(e.writer(), invalid_node_id);
-        EXPECT_THROW(e.manages(), invalid_node_id);
         EXPECT_THROW(e.delete_row(), invalid_node_id);
 
-        for (auto a : e.addresses_list())
+        for (auto a : e.addressee_address_list())
         {
             printf("%s\n", a.state());
         }


### PR DESCRIPTION
Rookie error of not running the tests after merging back to master on my local machine.  We changed the way we generate ref names for EDC objects so I had to update a new test I added accordingly.  Apologies for the break.