### PR TITLE
Update stack_allocator interface to allow direct object creation

### DIFF
--- a/production/db/inc/memory_manager/access_control.hpp
+++ b/production/db/inc/memory_manager/access_control.hpp
@@ -50,14 +50,14 @@ struct access_control_t
 //
 class auto_access_control_t
 {
-    private:
+private:
 
     access_control_t* m_access_control;
     access_lock_type_t m_locked_access;
     bool m_has_marked_access;
     bool m_has_locked_access;
 
-    public:
+public:
 
     auto_access_control_t();
     ~auto_access_control_t();
@@ -85,7 +85,7 @@ class auto_access_control_t
         return m_has_locked_access;
     }
 
-    private:
+private:
 
     void clear();
 };

--- a/production/db/inc/memory_manager/base_memory_manager.hpp
+++ b/production/db/inc/memory_manager/base_memory_manager.hpp
@@ -21,11 +21,11 @@ const char* const c_debug_output_separator_line_end = "<<<<<<<<<<<<<<<<<<<<<<<<<
 
 class base_memory_manager_t
 {
-    public:
+public:
 
     static const size_t c_memory_alignment = sizeof(uint64_t);
 
-    public:
+public:
 
     base_memory_manager_t();
 
@@ -100,7 +100,7 @@ class base_memory_manager_t
     // Inserts a memory record in order by either offset or size value.
     void insert_memory_record(memory_record_t* list_head, memory_record_t* memory_record, bool sort_by_offset) const;
 
-    protected:
+protected:
 
     // The base memory address relative to which we compute our offsets.
     uint8_t* m_base_memory_address;
@@ -111,7 +111,7 @@ class base_memory_manager_t
     // The total size of the memory segment in which we operate.
     size_t m_total_memory_size;
 
-    protected:
+protected:
 
     // Helper function that attempts to advance the current record past the previous one.
     //

--- a/production/db/inc/memory_manager/memory_manager.hpp
+++ b/production/db/inc/memory_manager/memory_manager.hpp
@@ -19,7 +19,7 @@ namespace memory_manager
 
 class memory_manager_t : public base_memory_manager_t
 {
-    public:
+public:
 
     memory_manager_t();
 
@@ -48,10 +48,6 @@ class memory_manager_t : public base_memory_manager_t
     // such as in the case when we load the database objects from disk.
     error_code_t allocate(size_t memory_size, address_offset_t& allocated_memory_offset) const;
 
-    // Creates a stack_allocator_t object that will be used with transactions.
-    // This interface will be used to allocate memory during regular database operation.
-    error_code_t create_stack_allocator(size_t memory_size, stack_allocator_t*& stack_allocator) const;
-
     // Once a transaction commits, calling this method will achieve several goals:
     // (i) it will insert the block into a linked list of allocations
     // that is sorted by the associated serialization number.
@@ -73,7 +69,7 @@ class memory_manager_t : public base_memory_manager_t
     error_code_t update_unserialized_allocations_list_head(
         address_offset_t next_unserialized_allocation_record_offset) const;
 
-    private:
+private:
 
     // All data tracked by the memory manager can be accessed from here.
     // The metadata information structure is stored at the beginning of the managed memory,
@@ -99,7 +95,7 @@ class memory_manager_t : public base_memory_manager_t
         }
     };
 
-    private:
+private:
 
     // A pointer to our metadata information, stored in the same memory that we manage.
     metadata_t* m_metadata;
@@ -114,7 +110,7 @@ class memory_manager_t : public base_memory_manager_t
     // Our execution flags.
     execution_flags_t m_execution_flags;
 
-    private:
+private:
 
     size_t get_main_memory_available_size(bool include_system_reserved_size) const;
 

--- a/production/db/inc/memory_manager/stack_allocator.hpp
+++ b/production/db/inc/memory_manager/stack_allocator.hpp
@@ -20,7 +20,7 @@ class stack_allocator_t : public base_memory_manager_t
 {
     friend class memory_manager_t;
 
-    private:
+public:
 
     // Only a memory_manager_t can create stack_allocator_t instances.
     stack_allocator_t();
@@ -32,8 +32,6 @@ class stack_allocator_t : public base_memory_manager_t
     // The start of the buffer is specified as an offset from a base address.
     // This is also only callable by a memory_manager_t.
     error_code_t initialize(uint8_t* base_memory_address, address_offset_t memory_offset, size_t memory_size);
-
-    public:
 
     // Allocate a new memory block that will be designated by the provided slot id.
     // The old memory offset of the slot id is also provided, for later garbage collection.
@@ -63,7 +61,7 @@ class stack_allocator_t : public base_memory_manager_t
     // Find the offset where we can make the next allocation.
     address_offset_t get_next_allocation_offset() const;
 
-    private:
+private:
 
     // A pointer to our metadata information, stored in the same memory that we manage.
     // Unlike the memory manager, which stores its metadata at the start of the buffer,
@@ -73,7 +71,7 @@ class stack_allocator_t : public base_memory_manager_t
     // Our execution flags.
     execution_flags_t m_execution_flags;
 
-    private:
+private:
 
     void output_debugging_information(const std::string& context_description) const;
 };

