### PR TITLE
Introduce some new SE internal typedefs

### DIFF
--- a/production/db/inc/index/index.hpp
+++ b/production/db/inc/index/index.hpp
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+#include <db_types.hpp>
 #include <data_holder.hpp>
 
 namespace gaia
@@ -22,8 +23,8 @@ namespace index
 struct index_record_t
 {
     std::vector<gaia::db::payload_types::data_holder_t> key_values;
-    uint64_t row_id;
-    uint64_t transaction_id;
+    gaia_locator_t locator;
+    gaia_xid_t transaction_id;
     uint8_t deleted;
 
     index_record_t() = default;

--- a/production/db/inc/storage_engine/locator_allocator.hpp
+++ b/production/db/inc/storage_engine/locator_allocator.hpp
@@ -10,6 +10,7 @@
 
 #include <list>
 
+#include <db_types.hpp>
 #include <queue.hpp>
 
 namespace gaia
@@ -19,7 +20,7 @@ namespace db
 namespace storage
 {
 
-static const uint64_t c_invalid_locator = 0;
+static const gaia_locator_t c_invalid_locator = 0;
 
 class locator_allocator_t
 {
@@ -39,10 +40,10 @@ public:
     static locator_allocator_t* get();
 
     // Get a locator value.
-    uint64_t allocate_locator();
+    gaia_locator_t allocate_locator();
 
     // Release a previously obtained locator value.
-    void release_locator(uint64_t locator);
+    void release_locator(gaia_locator_t locator);
 
 protected:
 
@@ -51,10 +52,10 @@ protected:
 
     // List of previously allocated locators that have been released
     // and are available for reuse.
-    gaia::common::queue_t<uint64_t> m_available_locators;
+    gaia::common::queue_t<gaia_locator_t> m_available_locators;
 
     // The next available locator value from our global pool.
-    uint64_t m_next_locator;
+    gaia_locator_t m_next_locator;
 };
 
 }

--- a/production/db/inc/storage_engine/record_list.hpp
+++ b/production/db/inc/storage_engine/record_list.hpp
@@ -9,6 +9,8 @@
 #include <shared_mutex>
 #include <vector>
 
+#include <db_types.hpp>
+
 namespace gaia
 {
 namespace db
@@ -19,14 +21,14 @@ namespace storage
 struct record_data_t
 {
     // Provides the record's locator.
-    uint64_t locator;
+    gaia::db::gaia_locator_t locator;
 
     // Tells whether the record has been deleted.
     bool is_deleted;
 
     record_data_t();
 
-    void set(uint64_t locator);
+    void set(gaia::db::gaia_locator_t locator);
 };
 
 struct record_iterator_t;
@@ -49,7 +51,7 @@ public:
     void compact();
 
     // Add and get an element.
-    void add(uint64_t locator);
+    void add(gaia::db::gaia_locator_t locator);
     record_data_t& get(size_t index);
 
     // Add and read the next range.
@@ -101,7 +103,7 @@ public:
     void compact();
 
     // Add a recod's locator to our record list.
-    void add(uint64_t locator);
+    void add(gaia::db::gaia_locator_t locator);
 
     // Start an iteration.
     // Return true if the iterator was positioned on a valid record
@@ -114,7 +116,7 @@ public:
     static bool move_next(record_iterator_t& iterator);
 
     // Read the record locator for the current iterator position.
-    static uint64_t get_record_locator(record_iterator_t& iterator);
+    static gaia::db::gaia_locator_t get_record_locator(record_iterator_t& iterator);
 
     // Mark the record currently referenced by the iterator as deleted.
     static void delete_record(record_iterator_t& iterator);

--- a/production/db/storage_engine/inc/persistent_store_manager.hpp
+++ b/production/db/storage_engine/inc/persistent_store_manager.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "gaia_common.hpp"
+#include "db_types.hpp"
 
 // This file provides gaia specific functionality to persist writes to & read from
 // RocksDB during recovery.
@@ -46,7 +47,7 @@ public:
      */
     void recover();
 
-    std::string begin_txn(gaia::common::gaia_xid_t transaction_id);
+    std::string begin_txn(gaia::db::gaia_xid_t transaction_id);
 
     /**
      * This method will serialize the transaction to the log.

--- a/production/db/storage_engine/inc/storage_engine.hpp
+++ b/production/db/storage_engine/inc/storage_engine.hpp
@@ -25,6 +25,7 @@
 #include "system_error.hpp"
 #include "gaia_common.hpp"
 #include "gaia_db.hpp"
+#include "db_types.hpp"
 #include "gaia_exception.hpp"
 #include "retail_assert.hpp"
 
@@ -33,41 +34,39 @@ namespace db {
 
 using namespace common;
 
-typedef uint64_t gaia_edge_type_t;
-
 // 1K oughta be enough for anybody...
 const size_t MAX_MSG_SIZE = 1 << 10;
 
-enum class gaia_operation_t: uint8_t {
+enum class gaia_operation_t : uint8_t {
     create = 0x1,
     update = 0x2,
     remove = 0x3,
-    clone  = 0x4
+    clone = 0x4
 };
 
 struct hash_node {
     gaia_id_t id;
-    int64_t next;
-    int64_t row_id;
+    size_t next_offset;
+    gaia_locator_t locator;
 };
 
 class se_base {
     friend class gaia_ptr;
     friend class gaia_hash_map;
 
-   protected:
+protected:
     static const char* const SERVER_CONNECT_SOCKET_NAME;
-    static const char* const SCH_MEM_OFFSETS;
+    static const char* const SCH_MEM_LOCATORS;
     static const char* const SCH_MEM_DATA;
     static const char* const SCH_MEM_LOG;
 
-    auto static const MAX_RIDS = 32 * 128L * 1024L;
+    auto static const MAX_LOCATORS = 32 * 128L * 1024L;
     static const auto HASH_BUCKETS = 12289;
-    static const auto HASH_LIST_ELEMENTS = MAX_RIDS;
+    static const auto HASH_LIST_ELEMENTS = MAX_LOCATORS;
     static const auto MAX_LOG_RECS = 1000000;
-    static const auto MAX_OBJECTS = MAX_RIDS * 8;
+    static const auto MAX_OBJECTS = MAX_LOCATORS * 8;
 
-    typedef int64_t offsets[MAX_RIDS];
+    typedef gaia_locator_t locators[MAX_LOCATORS];
 
     struct data {
         // The first two fields are used as cross-process atomic counters.
@@ -76,19 +75,24 @@ class se_base {
         // This is because the instructions targeted by the intrinsics
         // operate at the level of physical memory, not virtual addresses.
         gaia_id_t next_id;
-        int64_t transaction_id_count;
-        int64_t row_id_count;
-        int64_t hash_node_count;
+        gaia_xid_t next_transaction_id;
+        size_t locator_count;
+        size_t hash_node_count;
         hash_node hash_nodes[HASH_BUCKETS + HASH_LIST_ELEMENTS];
-        int64_t objects[MAX_RIDS * 8];
+        // This array is actually an untyped array of bytes, but it's defined as
+        // an array of uint64_t just to enforce 8-byte alignment. Allocating
+        // (MAX_LOCATORS * 8) 8-byte words for this array means we reserve 64
+        // bytes on average for each object we allocate (or 1 cache line on
+        // every common architecture).
+        uint64_t objects[MAX_LOCATORS * 8];
     };
 
     struct log {
         size_t count;
         struct log_record {
-            int64_t row_id;
-            int64_t old_object;
-            int64_t new_object;
+            gaia_locator_t locator;
+            gaia_offset_t old_offset;
+            gaia_offset_t new_offset;
             gaia_id_t deleted_id;
             gaia_operation_t operation;
         } log_records[MAX_LOG_RECS];
@@ -98,20 +102,15 @@ class se_base {
     thread_local static int s_session_socket;
     thread_local static gaia_xid_t s_transaction_id;
 
-   public:
-    // The real implementation will need
-    // to do something better than increment
-    // a counter.  It will need to guarantee
-    // that the generated id is not in use
-    // already by a database that is
-    // restored.
+public:
+    // REVIEW: this counter needs to be initialized from persistent storage.
     static gaia_id_t generate_id(data* s_data) {
         gaia_id_t id = __sync_add_and_fetch(&s_data->next_id, 1);
         return id;
     }
 
     static gaia_xid_t allocate_transaction_id(data* s_data) {
-        gaia_xid_t xid = __sync_add_and_fetch (&s_data->transaction_id_count, 1);
+        gaia_xid_t xid = __sync_add_and_fetch(&s_data->next_transaction_id, 1);
         return xid;
     }
 
@@ -119,28 +118,28 @@ class se_base {
         return s_log;
     }
 
-    static inline int64_t allocate_row_id(offsets* offsets, data* s_data, bool invoked_by_server = false) {
+    static inline gaia_locator_t allocate_locator(locators* locators, data* s_data, bool invoked_by_server = false) {
         if (invoked_by_server) {
-            retail_assert(offsets, "Server offsets should be non-null");
+            retail_assert(locators, "Server locators should be non-null");
         }
 
-        if (offsets == nullptr) {
+        if (locators == nullptr) {
             throw transaction_not_open();
         }
 
-        if (s_data->row_id_count >= MAX_RIDS) {
+        if (s_data->locator_count >= MAX_LOCATORS) {
             throw oom();
         }
 
-        return 1 + __sync_fetch_and_add(&s_data->row_id_count, 1);
+        return 1 + __sync_fetch_and_add(&s_data->locator_count, 1);
     }
 
-    static void inline allocate_object(int64_t row_id, uint64_t size, offsets* offsets, data* s_data, bool invoked_by_server = false) {
+    static void inline allocate_object(gaia_locator_t locator, size_t size, locators* locators, data* s_data, bool invoked_by_server = false) {
         if (invoked_by_server) {
-            retail_assert(offsets, "Server offsets should be non-null");
+            retail_assert(locators, "Server locators should be non-null");
         }
 
-        if (offsets == nullptr) {
+        if (locators == nullptr) {
             throw transaction_not_open();
         }
 
@@ -148,15 +147,13 @@ class se_base {
             throw oom();
         }
 
-        (*offsets)[row_id] = 1 + __sync_fetch_and_add(
-            &s_data->objects[0],
-            (size + sizeof(int64_t) - 1) / sizeof(int64_t));
+        (*locators)[locator] = 1 + __sync_fetch_and_add(&s_data->objects[0], (size + sizeof(uint64_t) - 1) / sizeof(uint64_t));
     }
 
-    static bool locator_exists(se_base::offsets* offsets, int64_t offset) {
-        return (*offsets)[offset];
+    static bool locator_exists(se_base::locators* locators, gaia_locator_t locator) {
+        return (*locators)[locator];
     }
 };
 
-}  // namespace db
-}  // namespace gaia
+} // namespace db
+} // namespace gaia

--- a/production/db/storage_engine/inc/storage_engine_client.hpp
+++ b/production/db/storage_engine/inc/storage_engine_client.hpp
@@ -14,8 +14,6 @@
 #include <atomic>
 #include <unordered_set>
 
-#include <flatbuffers/flatbuffers.h>
-
 #include "array_size.hpp"
 #include "retail_assert.hpp"
 #include "system_error.hpp"
@@ -24,7 +22,7 @@
 #include "messages_generated.h"
 #include "storage_engine.hpp"
 #include "triggers.hpp"
-#include "gaia_db_internal.hpp"
+#include "db_types.hpp"
 
 using namespace std;
 using namespace gaia::common;
@@ -42,28 +40,36 @@ class client : private se_base {
     friend class gaia_hash_map;
     friend class event_trigger_threadpool_t;
 
-   public:
+public:
     static inline bool is_transaction_active() {
-        return (s_offsets != nullptr);
+        return (s_locators != nullptr);
     }
+
+    static inline bool set_commit_trigger(commit_trigger_fn trigger_fn) {
+        return __sync_val_compare_and_swap(&s_tx_commit_trigger, nullptr, trigger_fn);
+    }
+
+    // This test-only function is exported from gaia_db_internal.hpp.
+    static void clear_shared_memory();
+
+    // These public functions are exported from and documented in gaia_db.hpp.
     static void begin_session();
     static void end_session();
     static void begin_transaction();
     static void rollback_transaction();
     static void commit_transaction();
 
-    // This is test-only functionality, intended to be exposed only in internal headers.
-    static void clear_shared_memory();
-
-   private:
-    // Both s_fd_log & s_offsets have transaction lifetime.
+private:
+    // Both s_fd_log & s_locators have transaction lifetime.
     thread_local static int s_fd_log;
-    thread_local static offsets* s_offsets;
-    // Both s_fd_offsets & s_data have session lifetime.
-    thread_local static int s_fd_offsets;
+    thread_local static locators* s_locators;
+    // Both s_fd_locators & s_data have session lifetime.
+    thread_local static int s_fd_locators;
     thread_local static data* s_data;
     // s_events has transaction lifetime and is cleared after each transaction.
     thread_local static std::vector<gaia::db::triggers::trigger_event_t> s_events;
+    // Set by the rules engine.
+    static commit_trigger_fn s_tx_commit_trigger;
 
     // Maintain a static filter in the client to disable generating events
     // for system types.
@@ -83,7 +89,7 @@ class client : private se_base {
      *  Check if an event should be generated for a given type.
      */
     static inline bool is_valid_event(const gaia_type_t type) {
-        return (gaia::db::s_tx_commit_trigger
+        return (s_tx_commit_trigger
             && (trigger_excluded_types.find(type) == trigger_excluded_types.end()));
     }
 
@@ -112,22 +118,22 @@ class client : private se_base {
     }
 
     static inline void tx_log(
-        int64_t row_id,
-        int64_t old_object,
-        int64_t new_object,
+        gaia_locator_t locator,
+        gaia_offset_t old_offset,
+        gaia_offset_t new_offset,
         gaia_operation_t operation,
         // 'deleted_id' is required to keep track of deleted keys which will be propagated to the persistent layer.
         // Memory for other operations will be unused. An alternative would be to keep a separate log for deleted keys only.
         gaia_id_t deleted_id = 0) {
         retail_assert(s_log->count < MAX_LOG_RECS);
         log::log_record* lr = s_log->log_records + s_log->count++;
-        lr->row_id = row_id;
-        lr->old_object = old_object;
-        lr->new_object = new_object;
+        lr->locator = locator;
+        lr->old_offset = old_offset;
+        lr->new_offset = new_offset;
         lr->deleted_id = deleted_id;
         lr->operation = operation;
     }
 };
 
-}  // namespace db
-}  // namespace gaia
+} // namespace db
+} // namespace gaia

