### PR TITLE
Improve the stack allocator's recalculation method of the next allocation offset

### DIFF
--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -135,7 +135,7 @@ error_code_t memory_manager_t::commit_stack_allocator(
     else
     {
         // Iterate over all stack_allocator_t allocations and collect old memory offsets in free memory records.
-        for (size_t allocation_number = 1; allocation_number <= count_allocations; allocation_number++)
+        for (size_t allocation_number = 1; allocation_number <= count_allocations; ++allocation_number)
         {
             stack_allocator_allocation_t* allocation_record = stack_allocator->get_allocation_record(allocation_number);
             retail_assert(allocation_record != nullptr, "An unexpected null allocation record was retrieved!");

--- a/production/db/memory_manager/tests/test_stack_allocator.cpp
+++ b/production/db/memory_manager/tests/test_stack_allocator.cpp
@@ -50,7 +50,6 @@ TEST(memory_manager, stack_allocator)
     memory_manager.set_execution_flags(execution_flags);
     error_code = memory_manager.manage(memory, memory_size);
     ASSERT_EQ(error_code_t::success, error_code);
-    cout << "PASSED: Manager initialization was successful!" << endl;
 
     size_t stack_allocator_memory_size = 2000;
 
@@ -110,9 +109,9 @@ TEST(memory_manager, stack_allocator)
 
     ASSERT_EQ(3, stack_allocator->get_allocation_count());
 
+    cout << endl << "Deallocate all but the first allocation." << endl;
     error_code = stack_allocator->deallocate(1);
     ASSERT_EQ(error_code_t::success, error_code);
-    cout << endl << "Deallocate all but the first allocation." << endl;
 
     ASSERT_EQ(1, stack_allocator->get_allocation_count());
 
@@ -133,9 +132,9 @@ TEST(memory_manager, stack_allocator)
 
     ASSERT_EQ(3, stack_allocator->get_allocation_count());
 
+    cout << endl << "Deallocate all allocations." << endl;
     stack_allocator->deallocate(0);
     ASSERT_EQ(error_code_t::success, error_code);
-    cout << endl << "Deallocate all allocations." << endl;
 
     ASSERT_EQ(0, stack_allocator->get_allocation_count());
 


### PR DESCRIPTION
After a rollback of several allocations, the stack allocator needs to recalculate the next position from which it should perform new allocations. Previous method iterated over the full allocation record list to determine this. The new method iterates backward and just looks for the last allocation record, so it will usually terminate faster.

Also performed some additional small cleanup.