### PR TITLE
Fix airport unit test

### DIFF
--- a/production/tools/gaia_generate/CMakeLists.txt
+++ b/production/tools/gaia_generate/CMakeLists.txt
@@ -35,5 +35,5 @@ add_gtest(test_gaia_generate
   "tests/test_gaia_generate.cpp"
   "${GAIA_GENERATE_INCLUDES};${GAIA_GENERATED_SCHEMAS}"
   "rt;gaia;gaia_catalog;gaia_parser"
-  "generate_airport_headers"
+  "generate_airport_headers" ""
   "AIRPORT_DDL_FILE=${GAIA_REPO}/production/schemas/test/airport/airport.ddl")


### PR DESCRIPTION
Fix the unit test failure. `add_gtest` takes the 6th argument after test name as environment variable settings. I deleted comma without adding an empty string for the 5th argument in previous commit, and hence the failure.