--- a/production/db/storage_engine/inc/storage_engine_server.hpp
+++ b/production/db/storage_engine/inc/storage_engine_server.hpp
@@ -45,12 +45,12 @@ class server : private se_base {
     static int s_connect_socket;
     static std::mutex s_commit_lock;
     static int s_fd_data;
-    static offsets* s_shared_offsets;
+    static locators* s_shared_locators;
     static std::unique_ptr<persistent_store_manager> rdb;
     thread_local static session_state_t s_session_state;
     thread_local static bool s_session_shutdown;
 
-    static int s_fd_offsets;
+    static int s_fd_locators;
     static data* s_data;
 
     // Inherited from se_base:
@@ -145,13 +145,13 @@ class server : private se_base {
     }
 
     static void clear_shared_memory() {
-        if (s_shared_offsets) {
-            unmap_fd(s_shared_offsets, sizeof(offsets));
-            s_shared_offsets = nullptr;
+        if (s_shared_locators) {
+            unmap_fd(s_shared_locators, sizeof(locators));
+            s_shared_locators = nullptr;
         }
-        if (s_fd_offsets != -1) {
-            close(s_fd_offsets);
-            s_fd_offsets = -1;
+        if (s_fd_locators != -1) {
+            close(s_fd_locators);
+            s_fd_locators = -1;
         }
         if (s_data) {
             unmap_fd(s_data, sizeof(data));
@@ -183,21 +183,21 @@ class server : private se_base {
         auto cleanup_memory = scope_guard::make_scope_guard([]() {
             clear_shared_memory();
         });
-        retail_assert(s_fd_data == -1 && s_fd_offsets == -1);
-        retail_assert(!s_data && !s_shared_offsets);
-        s_fd_offsets = memfd_create(SCH_MEM_OFFSETS, MFD_ALLOW_SEALING);
-        if (s_fd_offsets == -1) {
+        retail_assert(s_fd_data == -1 && s_fd_locators == -1);
+        retail_assert(!s_data && !s_shared_locators);
+        s_fd_locators = memfd_create(SCH_MEM_LOCATORS, MFD_ALLOW_SEALING);
+        if (s_fd_locators == -1) {
             throw_system_error("memfd_create failed");
         }
         s_fd_data = memfd_create(SCH_MEM_DATA, MFD_ALLOW_SEALING);
         if (s_fd_data == -1) {
             throw_system_error("memfd_create failed");
         }
-        if (-1 == ftruncate(s_fd_offsets, sizeof(offsets)) || -1 == ftruncate(s_fd_data, sizeof(data))) {
+        if (-1 == ftruncate(s_fd_locators, sizeof(locators)) || -1 == ftruncate(s_fd_data, sizeof(data))) {
             throw_system_error("ftruncate failed");
         }
-        s_shared_offsets = static_cast<offsets*>(map_fd(sizeof(offsets),
-            PROT_READ | PROT_WRITE, MAP_SHARED, s_fd_offsets, 0));
+        s_shared_locators = static_cast<locators*>(map_fd(sizeof(locators),
+            PROT_READ | PROT_WRITE, MAP_SHARED, s_fd_locators, 0));
         s_data = static_cast<data*>(map_fd(sizeof(data),
             PROT_READ | PROT_WRITE, MAP_SHARED, s_fd_data, 0));
 
@@ -364,10 +364,10 @@ class server : private se_base {
         }
     }
 
-    static gaia_se_object_t* locator_to_ptr(offsets* offsets, data* s_data, int64_t row_id) {
-        assert(*offsets);
-        return row_id && (*offsets)[row_id]
-            ? reinterpret_cast<gaia_se_object_t*>(s_data->objects + (*offsets)[row_id])
+    static gaia_se_object_t* locator_to_ptr(locators* locators, data* s_data, gaia_locator_t locator) {
+        assert(*locators);
+        return locator && (*locators)[locator]
+            ? reinterpret_cast<gaia_se_object_t*>(s_data->objects + (*locators)[locator])
             : nullptr;
     }
 
@@ -503,13 +503,13 @@ class server : private se_base {
         // guarantees there are no clients mapping the locator segment. It does not
         // guarantee there are no other threads in this process that have acquired
         // an exclusive lock, though (hence the additional mutex).
-        if (-1 == flock(s_fd_offsets, LOCK_EX)) {
+        if (-1 == flock(s_fd_locators, LOCK_EX)) {
             throw_system_error("flock failed");
         }
         // Within our own process, we must have exclusive access to the locator segment.
         const std::lock_guard<std::mutex> lock(s_commit_lock);
         auto cleanup = scope_guard::make_scope_guard([]() {
-            if (-1 == flock(s_fd_offsets, LOCK_UN)) {
+            if (-1 == flock(s_fd_locators, LOCK_UN)) {
                 // Per C++11 semantics, throwing an exception from a destructor
                 // will just call std::terminate(), no undefined behavior.
                 throw_system_error("flock failed");
@@ -517,7 +517,7 @@ class server : private se_base {
             unmap_fd(s_log, sizeof(s_log));
         });
 
-        std::set<int64_t> row_ids;
+        std::set<gaia_locator_t> locators;
 
         auto txn_name = rdb->begin_txn(s_transaction_id);
         // Prepare tx
@@ -526,8 +526,8 @@ class server : private se_base {
         for (size_t i = 0; i < s_log->count; i++) {
             auto lr = s_log->log_records + i;
 
-            if (row_ids.insert(lr->row_id).second) {
-                if ((*s_shared_offsets)[lr->row_id] != lr->old_object) {
+            if (locators.insert(lr->locator).second) {
+                if ((*s_shared_locators)[lr->locator] != lr->old_offset) {
                     // Append Rollback decision to log.
                     // This isn't really required because recovery will skip deserializing transactions
                     // that don't have a commit marker; we do it for completeness anyway.
@@ -539,7 +539,7 @@ class server : private se_base {
 
         for (size_t i = 0; i < s_log->count; i++) {
             auto lr = s_log->log_records + i;
-            (*s_shared_offsets)[lr->row_id] = lr->new_object;
+            (*s_shared_locators)[lr->locator] = lr->new_offset;
         }
 
         // Append commit decision to the log.

--- a/production/db/storage_engine/src/gaia_db.cpp
+++ b/production/db/storage_engine/src/gaia_db.cpp
@@ -3,7 +3,9 @@
 // All rights reserved.
 /////////////////////////////////////////////
 
+#include "db_types.hpp"
 #include "gaia_db.hpp"
+#include "gaia_db_internal.hpp"
 
 #include "storage_engine_client.hpp"
 
@@ -29,6 +31,10 @@ void gaia::db::rollback_transaction() {
 
 void gaia::db::commit_transaction() {
     gaia::db::client::commit_transaction();
+}
+
+bool gaia::db::set_commit_trigger(commit_trigger_fn trigger_fn) {
+    return gaia::db::client::set_commit_trigger(trigger_fn);
 }
 
 void gaia::db::clear_shared_memory() {

--- a/production/db/storage_engine/src/gaia_ptr.cpp
+++ b/production/db/storage_engine/src/gaia_ptr.cpp
@@ -22,20 +22,20 @@ gaia_id_t gaia_ptr::generate_id() {
 }
 
 void gaia_ptr::clone_no_tx() {
-    auto old_this = to_ptr();
-    auto new_size = sizeof(gaia_se_object_t) + old_this->payload_size;
+    gaia_se_object_t* old_this = to_ptr();
+    size_t new_size = sizeof(gaia_se_object_t) + old_this->payload_size;
     allocate(new_size);
-    auto new_this = to_ptr();
+    gaia_se_object_t* new_this = to_ptr();
     memcpy(new_this, old_this, new_size);
 }
 
 gaia_ptr& gaia_ptr::clone() {
-    auto old_offset = to_offset();
+    gaia_offset_t old_offset = to_offset();
     clone_no_tx();
 
-    client::tx_log(row_id, old_offset, to_offset(), gaia_operation_t::clone);
+    client::tx_log(m_locator, old_offset, to_offset(), gaia_operation_t::clone);
 
-    auto new_this = to_ptr();
+    gaia_se_object_t* new_this = to_ptr();
     if (client::is_valid_event(new_this->type)) {
         client::s_events.push_back(trigger_event_t{event_type_t::row_insert, new_this->type, new_this->id, empty_position_list});
     }
@@ -44,14 +44,14 @@ gaia_ptr& gaia_ptr::clone() {
 }
 
 gaia_ptr& gaia_ptr::update_payload(size_t data_size, const void* data) {
-    auto old_this = to_ptr();
-    auto old_offset = to_offset();
+    gaia_se_object_t* old_this = to_ptr();
+    gaia_offset_t old_offset = to_offset();
 
     size_t ref_len = old_this->num_references * sizeof(gaia_id_t);
     size_t total_len = data_size + ref_len;
     allocate(sizeof(gaia_se_object_t) + total_len);
 
-    auto new_this = to_ptr();
+    gaia_se_object_t* new_this = to_ptr();
 
     memcpy(new_this, old_this, sizeof(gaia_se_object_t));
     new_this->payload_size = total_len;
@@ -61,10 +61,10 @@ gaia_ptr& gaia_ptr::update_payload(size_t data_size, const void* data) {
     new_this->num_references = old_this->num_references;
     memcpy(new_this->payload + ref_len, data, data_size);
 
-    client::tx_log(row_id, old_offset, to_offset(), gaia_operation_t::update);
+    client::tx_log(m_locator, old_offset, to_offset(), gaia_operation_t::update);
 
     if (client::is_valid_event(new_this->type)) {
-        auto old_data = (const uint8_t*)old_this->payload;
+        const uint8_t* old_data = (const uint8_t*)old_this->payload;
 
         const uint8_t* old_data_payload;
 
@@ -81,42 +81,42 @@ gaia_ptr& gaia_ptr::update_payload(size_t data_size, const void* data) {
 }
 
 gaia_ptr& gaia_ptr::update_parent_references(size_t child_slot, gaia_id_t child_id) {
-    auto old_offset = to_offset();
+    gaia_offset_t old_offset = to_offset();
     clone_no_tx();
 
     references()[child_slot] = child_id;
 
-    client::tx_log(row_id, old_offset, to_offset(), gaia_operation_t::update);
+    client::tx_log(m_locator, old_offset, to_offset(), gaia_operation_t::update);
     return *this;
 }
 
 gaia_ptr& gaia_ptr::update_child_references(
     size_t next_child_slot, gaia_id_t next_child_id,
     size_t parent_slot, gaia_id_t parent_id) {
-    auto old_offset = to_offset();
+    gaia_offset_t old_offset = to_offset();
     clone_no_tx();
 
     references()[next_child_slot] = next_child_id;
     references()[parent_slot] = parent_id;
 
-    client::tx_log(row_id, old_offset, to_offset(), gaia_operation_t::update);
+    client::tx_log(m_locator, old_offset, to_offset(), gaia_operation_t::update);
     return *this;
 }
 
 gaia_ptr::gaia_ptr(const gaia_id_t id) {
-    row_id = gaia_hash_map::find(client::s_data, client::s_offsets, id);
+    m_locator = gaia_hash_map::find(client::s_data, client::s_locators, id);
 }
 
 gaia_ptr::gaia_ptr(const gaia_id_t id, const size_t size)
-    : row_id(0) {
-    hash_node* hash_node = gaia_hash_map::insert(client::s_data, client::s_offsets, id);
-    hash_node->row_id = row_id = se_base::allocate_row_id(client::s_offsets, client::s_data);
-    se_base::allocate_object(row_id, size, client::s_offsets, client::s_data);
-    client::tx_log(row_id, 0, to_offset(), gaia_operation_t::create);
+    : m_locator(0) {
+    hash_node* hash_node = gaia_hash_map::insert(client::s_data, client::s_locators, id);
+    hash_node->locator = m_locator = se_base::allocate_locator(client::s_locators, client::s_data);
+    se_base::allocate_object(m_locator, size, client::s_locators, client::s_data);
+    client::tx_log(m_locator, 0, to_offset(), gaia_operation_t::create);
 }
 
 void gaia_ptr::allocate(const size_t size) {
-    se_base::allocate_object(row_id, size, client::s_offsets, client::s_data);
+    se_base::allocate_object(m_locator, size, client::s_locators, client::s_data);
 }
 
 void gaia_ptr::create_insert_trigger(gaia_type_t type, gaia_id_t id) {
@@ -128,41 +128,41 @@ void gaia_ptr::create_insert_trigger(gaia_type_t type, gaia_id_t id) {
 gaia_se_object_t* gaia_ptr::to_ptr() const {
     client::verify_tx_active();
 
-    return row_id && se_base::locator_exists(client::s_offsets, row_id)
-               ? reinterpret_cast<gaia_se_object_t*>(client::s_data->objects + (*client::s_offsets)[row_id])
+    return m_locator && se_base::locator_exists(client::s_locators, m_locator)
+               ? reinterpret_cast<gaia_se_object_t*>(client::s_data->objects + (*client::s_locators)[m_locator])
                : nullptr;
 }
 
-int64_t gaia_ptr::to_offset() const {
+gaia_offset_t gaia_ptr::to_offset() const {
     client::verify_tx_active();
 
-    return row_id
-               ? (*client::s_offsets)[row_id]
+    return m_locator
+               ? (*client::s_locators)[m_locator]
                : 0;
 }
 
 void gaia_ptr::find_next(gaia_type_t type) {
     // search for rows of this type within the range of used slots
-    while (++row_id && row_id < client::s_data->row_id_count + 1) {
+    while (++m_locator && m_locator < client::s_data->locator_count + 1) {
         if (is(type)) {
             return;
         }
     }
-    row_id = 0;
+    m_locator = 0;
 }
 
 void gaia_ptr::reset() {
-    client::tx_log(row_id, to_offset(), 0, gaia_operation_t::remove, to_ptr()->id);
+    client::tx_log(m_locator, to_offset(), 0, gaia_operation_t::remove, to_ptr()->id);
 
     if (client::is_valid_event(to_ptr()->type)) {
         client::s_events.push_back(trigger_event_t{event_type_t::row_delete, to_ptr()->type, to_ptr()->id, empty_position_list});
     }
-    (*client::s_offsets)[row_id] = 0;
-    row_id = 0;
+    (*client::s_locators)[m_locator] = 0;
+    m_locator = 0;
 }
 
 void gaia_ptr::add_child_reference(gaia_id_t child_id, reference_offset_t first_child_offset) {
-    auto parent_type = type();
+    gaia_type_t parent_type = type();
     auto parent_metadata = type_registry_t::instance().get_or_create(parent_type);
     auto relationship = parent_metadata.find_parent_relationship(first_child_offset);
 
@@ -172,7 +172,7 @@ void gaia_ptr::add_child_reference(gaia_id_t child_id, reference_offset_t first_
 
     // CHECK TYPES
 
-    auto child_ptr = gaia_ptr(child_id);
+    gaia_ptr child_ptr = gaia_ptr(child_id);
 
     if (!child_ptr) {
         throw invalid_node_id(child_id);
@@ -214,7 +214,7 @@ void gaia_ptr::add_child_reference(gaia_id_t child_id, reference_offset_t first_
 }
 
 void gaia_ptr::add_parent_reference(gaia_id_t parent_id, reference_offset_t parent_offset) {
-    auto child_type = type();
+    gaia_type_t child_type = type();
 
     auto child_metadata = type_registry_t::instance().get_or_create(child_type);
     auto child_relationship = child_metadata.find_child_relationship(parent_offset);
@@ -223,7 +223,7 @@ void gaia_ptr::add_parent_reference(gaia_id_t parent_id, reference_offset_t pare
         throw invalid_reference_offset(child_type, parent_offset);
     }
 
-    auto parent_ptr = gaia_ptr(parent_id);
+    gaia_ptr parent_ptr = gaia_ptr(parent_id);
 
     if (!parent_ptr) {
         throw invalid_node_id(parent_ptr);
@@ -233,7 +233,7 @@ void gaia_ptr::add_parent_reference(gaia_id_t parent_id, reference_offset_t pare
 }
 
 void gaia_ptr::remove_child_reference(gaia_id_t child_id, reference_offset_t first_child_offset) {
-    auto parent_type = type();
+    gaia_type_t parent_type = type();
     auto parent_metadata = type_registry_t::instance().get_or_create(parent_type);
     auto relationship = parent_metadata.find_parent_relationship(first_child_offset);
 
@@ -246,7 +246,7 @@ void gaia_ptr::remove_child_reference(gaia_id_t child_id, reference_offset_t fir
     //   I still prefer to fail because calling this method with worng arguments means there
     //   is something seriously ill in the caller code.
 
-    auto child_ptr = gaia_ptr(child_id);
+    gaia_ptr child_ptr = gaia_ptr(child_id);
 
     if (!child_ptr) {
         throw invalid_node_id(child_id);
@@ -271,14 +271,14 @@ void gaia_ptr::remove_child_reference(gaia_id_t child_id, reference_offset_t fir
 
     // match found
     if (curr_child == child_id) {
-        auto curr_ptr = gaia_ptr(curr_child);
+        gaia_ptr curr_ptr = gaia_ptr(curr_child);
 
         if (!prev_child) {
             // first child in the linked list, need to update the parent
             references()[first_child_offset] = curr_ptr.references()[relationship->next_child_offset];
         } else {
             // non-first child in the linked list, update the previous child
-            auto prev_ptr = gaia_ptr(prev_child);
+            gaia_ptr prev_ptr = gaia_ptr(prev_child);
             prev_ptr.references()[relationship->next_child_offset] = curr_ptr.references()[relationship->next_child_offset];
         }
 
@@ -288,7 +288,7 @@ void gaia_ptr::remove_child_reference(gaia_id_t child_id, reference_offset_t fir
 }
 
 void gaia_ptr::remove_parent_reference(gaia_id_t parent_id, reference_offset_t parent_offset) {
-    auto child_type = type();
+    gaia_type_t child_type = type();
 
     auto child_metadata = type_registry_t::instance().get_or_create(child_type);
     auto relationship = child_metadata.find_child_relationship(parent_offset);
@@ -297,7 +297,7 @@ void gaia_ptr::remove_parent_reference(gaia_id_t parent_id, reference_offset_t p
         throw invalid_reference_offset(child_type, parent_offset);
     }
 
-    auto parent_ptr = gaia_ptr(parent_id);
+    gaia_ptr parent_ptr = gaia_ptr(parent_id);
 
     if (!parent_ptr) {
         throw invalid_node_id(parent_ptr);

--- a/production/db/storage_engine/src/record_list.cpp
+++ b/production/db/storage_engine/src/record_list.cpp
@@ -9,6 +9,7 @@
 #include <locator_allocator.hpp>
 
 using namespace gaia::common;
+using namespace gaia::db;
 using namespace gaia::db::storage;
 
 record_data_t::record_data_t()
@@ -17,7 +18,7 @@ record_data_t::record_data_t()
     is_deleted = false;
 }
 
-void record_data_t::set(uint64_t locator)
+void record_data_t::set(gaia_locator_t locator)
 {
     retail_assert(locator != c_invalid_locator, "An invalid locator was passed to record_data_t::set()!");
 
@@ -67,7 +68,7 @@ void record_range_t::compact()
     m_has_deletions = false;
 }
 
-void record_range_t::add(uint64_t locator)
+void record_range_t::add(gaia_locator_t locator)
 {
     retail_assert(locator != c_invalid_locator, "An invalid locator was passed to record_range_t::add()!");
     retail_assert(!is_full(), "Range is full!");
@@ -151,7 +152,7 @@ void record_list_t::compact()
     }
 }
 
-void record_list_t::add(uint64_t locator)
+void record_list_t::add(gaia_locator_t locator)
 {
     retail_assert(locator != c_invalid_locator, "An invalid locator was passed to record_list_t::add()!");
 
@@ -244,14 +245,14 @@ bool record_list_t::move_next(record_iterator_t& iterator)
     return (iterator.at_end() == false);
 }
 
-uint64_t record_list_t::get_record_locator(record_iterator_t& iterator)
+gaia_locator_t record_list_t::get_record_locator(record_iterator_t& iterator)
 {
     retail_assert(iterator.at_end() == false, "Attempt to access invalid iterator state!");
 
     return iterator.current_range->get(iterator.current_index).locator;
 }
 
-void  record_list_t::delete_record(record_iterator_t& iterator)
+void record_list_t::delete_record(record_iterator_t& iterator)
 {
     retail_assert(iterator.at_end() == false, "Attempt to access invalid iterator state!");
 

--- a/production/db/storage_engine/src/storage_engine.cpp
+++ b/production/db/storage_engine/src/storage_engine.cpp
@@ -6,10 +6,10 @@
 #include "storage_engine.hpp"
 
 const char* const gaia::db::se_base::SERVER_CONNECT_SOCKET_NAME = "gaia_se_server";
-const char* const gaia::db::se_base::SCH_MEM_OFFSETS = "gaia_mem_offsets";
+const char* const gaia::db::se_base::SCH_MEM_LOCATORS = "gaia_mem_locators";
 const char* const gaia::db::se_base::SCH_MEM_DATA = "gaia_mem_data";
 const char* const gaia::db::se_base::SCH_MEM_LOG = "gaia_mem_log";
 
 thread_local int gaia::db::se_base::s_session_socket = -1;
-thread_local gaia::common::gaia_xid_t gaia::db::se_base::s_transaction_id = 0;
+thread_local gaia::db::gaia_xid_t gaia::db::se_base::s_transaction_id = 0;
 thread_local gaia::db::se_base::log* gaia::db::se_base::s_log = nullptr;

--- a/production/db/storage_engine/src/storage_engine_client.cpp
+++ b/production/db/storage_engine/src/storage_engine_client.cpp
@@ -5,6 +5,9 @@
 
 #include "storage_engine_client.hpp"
 
+#include <flatbuffers/flatbuffers.h>
+
+#include "messages_generated.h"
 #include "system_table_types.hpp"
 
 using namespace gaia::common;
@@ -13,23 +16,21 @@ using namespace gaia::db::triggers;
 using namespace gaia::db::messages;
 using namespace flatbuffers;
 
-thread_local se_base::offsets *client::s_offsets = nullptr;
+thread_local se_base::locators* client::s_locators = nullptr;
 thread_local int client::s_fd_log = -1;
-thread_local int client::s_fd_offsets = -1;
-thread_local se_base::data *client::s_data;
+thread_local int client::s_fd_locators = -1;
+thread_local se_base::data* client::s_data;
 thread_local std::vector<trigger_event_t> client::s_events;
-commit_trigger_fn gaia::db::s_tx_commit_trigger = nullptr;
+commit_trigger_fn client::s_tx_commit_trigger = nullptr;
 
 std::unordered_set<gaia_type_t> client::trigger_excluded_types{
     static_cast<gaia_type_t>(system_table_type_t::catalog_gaia_table),
     static_cast<gaia_type_t>(system_table_type_t::catalog_gaia_field),
     static_cast<gaia_type_t>(system_table_type_t::catalog_gaia_ruleset),
     static_cast<gaia_type_t>(system_table_type_t::catalog_gaia_rule),
-    static_cast<gaia_type_t>(system_table_type_t::event_log)
-};
+    static_cast<gaia_type_t>(system_table_type_t::event_log)};
 
-
-static void build_client_request(FlatBufferBuilder &builder, session_event_t event) {
+static void build_client_request(FlatBufferBuilder& builder, session_event_t event) {
     auto client_request = Createclient_request_t(builder, event);
     auto message = Createmessage_t(builder, any_message_t::request, client_request.Union());
     builder.Finish(message);
@@ -56,11 +57,11 @@ void client::clear_shared_memory() {
         unmap_fd(s_data, sizeof(data));
         s_data = nullptr;
     }
-    // If the server has already closed its fd for the offset segment
+    // If the server has already closed its fd for the locator segment
     // (and there are no other clients), this will release it.
-    if (s_fd_offsets != -1) {
-        close(s_fd_offsets);
-        s_fd_offsets = -1;
+    if (s_fd_locators != -1) {
+        close(s_fd_locators);
+        s_fd_locators = -1;
     }
 }
 
@@ -70,10 +71,10 @@ void client::tx_cleanup() {
     // Destroy the log fd.
     close(s_fd_log);
     s_fd_log = -1;
-    // Destroy the offset mapping.
-    if (s_offsets) {
-        unmap_fd(s_offsets, sizeof(offsets));
-        s_offsets = nullptr;
+    // Destroy the locator mapping.
+    if (s_locators) {
+        unmap_fd(s_locators, sizeof(locators));
+        s_locators = nullptr;
     }
 }
 
@@ -99,9 +100,8 @@ int client::get_session_socket() {
         sizeof(server_addr.sun_path) - 1);
     // The socket name is not null-terminated in the address structure, but
     // we need to add an extra byte for the null byte prefix.
-    socklen_t server_addr_size =
-        sizeof(server_addr.sun_family) + 1 + strlen(&server_addr.sun_path[1]);
-    if (-1 == connect(session_socket, (struct sockaddr *)&server_addr, server_addr_size)) {
+    socklen_t server_addr_size = sizeof(server_addr.sun_family) + 1 + strlen(&server_addr.sun_path[1]);
+    if (-1 == connect(session_socket, (struct sockaddr*)&server_addr, server_addr_size)) {
         throw_system_error("connect failed");
     }
     cleanup_session_socket.dismiss();
@@ -127,10 +127,10 @@ void client::begin_session() {
     clear_shared_memory();
     // Assert relevant fd's and pointers are in clean state.
     retail_assert(s_data == nullptr, "Data segment uninitialized");
-    retail_assert(s_fd_offsets == -1, "Offsets file descriptor uninitialized");
+    retail_assert(s_fd_locators == -1, "Locators file descriptor uninitialized");
     retail_assert(s_fd_log == -1, "Log file descriptor uninitialized");
-    retail_assert(s_log == nullptr, "Log uninitialized");
-    retail_assert(s_offsets == nullptr, "Offset uninitialized");
+    retail_assert(s_log == nullptr, "Log segment uninitialized");
+    retail_assert(s_locators == nullptr, "Locators segment uninitialized");
 
     // Connect to the server's well-known socket name, and ask it
     // for the data and locator shared memory segment fds.
@@ -152,27 +152,27 @@ void client::begin_session() {
     int fds[FD_COUNT] = {-1};
     size_t fd_count = FD_COUNT;
     const size_t DATA_FD_INDEX = 0;
-    const size_t OFFSETS_FD_INDEX = 1;
+    const size_t LOCATORS_FD_INDEX = 1;
     size_t bytes_read = recv_msg_with_fds(s_session_socket, fds, &fd_count, msg_buf, sizeof(msg_buf));
     retail_assert(bytes_read > 0);
     retail_assert(fd_count == FD_COUNT);
     int fd_data = fds[DATA_FD_INDEX];
     retail_assert(fd_data != -1);
-    int fd_offsets = fds[OFFSETS_FD_INDEX];
-    retail_assert(fd_offsets != -1);
-    auto cleanup_fds = scope_guard::make_scope_guard([fd_data, fd_offsets]() {
+    int fd_locators = fds[LOCATORS_FD_INDEX];
+    retail_assert(fd_locators != -1);
+    auto cleanup_fds = scope_guard::make_scope_guard([fd_data, fd_locators]() {
         // We can unconditionally close the data fd,
         // since it's not saved anywhere and the mapping
         // increments the shared memory segment's refcount.
         close(fd_data);
         // We can only close the locator fd if it hasn't been cached.
-        if (s_fd_offsets != fd_offsets) {
-            close(fd_offsets);
+        if (s_fd_locators != fd_locators) {
+            close(fd_locators);
         }
     });
 
-    const message_t *msg = Getmessage_t(msg_buf);
-    const server_reply_t *reply = msg->msg_as_reply();
+    const message_t* msg = Getmessage_t(msg_buf);
+    const server_reply_t* reply = msg->msg_as_reply();
     const session_event_t event = reply->event();
     retail_assert(event == session_event_t::CONNECT);
 
@@ -180,14 +180,14 @@ void client::begin_session() {
     // (but only if they're not already initialized).
 
     // Set up the shared data segment mapping.
-    s_data = static_cast<data *>(map_fd(
+    s_data = static_cast<data*>(map_fd(
         sizeof(data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_data, 0));
 
     // We've already mapped the data fd, so we can close it now.
     close(fd_data);
 
     // Set up the private locator segment fd.
-    s_fd_offsets = fd_offsets;
+    s_fd_locators = fd_locators;
     cleanup_session_socket.dismiss();
 }
 
@@ -213,29 +213,29 @@ void client::begin_transaction() {
     if (-1 == ftruncate(fd_log, sizeof(log))) {
         throw_system_error("ftruncate failed");
     }
-    s_log = static_cast<log *>(map_fd(sizeof(log), PROT_READ | PROT_WRITE, MAP_SHARED, fd_log, 0));
+    s_log = static_cast<log*>(map_fd(sizeof(log), PROT_READ | PROT_WRITE, MAP_SHARED, fd_log, 0));
     auto cleanup_log_mapping = scope_guard::make_scope_guard([]() {
         unmap_fd(s_log, sizeof(log));
         s_log = nullptr;
     });
 
     // Now we map a private COW view of the locator shared memory segment.
-    if (flock(s_fd_offsets, LOCK_SH) < 0) {
+    if (flock(s_fd_locators, LOCK_SH) < 0) {
         throw_system_error("flock failed");
     }
     auto cleanup_flock = scope_guard::make_scope_guard([]() {
-        if (-1 == flock(s_fd_offsets, LOCK_UN)) {
+        if (-1 == flock(s_fd_locators, LOCK_UN)) {
             // Per C++11 semantics, throwing an exception from a destructor
             // will just call std::terminate(), no undefined behavior.
             throw_system_error("flock failed");
         }
     });
 
-    s_offsets = static_cast<offsets *>(map_fd(sizeof(offsets),
-        PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_POPULATE, s_fd_offsets, 0));
+    s_locators = static_cast<locators*>(map_fd(sizeof(locators),
+        PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_POPULATE, s_fd_locators, 0));
     auto cleanup_locator_mapping = scope_guard::make_scope_guard([]() {
-        unmap_fd(s_offsets, sizeof(offsets));
-        s_offsets = nullptr;
+        unmap_fd(s_locators, sizeof(locators));
+        s_locators = nullptr;
     });
 
     // Notify the server that we're in a transaction. (We don't send our log fd until commit.)
@@ -249,8 +249,8 @@ void client::begin_transaction() {
     retail_assert(bytes_read > 0);
 
     // Extract the transaction id and cache it; it needs to be reset for the next transaction.
-    const message_t *msg = Getmessage_t(msg_buf);
-    const server_reply_t *reply = msg->msg_as_reply();
+    const message_t* msg = Getmessage_t(msg_buf);
+    const server_reply_t* reply = msg->msg_as_reply();
     s_transaction_id = reply->transaction_id();
 
     // Save the log fd to send to the server on commit.
@@ -301,8 +301,8 @@ void client::commit_transaction() {
     retail_assert(bytes_read > 0);
 
     // Extract the commit decision from the server's reply and return it.
-    const message_t *msg = Getmessage_t(msg_buf);
-    const server_reply_t *reply = msg->msg_as_reply();
+    const message_t* msg = Getmessage_t(msg_buf);
+    const server_reply_t* reply = msg->msg_as_reply();
     const session_event_t event = reply->event();
     retail_assert(event == session_event_t::DECIDE_TXN_COMMIT || event == session_event_t::DECIDE_TXN_ABORT);
 
@@ -324,5 +324,4 @@ void client::commit_transaction() {
 
     // Reset TLS events vector for the next transaction that will run on this thread.
     s_events.clear();
-
 }

--- a/production/db/storage_engine/src/storage_engine_server.cpp
+++ b/production/db/storage_engine/src/storage_engine_server.cpp
@@ -15,12 +15,12 @@ int server::s_server_shutdown_event_fd = -1;
 int server::s_connect_socket = -1;
 std::mutex server::s_commit_lock;
 int server::s_fd_data = -1;
-se_base::offsets* server::s_shared_offsets = nullptr;
+se_base::locators* server::s_shared_locators = nullptr;
 std::unique_ptr<persistent_store_manager> server::rdb {};
 thread_local session_state_t server::s_session_state = session_state_t::DISCONNECTED;
 thread_local bool server::s_session_shutdown = false;
 constexpr server::valid_transition_t server::s_valid_transitions[];
-int server::s_fd_offsets = -1;
+int server::s_fd_locators = -1;
 se_base::data* server::s_data = nullptr;
 
 void server::handle_connect(int*, size_t, session_event_t event, session_state_t old_state, session_state_t new_state) {
@@ -30,7 +30,7 @@ void server::handle_connect(int*, size_t, session_event_t event, session_state_t
     // We need to reply to the client with the fds for the data/locator segments.
     FlatBufferBuilder builder;
     build_server_reply(builder, session_event_t::CONNECT, old_state, new_state, s_transaction_id);
-    const int send_fds[] = {s_fd_data, s_fd_offsets};
+    const int send_fds[] = {s_fd_data, s_fd_locators};
     send_msg_with_fds(s_session_socket, send_fds, array_size(send_fds), builder.GetBufferPointer(), builder.GetSize());
 }
 

--- a/production/db/storage_engine/tests/test_locator_allocator.cpp
+++ b/production/db/storage_engine/tests/test_locator_allocator.cpp
@@ -7,6 +7,7 @@
 
 #include "gtest/gtest.h"
 
+#include <db_types.hpp>
 #include <locator_allocator.hpp>
 
 using namespace std;
@@ -15,7 +16,7 @@ using namespace gaia::db::storage;
 TEST(storage, locator_allocator)
 {
     // Allocate a few locators: they should be allocated incrementally from 1.
-    uint64_t locator = locator_allocator_t::get()->allocate_locator();
+    gaia::db::gaia_locator_t locator = locator_allocator_t::get()->allocate_locator();
     ASSERT_EQ(1, locator);
 
     locator = locator_allocator_t::get()->allocate_locator();

--- a/production/db/storage_engine/tests/test_record_list.cpp
+++ b/production/db/storage_engine/tests/test_record_list.cpp
@@ -7,22 +7,25 @@
 
 #include "gtest/gtest.h"
 
+#include "db_types.hpp"
+
 #include <record_list.hpp>
 
 using namespace std;
+using namespace gaia::db;
 using namespace gaia::db::storage;
 
 TEST(storage, record_list)
 {
     const size_t c_range_size = 3;
-    const uint64_t c_starting_locator = 1000;
-    const uint64_t c_count_locators = 10;
-    const uint64_t c_new_locator = 88;
+    const gaia_locator_t c_starting_locator = 1000;
+    const gaia_locator_t c_count_locators = 10;
+    const gaia_locator_t c_new_locator = 88;
 
     record_list_t record_list(c_range_size);
 
     // Add some locator values to our list.
-    for (uint64_t locator = c_starting_locator; locator < c_starting_locator + c_count_locators; locator++)
+    for (gaia_locator_t locator = c_starting_locator; locator < c_starting_locator + c_count_locators; locator++)
     {
         record_list.add(locator);
     }
@@ -33,7 +36,7 @@ TEST(storage, record_list)
     ASSERT_EQ(true, return_value);
     ASSERT_EQ(false, iterator.at_end());
 
-    uint64_t expected_locator = c_starting_locator;
+    gaia_locator_t expected_locator = c_starting_locator;
     record_range_t* current_range = iterator.current_range;
 
     // Iterate over the list and verify content and range changes.
@@ -99,7 +102,7 @@ TEST(storage, record_list)
     do
     {
         // Skip our checks if we encounter the new locator value.
-        uint64_t current_locator = record_list_t::get_record_locator(iterator);
+        gaia_locator_t current_locator = record_list_t::get_record_locator(iterator);
         if (current_locator != c_new_locator)
         {
             ASSERT_EQ(expected_locator, current_locator);

--- a/production/inc/internal/db/db_test_base.hpp
+++ b/production/inc/internal/db/db_test_base.hpp
@@ -17,7 +17,7 @@
 #include "retail_assert.hpp"
 #include "system_error.hpp"
 #include "gaia_db.hpp"
-#include "gaia_db_internal.hpp"
+#include "db_types.hpp"
 #include "db_test_helpers.hpp"
 
 using namespace gaia::common;

--- a/production/inc/internal/db/db_test_helpers.hpp
+++ b/production/inc/internal/db/db_test_helpers.hpp
@@ -15,6 +15,7 @@
 #include "system_error.hpp"
 #include "gaia_db.hpp"
 #include "gaia_db_internal.hpp"
+#include "db_types.hpp"
 #include "logger.hpp"
 
 namespace gaia {

--- a/production/inc/internal/db/db_types.hpp
+++ b/production/inc/internal/db/db_types.hpp
@@ -1,0 +1,28 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+
+namespace gaia {
+namespace db {
+
+/**
+ * The type of a Gaia transaction id.
+ */
+typedef uint64_t gaia_xid_t;
+/**
+ * The type of a Gaia locator id.
+ */
+typedef uint64_t gaia_locator_t;
+
+/**
+ * The type of a Gaia data offset.
+ */
+typedef uint64_t gaia_offset_t;
+
+}  // namespace db
+}  // namespace gaia

--- a/production/inc/internal/db/gaia_db_internal.hpp
+++ b/production/inc/internal/db/gaia_db_internal.hpp
@@ -4,19 +4,30 @@
 /////////////////////////////////////////////
 
 #pragma once
+
 #include "triggers.hpp"
 
 namespace gaia {
 namespace db {
 
-// Set by the rules engine
-extern triggers::commit_trigger_fn s_tx_commit_trigger;
+/**
+ * Sets the DB client's commit trigger function.
+ * Can only be called once.
+ * Returns true if the trigger was successfully initialized,
+ * false if it was already set.
+ */
+bool set_commit_trigger(gaia::db::triggers::commit_trigger_fn trigger_fn);
 
+/**
+ * Reinitializes the DB client's shared memory structures.
+ * For use only by test code, in combination with the DB
+ * server's reinitialization feature.
+ */
 void clear_shared_memory();
 
-// Todo (Mihir): Expose options to set the persistent 
-// directory path & also some way to destroy it instead 
-// of hardcoding the path. 
+// Todo (Mihir): Expose options to set the persistent
+// directory path & also some way to destroy it instead
+// of hardcoding the path.
 // https://gaiaplatform.atlassian.net/browse/GAIAPLAT-310
 const char* const PERSISTENT_DIRECTORY_PATH = "/tmp/gaia_db";
 

--- a/production/inc/internal/db/gaia_ptr.hpp
+++ b/production/inc/internal/db/gaia_ptr.hpp
@@ -10,6 +10,7 @@
 
 #include "retail_assert.hpp"
 #include "gaia_db.hpp"
+#include "db_types.hpp"
 #include "gaia_se_object.hpp"
 #include "type_metadata.hpp"
 
@@ -20,21 +21,21 @@ namespace db {
 
 class gaia_ptr {
 private:
-    int64_t row_id;
+    gaia_locator_t m_locator;
     void create_insert_trigger(gaia_type_t type, gaia_id_t id);
     void clone_no_tx();
 
 public:
     gaia_ptr(const std::nullptr_t = nullptr)
-        : row_id(0) {}
+        : m_locator(0) {}
 
     gaia_ptr(const gaia_ptr& other)
-        : row_id(other.row_id) {}
+        : m_locator(other.m_locator) {}
 
     gaia_ptr& operator=(const gaia_ptr& other) = default;
 
     bool operator==(const gaia_ptr& other) const {
-        return row_id == other.row_id;
+        return m_locator == other.m_locator;
     }
 
     bool operator==(const std::nullptr_t) const {
@@ -128,7 +129,7 @@ public:
 
     static gaia_ptr find_first(gaia_type_t type) {
         gaia_ptr ptr;
-        ptr.row_id = 1;
+        ptr.m_locator = 1;
 
         if (!ptr.is(type)) {
             ptr.find_next(type);
@@ -138,7 +139,7 @@ public:
     }
 
     gaia_ptr find_next() {
-        if (row_id) {
+        if (m_locator) {
             find_next(to_ptr()->type);
         }
 
@@ -146,14 +147,14 @@ public:
     }
 
     gaia_ptr operator++() {
-        if (row_id) {
+        if (m_locator) {
             find_next(to_ptr()->type);
         }
         return *this;
     }
 
     bool is_null() const {
-        return row_id == 0;
+        return m_locator == 0;
     }
 
     gaia_id_t id() const {
@@ -236,7 +237,7 @@ protected:
 
     gaia_se_object_t* to_ptr() const;
 
-    int64_t to_offset() const;
+    gaia_offset_t to_offset() const;
 
     bool is(gaia_type_t type) const {
         return to_ptr() && to_ptr()->type == type;

--- a/production/inc/internal/db/triggers.hpp
+++ b/production/inc/internal/db/triggers.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 
 #include "gaia_common.hpp"
+#include "db_types.hpp"
 #include "events.hpp"
 
 using namespace gaia::common;
@@ -24,11 +25,11 @@ namespace triggers {
 
 struct trigger_event_t {
     event_type_t event_type; // insert, update, delete, begin, commit, rollback
-    gaia_id_t gaia_type; // gaia table type, maybe 0 if event has no associated tables
+    gaia_type_t gaia_type; // gaia table type, maybe 0 if event has no associated tables
     gaia_id_t record; //row id, may be 0 if if there is no assocated row id
     field_position_list_t columns; // list of affected columns
 
-    trigger_event_t(event_type_t event_type, gaia_id_t gaia_type, gaia_id_t record, field_position_list_t columns):
+    trigger_event_t(event_type_t event_type, gaia_type_t gaia_type, gaia_id_t record, field_position_list_t columns):
         event_type(event_type), gaia_type(gaia_type), record(record), columns(columns) {}
 };
 
@@ -37,11 +38,11 @@ typedef std::vector<trigger_event_t> trigger_event_list_t;
 /**
  * The type of Gaia commit trigger.
  */
-typedef void (*commit_trigger_fn) (uint64_t, const trigger_event_list_t&);
+typedef void (*commit_trigger_fn) (gaia::db::gaia_xid_t, const trigger_event_list_t&);
 
 /**
  * Use this constant to specify that no fields are needed when generating trigger_event_t.
- */ 
+ */
 const field_position_list_t empty_position_list;
 
 }

--- a/production/inc/public/common/gaia_common.hpp
+++ b/production/inc/public/common/gaia_common.hpp
@@ -40,11 +40,6 @@ typedef uint64_t gaia_type_t;
 constexpr gaia_type_t INVALID_GAIA_TYPE = 0;
 
 /**
- * The type of a Gaia transaction id.
- */
-typedef uint64_t gaia_xid_t;
-
-/**
  * The type of a Gaia event type.
  */
 typedef uint8_t gaia_event_t;

--- a/production/rules/event_manager/inc/event_manager.hpp
+++ b/production/rules/event_manager/inc/event_manager.hpp
@@ -19,14 +19,14 @@
 
 using namespace gaia::db::triggers;
 
-namespace gaia 
+namespace gaia
 {
 namespace rules
 {
 /**
  * Implementation class for event and rule APIs defined
  * in events.hpp and rules.hpp respectively.  See documentation
- * for this API in those headers.  
+ * for this API in those headers.
  */
 class event_manager_t
 {
@@ -38,10 +38,10 @@ public:
     event_manager_t(event_manager_t&) = delete;
     void operator=(event_manager_t const&) = delete;
     static event_manager_t& get(bool is_initializing = false);
-    
+
     /**
      * Rule APIs
-     */ 
+     */
     void init();
 
     void subscribe_rule(
@@ -51,7 +51,7 @@ public:
         const rule_binding_t& rule_binding);
 
     bool unsubscribe_rule(
-      gaia::common::gaia_type_t gaia_type, 
+      gaia::common::gaia_type_t gaia_type,
       event_type_t event_type,
       const field_position_list_t& fields,
       const rule_binding_t& rule_binding);
@@ -59,8 +59,8 @@ public:
     void unsubscribe_rules();
 
     void list_subscribed_rules(
-      const char* ruleset_name, 
-      const gaia::common::gaia_type_t* gaia_type, 
+      const char* ruleset_name,
+      const gaia::common::gaia_type_t* gaia_type,
       const event_type_t* event_type,
       const uint16_t* field,
       subscription_list_t& subscriptions);
@@ -117,7 +117,7 @@ private:
     // the catalog.
     unique_ptr<rule_checker_t> m_rule_checker;
 
-    // Enable profiling of rules engine function.  Also used to 
+    // Enable profiling of rules engine function.  Also used to
     // get time points for rules engine statistics.
     optional_timer_t m_timer;
 
@@ -125,19 +125,19 @@ private:
     // Only internal static creation is allowed.
     event_manager_t();
 
-    // Test helper methods.  These are just the friend declarations.  These methods are 
+    // Test helper methods.  These are just the friend declarations.  These methods are
     // implemented in a separate source file that must be compiled into the test.
     friend void gaia::rules::test::initialize_rules_engine(event_manager_settings_t& settings);
-    friend void gaia::rules::test::commit_trigger(uint64_t, const trigger_event_t*, size_t count_events);
+    friend void gaia::rules::test::commit_trigger(gaia_xid_t, const trigger_event_t*, size_t count_events);
 
     // Well known trigger function called by the storage engine after commit.
-    void commit_trigger(uint64_t tx_id, const trigger_event_list_t& event_list);
+    void commit_trigger(gaia_xid_t tx_id, const trigger_event_list_t& event_list);
     bool process_last_operation_events(event_binding_t& binding, const trigger_event_t& event,
         std::chrono::steady_clock::time_point& start_time);
     bool process_field_events(event_binding_t& binding, const trigger_event_t& event,
         std::chrono::steady_clock::time_point& start_time);
     void init(event_manager_settings_t& settings);
-    const _rule_binding_t* find_rule(const rules::rule_binding_t& binding); 
+    const _rule_binding_t* find_rule(const rules::rule_binding_t& binding);
     void add_rule(rule_list_t& rules, const rules::rule_binding_t& binding);
     bool remove_rule(rule_list_t& rules, const rules::rule_binding_t& binding);
     void enqueue_invocation(const trigger_event_list_t& events, const vector<bool>& rules_invoked_list,
@@ -147,7 +147,7 @@ private:
     void check_subscription(event_type_t event_type, const field_position_list_t& fields);
     static inline void check_rule_binding(const rule_binding_t& binding)
     {
-        if (nullptr == binding.rule 
+        if (nullptr == binding.rule
             || nullptr == binding.rule_name
             || nullptr == binding.ruleset_name)
         {
@@ -156,7 +156,7 @@ private:
     }
     static bool is_valid_rule_binding(const rules::rule_binding_t& binding);
     static std::string make_rule_key(const rules::rule_binding_t& binding);
-    static void add_subscriptions(rules::subscription_list_t& subscriptions, 
+    static void add_subscriptions(rules::subscription_list_t& subscriptions,
         const rule_list_t& rules,
         gaia::common::gaia_type_t gaia_type,
         event_type_t event_type,

--- a/production/rules/event_manager/inc/event_manager_test_helpers.hpp
+++ b/production/rules/event_manager/inc/event_manager_test_helpers.hpp
@@ -4,6 +4,7 @@
 /////////////////////////////////////////////
 #pragma once
 
+#include "db_types.hpp"
 #include "triggers.hpp"
 #include "event_manager_settings.hpp"
 
@@ -17,8 +18,8 @@ namespace test
     void initialize_rules_engine(event_manager_settings_t& settings);
 
     void commit_trigger(
-        uint64_t transaction_id,
-        const db::triggers::trigger_event_t* triggger_events,
+        gaia_xid_t transaction_id,
+        const db::triggers::trigger_event_t* trigger_events,
         size_t count_events);
 
 } // test

--- a/production/rules/event_manager/src/event_manager.cpp
+++ b/production/rules/event_manager/src/event_manager.cpp
@@ -6,6 +6,7 @@
 #include "retail_assert.hpp"
 #include "event_manager.hpp"
 #include "rule_stats_manager.hpp"
+#include "db_types.hpp"
 #include "gaia_db_internal.hpp"
 #include "events.hpp"
 #include "triggers.hpp"
@@ -17,6 +18,7 @@
 
 using namespace gaia::rules;
 using namespace gaia::common;
+using namespace gaia::db;
 using namespace gaia::db::triggers;
 using namespace std;
 using namespace std::chrono;
@@ -29,13 +31,13 @@ event_manager_t& event_manager_t::get(bool is_initializing)
     static event_manager_t s_instance;
 
     // Initialize errors can happen for two reasons:
-    // 
-    // If we are currently trying to initialize then is_initializing 
-    // will be true. At this point, we don't expect the instance to be 
+    //
+    // If we are currently trying to initialize, then is_initializing
+    // will be true. At this point, we don't expect the instance to be
     // initialized yet.
     //
-    // If we are not intializing then we expect the instance to already be
-    // initialized
+    // If we are not initializing, then we expect the instance to already be
+    // initialized.
     if (is_initializing == s_instance.m_is_initialized)
     {
         throw initialization_error(is_initializing);
@@ -43,7 +45,7 @@ event_manager_t& event_manager_t::get(bool is_initializing)
     return s_instance;
 }
 
-event_manager_t::event_manager_t() 
+event_manager_t::event_manager_t()
 {
 }
 
@@ -51,7 +53,7 @@ void event_manager_t::init()
 {
     // TODO[GAIAPLAT-111]: Check a configuration setting supplied by the
     // application developer for the number of threads to create.
-    
+
     // Apply default settings.  See explanation in event_manager_settings.hpp.
     event_manager_settings_t settings;
     init(settings);
@@ -70,14 +72,13 @@ void event_manager_t::init(event_manager_settings_t& settings)
     rule_stats_manager_t::s_enabled = settings.enable_stats;
     m_timer.set_enabled(settings.enable_stats);
 
-    auto fn = [](uint64_t transaction_id, const trigger_event_list_t& event_list) {
+    auto fn = [](gaia_xid_t transaction_id, const trigger_event_list_t& event_list) {
         event_manager_t::get().commit_trigger(transaction_id, event_list);
     };
-    gaia::db::s_tx_commit_trigger = fn;
+    set_commit_trigger(fn);
 
     m_is_initialized = true;
 }
-
 
 bool event_manager_t::process_last_operation_events(event_binding_t& binding, const trigger_event_t& event,
     steady_clock::time_point& start_time)
@@ -128,7 +129,7 @@ bool event_manager_t::process_field_events(event_binding_t& binding,
     return rules_invoked;
 }
 
-void event_manager_t::commit_trigger(uint64_t, const trigger_event_list_t& trigger_event_list)
+void event_manager_t::commit_trigger(gaia_xid_t, const trigger_event_list_t& trigger_event_list)
 {
     m_timer.log_function_duration([&]() {
 
@@ -188,11 +189,11 @@ void event_manager_t::commit_trigger(uint64_t, const trigger_event_list_t& trigg
 }
 
 void event_manager_t::enqueue_invocation(const trigger_event_list_t& events,
-    const vector<bool>& rules_invoked_list, 
+    const vector<bool>& rules_invoked_list,
     steady_clock::time_point& start_time)
 {
     rule_thread_pool_t::log_events_invocation_t event_invocation {
-        events, 
+        events,
         rules_invoked_list
     };
     rule_thread_pool_t::invocation_t invocation {
@@ -202,7 +203,7 @@ void event_manager_t::enqueue_invocation(const trigger_event_list_t& events,
             start_time, rule_stats_manager_t::c_log_event_tag)
     };
     m_invocations->enqueue(invocation);
-} 
+}
 
 void event_manager_t::enqueue_invocation(const trigger_event_t& event, gaia_rule_fn rule_fn,
     steady_clock::time_point& start_time)
@@ -221,7 +222,7 @@ void event_manager_t::enqueue_invocation(const trigger_event_t& event, gaia_rule
             start_time, rule_stats_manager_t::c_rule_tag)
     };
     m_invocations->enqueue(invocation);
-} 
+}
 
 void event_manager_t::check_subscription(
     event_type_t event_type,
@@ -238,7 +239,7 @@ void event_manager_t::check_subscription(
 }
 
 void event_manager_t::subscribe_rule(
-    gaia_type_t gaia_type, 
+    gaia_type_t gaia_type,
     event_type_t event_type,
     const field_position_list_t& fields,
     const rule_binding_t& rule_binding)
@@ -259,7 +260,7 @@ void event_manager_t::subscribe_rule(
     // Look up the gaia_type in our type map.  If we do not find it
     // then we create a new empty event map map.
     auto type_it = m_subscriptions.find(gaia_type);
-    if (type_it == m_subscriptions.end()) 
+    if (type_it == m_subscriptions.end())
     {
         auto inserted_type = m_subscriptions.insert(
             make_pair(gaia_type, events_map_t()));
@@ -309,7 +310,7 @@ void event_manager_t::subscribe_rule(
 
 bool event_manager_t::unsubscribe_rule(
     gaia_type_t gaia_type,
-    event_type_t event_type, 
+    event_type_t event_type,
     const field_position_list_t& fields,
     const rule_binding_t& rule_binding)
 {
@@ -368,8 +369,8 @@ void event_manager_t::unsubscribe_rules()
 }
 
 void event_manager_t::list_subscribed_rules(
-    const char* ruleset_name, 
-    const gaia_type_t* gaia_type_ptr, 
+    const char* ruleset_name,
+    const gaia_type_t* gaia_type_ptr,
     const event_type_t* event_type_ptr,
     const uint16_t* field_ptr,
     subscription_list_t& subscriptions)
@@ -400,7 +401,7 @@ void event_manager_t::list_subscribed_rules(
                     continue;
                 }
                 const rule_list_t& rules = field.second;
-                add_subscriptions(subscriptions, rules, type_it.first, 
+                add_subscriptions(subscriptions, rules, type_it.first,
                     event_it.first, field.first, ruleset_name);
             }
 
@@ -413,7 +414,7 @@ void event_manager_t::list_subscribed_rules(
     }
 }
 
-void event_manager_t::add_subscriptions(subscription_list_t& subscriptions, 
+void event_manager_t::add_subscriptions(subscription_list_t& subscriptions,
     const rule_list_t& rules,
     gaia_type_t gaia_type,
     event_type_t event_type,
@@ -431,7 +432,7 @@ void event_manager_t::add_subscriptions(subscription_list_t& subscriptions,
         subscriptions.emplace_back(make_unique<subscription_t>(
             rule->ruleset_name.c_str(),
             rule->rule_name.c_str(),
-            gaia_type, 
+            gaia_type,
             event_type,
             field)
         );
@@ -446,7 +447,7 @@ void event_manager_t::add_rule(
     // key as another rule but is bound to a different
     // rule function.
     const _rule_binding_t* rule_ptr = find_rule(binding);
-    if (rule_ptr != nullptr && rule_ptr->rule != binding.rule) 
+    if (rule_ptr != nullptr && rule_ptr->rule != binding.rule)
     {
         throw duplicate_rule(binding, true);
     }
@@ -455,23 +456,23 @@ void event_manager_t::add_rule(
     // This is most likely a programming error.
     for (auto rules_it = rules.begin(); rules_it != rules.end(); ++rules_it)
     {
-        if (*rules_it == rule_ptr) 
+        if (*rules_it == rule_ptr)
         {
             throw duplicate_rule(binding, false);
         }
     }
 
     // If we already have seen this rule, then
-    // add it to the list.  Otherwise, create a new 
+    // add it to the list.  Otherwise, create a new
     // rule binding entry and put it in our global list.
     _rule_binding_t* this_rule = nullptr;
-    if (rule_ptr == nullptr) 
+    if (rule_ptr == nullptr)
     {
         const string& key = make_rule_key(binding);
         this_rule = new _rule_binding_t(binding);
         m_rules.insert(make_pair(key, unique_ptr<_rule_binding_t>(this_rule)));
     }
-    else 
+    else
     {
         this_rule = const_cast<_rule_binding_t*>(rule_ptr);
     }
@@ -525,13 +526,13 @@ event_manager_t::_rule_binding_t::_rule_binding_t(
 }
 
 event_manager_t::_rule_binding_t::_rule_binding_t(
-    const char* a_ruleset_name, 
-    const char* a_rule_name, 
+    const char* a_ruleset_name,
+    const char* a_rule_name,
     gaia_rule_fn a_rule)
 {
     ruleset_name = a_ruleset_name;
     rule = a_rule;
-    if (a_rule_name != nullptr) 
+    if (a_rule_name != nullptr)
     {
         rule_name = a_rule_name;
     }
@@ -550,7 +551,7 @@ void gaia::rules::initialize_rules_engine()
     event_manager_t::get(is_initializing).init();
 
     /**
-     * This function must be provided by the 
+     * This function must be provided by the
      * rules application.  This function is
      * generated by the gaia preprocessor on
      * behalf of the user.
@@ -568,9 +569,9 @@ void gaia::rules::subscribe_rule(
 }
 
 bool gaia::rules::unsubscribe_rule(
-    gaia_type_t gaia_type, 
+    gaia_type_t gaia_type,
     event_type_t event_type,
-    const field_position_list_t& fields, 
+    const field_position_list_t& fields,
     const gaia::rules::rule_binding_t& rule_binding)
 {
     return event_manager_t::get().unsubscribe_rule(gaia_type, event_type, fields, rule_binding);
@@ -582,10 +583,10 @@ void gaia::rules::unsubscribe_rules()
 }
 
 void gaia::rules::list_subscribed_rules(
-    const char* ruleset_name, 
-    const gaia_type_t* gaia_type, 
+    const char* ruleset_name,
+    const gaia_type_t* gaia_type,
     const event_type_t* event_type,
-    const uint16_t* field, 
+    const uint16_t* field,
     subscription_list_t& subscriptions)
 {
     event_manager_t::get().list_subscribed_rules(ruleset_name, gaia_type,

--- a/production/rules/event_manager/tests/event_manager_test_helpers.cpp
+++ b/production/rules/event_manager/tests/event_manager_test_helpers.cpp
@@ -15,9 +15,9 @@ void gaia::rules::test::initialize_rules_engine(event_manager_settings_t& settin
 }
 
 void gaia::rules::test::commit_trigger(
-    uint64_t transaction_id,
+    gaia_xid_t transaction_id,
     const trigger_event_t* trigger_events,
-    size_t count_events) 
+    size_t count_events)
 {
     trigger_event_list_t trigger_event_list;
     for (size_t i = 0; i < count_events; i++)


### PR DESCRIPTION
Besides the new typedefs `gaia_locator_t`, `gaia_offset_t` and associated renaming of types and variable names, I had to refactor a bit to eliminate a circular dependency between `triggers.hpp` and `gaia_db_internal.hpp`.