### PR TITLE
Disable .clang-tidy for headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,9 +19,12 @@ google-readability-casting,
 -modernize-use-trailing-return-type,
 -modernize-avoid-c-arrays,
 -modernize-concat-nested-namespaces,
+-modernize-use-using,
+-modernize-use-nodiscard
 '
 
-HeaderFilterRegex: "*.hpp"
+# TODO: headers are disabled for now, they produce too many warnings.
+#HeaderFilterRegex: "GaiaPlatform/production/.*inc/.*(hpp|inc|h)$"
 
 CheckOptions:
   #  - { key: readability-identifier-naming.ClassSuffix,           value: _t } can't do this because of exceptions

--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -242,4 +242,4 @@ file(
 # We want to disable all clang-tidy checks for generated code.
 # However, if no checks are specified, clang-tidy will assume we
 # did not configure it correctly. Just add one check that will never be found.
-file(WRITE ${GAIA_PARSER_GENERATED}/.clang-tidy "Checks: '-*,llvm-twine-local'\n")
+file(WRITE ${GAIA_PROD_BUILD}/.clang-tidy "Checks: '-*,llvm-twine-local'\n")


### PR DESCRIPTION
- Disable .clang-tidy for headers. At the moment headers produce too many warnings. Part of the problem is due to the fact that headers' warnings are counted twice. Keeping them disabled for now, will reanble after Thanksgiving release.
- Disable `-modernize-use-using`
- Disable `-modernize-use-nodiscard`
- Fix exclude `.clang-tidy` for genertaed code. Put fake rule into `GAIA_PROD_BUILD`