--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -141,38 +141,6 @@ error_code_t memory_manager_t::allocate(
     return error_code_t::success;
 }
 
-error_code_t memory_manager_t::create_stack_allocator(
-    size_t memory_size,
-    stack_allocator_t*& stack_allocator) const
-{
-    stack_allocator = nullptr;
-
-    if (m_metadata == nullptr)
-    {
-        return error_code_t::not_initialized;
-    }
-
-    address_offset_t memory_offset = 0;
-    error_code_t error_code = allocate(memory_size, memory_offset);
-    if (error_code != error_code_t::success)
-    {
-        return error_code;
-    }
-
-    stack_allocator = new stack_allocator_t();
-
-    stack_allocator->set_execution_flags(m_execution_flags);
-
-    error_code = stack_allocator->initialize(m_base_memory_address, memory_offset, memory_size);
-    if (error_code != error_code_t::success)
-    {
-        delete stack_allocator;
-        stack_allocator = nullptr;
-    }
-
-    return error_code;
-}
-
 error_code_t memory_manager_t::commit_stack_allocator(
     stack_allocator_t* stack_allocator,
     serialization_number_t serialization_number) const

--- a/production/db/memory_manager/tests/test_memory_manager.cpp
+++ b/production/db/memory_manager/tests/test_memory_manager.cpp
@@ -72,6 +72,7 @@ TEST(memory_manager, advanced_operation)
     const size_t memory_size = 8000;
     const size_t main_memory_system_reserved_size = 1000;
     uint8_t memory[memory_size];
+    address_offset_t memory_offset = 0;
 
     memory_manager_t memory_manager;
 
@@ -89,8 +90,11 @@ TEST(memory_manager, advanced_operation)
     size_t stack_allocator_memory_size = 2000;
 
     // Make 3 allocations using a stack_allocator_t.
-    stack_allocator_t* stack_allocator = nullptr;
-    error_code = memory_manager.create_stack_allocator(stack_allocator_memory_size, stack_allocator);
+    stack_allocator_t* stack_allocator = new stack_allocator_t();
+    stack_allocator->set_execution_flags(execution_flags);
+    error_code = memory_manager.allocate(stack_allocator_memory_size, memory_offset);
+    ASSERT_EQ(error_code_t::success, error_code);
+    error_code = stack_allocator->initialize(memory, memory_offset, stack_allocator_memory_size);
     ASSERT_EQ(error_code_t::success, error_code);
 
     size_t first_allocation_size = 64;
@@ -136,7 +140,11 @@ TEST(memory_manager, advanced_operation)
     // Make 2 more allocations using a new stack_allocator_t.
     // Both allocations will replace earlier allocations (4th replaces 2nd and 5th replaces 1st),
     // which will get garbage collected at commit time.
-    error_code = memory_manager.create_stack_allocator(stack_allocator_memory_size, stack_allocator);
+    stack_allocator = new stack_allocator_t();
+    stack_allocator->set_execution_flags(execution_flags);
+    error_code = memory_manager.allocate(stack_allocator_memory_size, memory_offset);
+    ASSERT_EQ(error_code_t::success, error_code);
+    error_code = stack_allocator->initialize(memory, memory_offset, stack_allocator_memory_size);
     ASSERT_EQ(error_code_t::success, error_code);
 
     size_t fourth_allocation_size = 256;

--- a/production/db/memory_manager/tests/test_stack_allocator.cpp
+++ b/production/db/memory_manager/tests/test_stack_allocator.cpp
@@ -38,6 +38,7 @@ TEST(memory_manager, stack_allocator)
     const size_t memory_size = 8000;
     const size_t main_memory_system_reserved_size = 1000;
     uint8_t memory[memory_size];
+    address_offset_t memory_offset = 0;
 
     memory_manager_t memory_manager;
 
@@ -54,8 +55,11 @@ TEST(memory_manager, stack_allocator)
 
     size_t stack_allocator_memory_size = 2000;
 
-    stack_allocator_t* stack_allocator = nullptr;
-    error_code = memory_manager.create_stack_allocator(stack_allocator_memory_size, stack_allocator);
+    stack_allocator_t* stack_allocator = new stack_allocator_t();
+    stack_allocator->set_execution_flags(execution_flags);
+    error_code = memory_manager.allocate(stack_allocator_memory_size, memory_offset);
+    ASSERT_EQ(error_code_t::success, error_code);
+    error_code = stack_allocator->initialize(memory, memory_offset, stack_allocator_memory_size);
     ASSERT_EQ(error_code_t::success, error_code);
 
     size_t first_allocation_size = 64;


### PR DESCRIPTION
Just a quick interface change to allow the current implementation of the memory manager to get used in our current client-server setup.

The original idea was that both the memory manager (MM) and the stack allocator (SA) could be initialized from various processes, so SAs would get produced by an MM, but not directly. But now we'll want the MM to only get initialized on the server side and the SA to be created on either server or client side, so the SA creation/initialization methods need to now become public.

Keep in mind that I have a larger rewrite scheduled for all this code. Many things need to go away and others need to get rewritten. So don't worry about any improvements to existing code that can wait.