### PR TITLE
Increase wait time after sending SIGHUP to SE server

### DIFF
--- a/production/inc/internal/db/db_test_base.hpp
+++ b/production/inc/internal/db/db_test_base.hpp
@@ -37,22 +37,6 @@ protected:
         gaia_log::initialize({});
     }
 
-
-    static void reset_server() {
-        // We need to drop all client references to shared memory before resetting the server.
-        // NB: this cannot be called within an active session!
-        clear_shared_memory();
-        // Reinitialize the server (forcibly disconnects all clients and clears database).
-        // Resetting the server will cause Recovery to be skipped. Recovery will only occur post 
-        // server process reboot. 
-        ::system((std::string("pkill -f -HUP ") + SE_SERVER_NAME).c_str());
-        // Wait a bit for the server's listening socket to be closed.
-        // (Otherwise, a new session might be accepted after the signal has been sent
-        // but before the server has been reinitialized.)
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        wait_for_server_init();
-    }
-
     db_test_base_t(bool client_manages_session) : m_client_manages_session(client_manages_session) {
     }
 

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -13,6 +13,7 @@
 #include "gaia_event_log.h"
 #include "triggers.hpp"
 #include "db_test_base.hpp"
+#include "db_test_helpers.hpp"
 #include "event_manager_test_helpers.hpp"
 
 using namespace gaia::common;
@@ -105,7 +106,7 @@ public:
         return s_fields;
     }
 
-    auto_transaction_t& get_dummy_transaction(bool init=false) 
+    auto_transaction_t& get_dummy_transaction(bool init=false)
     {
         // Create a transaction that won't do anything
         static auto_transaction_t s_dummy(auto_transaction_t::no_auto_begin);
@@ -281,7 +282,7 @@ void rule5(const rule_context_t* context)
 /**
  * Rule 6 handles TestGaia2::update
  * [Rule 8] Forward chains to Transaction::commit event (allowed: different event class)
- * 
+ *
  * TODO[GAIAPLAT-194]: Transaction events are out of scope for Q2
 void rule6(const rule_context_t* context)
 {
@@ -573,7 +574,7 @@ public:
 protected:
     static void SetUpTestSuite()
     {
-        db_test_base_t::reset_server();
+        reset_server();
         begin_session();
         event_manager_settings_t settings;
         settings.num_background_threads = 0;
@@ -622,7 +623,7 @@ TEST_F(event_manager_test, invalid_subscription)
 {
     field_position_list_t fields;
     fields.emplace_back(1);
-    
+
     // TODO[GAIAPLAT-194]: Transaction Events are out of scope for Q2
 
     // Transaction event subscriptions can't specify a gaia type
@@ -811,7 +812,7 @@ TEST_F(event_manager_test, log_event_multi_rule_multi_event)
     add_context_sequence(sequence, TestGaia::s_gaia_type, event_type_t::row_update);
     add_context_sequence(sequence, TestGaia::s_gaia_type, event_type_t::row_delete);
     add_context_sequence(sequence, TestGaia::s_gaia_type, event_type_t::row_delete);
-    
+
     // TODO[GAIAPLAT-194]: Transaction Events are out of scope for Q2
     //add_context_sequence(sequence, 0, event_type_t::transaction_commit);
     //add_context_sequence(sequence, 0, event_type_t::transaction_commit);
@@ -1215,7 +1216,7 @@ TEST_F(event_manager_test, event_logging_no_subscriptions)
 
     gaia::db::begin_transaction();
     auto entry = gaia::event_log::event_log_t::get_first();
-    verify_event_log_row(entry, event_type_t::row_update, 
+    verify_event_log_row(entry, event_type_t::row_update,
         TestGaia::s_gaia_type, record, s_last_name, false);
 
     EXPECT_FALSE(entry.get_next());
@@ -1240,7 +1241,7 @@ TEST_F(event_manager_test, event_logging_subscriptions)
 
     gaia::db::begin_transaction();
     auto entry = gaia::event_log::event_log_t::get_first();
-    verify_event_log_row(entry, event_type_t::row_update, 
+    verify_event_log_row(entry, event_type_t::row_update,
         TestGaia2::s_gaia_type, record, s_first_name, true);
 
     entry = entry.get_next();

--- a/production/rules/event_manager/tests/test_rule_checker.cpp
+++ b/production/rules/event_manager/tests/test_rule_checker.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "rules.hpp"
 #include "db_test_base.hpp"
+#include "db_test_helpers.hpp"
 #include "rule_checker.hpp"
 #include "gaia_catalog.hpp"
 #include "gaia_catalog.h"
@@ -53,7 +54,7 @@ void load_catalog()
         gaia_field_writer writer = field.writer();
         g_field_positions[field.name()] = field.position();
 
-        if (0 == strcmp(field.name(), "active") 
+        if (0 == strcmp(field.name(), "active")
             || (0 == strcmp(field.name(), "valid")))
         {
             writer.active = true;
@@ -82,11 +83,11 @@ public:
     void verify_exception(const char* expected_message, std::function<void ()> fn)
     {
         bool did_throw = false;
-        try 
+        try
         {
             fn();
         }
-        catch (const exception& e) 
+        catch (const exception& e)
         {
             // Find a relevant substring for this message
             string str = e.what();
@@ -106,7 +107,7 @@ protected:
     // these functions will only be called once for all tests.
     static void SetUpTestSuite()
     {
-        db_test_base_t::reset_server();
+        reset_server();
         begin_session();
         load_catalog();
     }

--- a/production/rules/event_manager/tests/test_rule_integration.cpp
+++ b/production/rules/event_manager/tests/test_rule_integration.cpp
@@ -236,7 +236,7 @@ protected:
     }
 
     // Ensure SetUp and TearDown don't do anything.  When we run the test
-    // directly, we only want SetUpTestSuite and TearDownTestSuite 
+    // directly, we only want SetUpTestSuite and TearDownTestSuite
     void SetUp() override {}
 
     void TearDown() override {
@@ -256,7 +256,7 @@ TEST_F(rule_integration_test, test_insert)
         writer.insert_row();
         g_start = g_timer.get_time_point();
         tx.commit();
-        
+
     }
 
     // Make sure the address was added and updated by the
@@ -301,7 +301,7 @@ TEST_F(rule_integration_test, test_update)
             writer.update_row();
         g_start = g_timer.get_time_point();
         tx.commit();
-        
+
     }
 }
 

--- a/production/system/tests/test_gaia_system.cpp
+++ b/production/system/tests/test_gaia_system.cpp
@@ -19,6 +19,7 @@
 #include "gaia_addr_book.h"
 #include "triggers.hpp"
 #include "db_test_base.hpp"
+#include "db_test_helpers.hpp"
 
 using namespace std;
 using namespace gaia::db;
@@ -43,9 +44,9 @@ class gaia_system_test : public db_test_base_t {
 public:
     static void SetUpTestSuite()
     {
-        db_test_base_t::reset_server();
+        reset_server();
         begin_session();
-        
+
         // NOTE: To run this test manually, you need to set the env variable DDL_FILE to the location of addr_book.ddl.
         // Currently this is under production/schemas/test/addr_book.
         const char *ddl_file = getenv("DDL_FILE");


### PR DESCRIPTION
This change is motivated by recent test failures that seem to be hitting a race between reinitializing the server by sending it `SIGHUP` vs. receiving new shared memory segments from the server via `begin_session()`. The change increases the wait time after sending the signal from 1ms to 10ms, and does a little refactoring of the `reset_server()` function. If we continue to hit this race in tests, we can increase the wait interval further (we may need to increase it to 100ms, the default Linux scheduling quantum).