### PR TITLE
Immediately close the session socket when end_session() is called

### DIFF
--- a/production/db/storage_engine/src/storage_engine_client.cpp
+++ b/production/db/storage_engine/src/storage_engine_client.cpp
@@ -192,28 +192,10 @@ void client::begin_session() {
 }
 
 void client::end_session() {
-    // Send the server EOF.
-    shutdown(s_session_socket, SHUT_WR);
-
-    auto cleanup_session_socket = scope_guard::make_scope_guard([]() {
-        close(s_session_socket);
-        s_session_socket = -1;
-    });
-
-    // Discard all pending messages from the server and block until EOF.
-    // REVIEW: Is there any reason not to just close the socket to begin with?
-    // That *should* deliver EPOLLRDHUP to the other side (but needs testing).
-    while (true) {
-        uint8_t msg_buf[MAX_MSG_SIZE] = {0};
-        // POSIX says we should never get SIGPIPE except on writes,
-        // but set MSG_NOSIGNAL just in case.
-        ssize_t bytes_read = recv(s_session_socket, msg_buf, sizeof(msg_buf), MSG_NOSIGNAL);
-        if (bytes_read == -1) {
-            throw_system_error("read failed");
-        } else if (bytes_read == 0) {
-            break;
-        }
-    }
+    // This will gracefully shut down the server-side session thread
+    // and all other threads that session thread owns.
+    ::close(s_session_socket);
+    s_session_socket = -1;
 }
 
 void client::begin_transaction() {


### PR DESCRIPTION
The client implementation of `end_session()` was needlessly complex and fragile: it tried to perform a half-close on the write end of the session socket and then read all pending data from the server until `EOF`. That would cause random `ECONNRESET` errors when the server closed the connection before the client had finished reading data. Now it just closes the socket, which I've verified is handled correctly by the server session thread polling the socket. This should eliminate a lot of random test errors caused by `ECONNRESET` received while in the `end_session()` call at the end of `wait_for_server_init()`.

This change is already in my cursor PR but I want to merge it ASAP to eliminate this class of random test failures.