### PR TITLE
No ci cameron llvm

### DIFF
--- a/third_party/private/TranslationEngineLLVM/gdev.cfg
+++ b/third_party/private/TranslationEngineLLVM/gdev.cfg
@@ -7,6 +7,10 @@ git
 python3
 python3-dev
 
+[env]
+CC=/usr/bin/gcc
+CXX=/usr/bin/g++
+
 [gaia]
 production
 
@@ -21,15 +25,12 @@ rm -rf .git
 rm -rf ~/.ssh
 
 [run]
-unset CC
-unset CXX
-/usr/bin/cmake -DCMAKE_BUILD_TYPE=Release \
+cmake -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_ENABLE_EH=ON \
     -DLLVM_ENABLE_PROJECTS=clang \
     -DLLVM_ENABLE_RTTI=ON \
     -DGAIA_SOURCE={source_dir('')} \
-    -DGAIA_PRODUCTION_BUILD={build_dir('production')} \
+    -DGAIA_PROD_BUILD={build_dir('production')} \
     -G "Unix Makefiles" \
     TranslationEngineLLVM/llvm
 make -j$(nproc)
-#/usr/bin/cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_PROJECTS=clang -DLLVM_ENABLE_RTTI=ON -DGAIA_SOURCE=/source -DGAIA_PROD_BUILD=/build/production -G "Unix Makefiles" TranslationEngineLLVM/llvm


### PR DESCRIPTION
A few oddities that need to be addressed in here.

1. I'm setting the compiler to GCC. I could not get clang to work.
2. I think I ran into a cmake bug with v3.17.0. I found some forum about it, but am having trouble rediscovering it. I updated to v3.18.2 and it seems to work.
3. The commit hash I'm using actually points to a branch in the TranslationEngineLLVM repo that isn't committed to the main branch yet. I expect to change the commit hash here once that branch is merged properly.