### PR TITLE
Temporarily disallow ssh keys in gdev build

### DIFF
--- a/dev_tools/gdev/gdev/cmd/gen/_abc/build.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/build.py
@@ -207,7 +207,9 @@ class GenAbcBuild(Dependency, ABC):
                 f' --shm-size 1gb'
 
                 # Allow cloning repos with ssh.
-                f' --ssh default'
+                # FIXME TeamCity is unable to handle this, but it is required for
+                #  TranslationEngineLLVM build.
+                #f' --ssh default'
 
                 f''' --cache-from {','.join([
                     f'{self.options.registry}/{base_build_name}:latest'


### PR DESCRIPTION
Ssh authentication isn't needed for building just production, so disabling ssh git access in gdev while I figure out how to make it work in TeamCity. Note this is a temporary fix and must be reversed if we want gdev to be able to check out any of our private repos (such as in our third_party/private/TranslationEngineLLVM/gdev.cfg rule).