### PR TITLE
Add NOLINT comments to prevent warnings due to macro expansions in FDW code

### DIFF
--- a/production/sql/src/gaia_fdw.cpp
+++ b/production/sql/src/gaia_fdw.cpp
@@ -24,7 +24,7 @@ extern "C" Datum gaia_fdw_handler(PG_FUNCTION_ARGS)
 {
     elog(DEBUG1, "Entering function %s...", __func__);
 
-    FdwRoutine* routine = makeNode(FdwRoutine);
+    FdwRoutine* routine = makeNode(FdwRoutine); // NOLINT (macro expansion)
 
     // Functions for scanning foreign tables.
     routine->GetForeignRelSize = gaia_get_foreign_rel_size;
@@ -75,7 +75,7 @@ extern "C" Datum gaia_fdw_handler(PG_FUNCTION_ARGS)
     routine->GetForeignRowMarkType = gaia_get_foreign_row_mark_type;
     routine->RefetchForeignRow = gaia_refetch_foreign_row;
 
-    PG_RETURN_POINTER(routine);
+    PG_RETURN_POINTER(routine); // NOLINT (macro expansion)
 }
 
 // The validator function is responsible for validating options given in CREATE
@@ -492,7 +492,7 @@ extern "C" List* gaia_plan_foreign_modify(
     // We don't return any private data from this method, just check that
     // gaia_id is not an INSERT or UPDATE target.
     CmdType operation = plan->operation;
-    RangeTblEntry* rte = planner_rt_fetch(result_relation, root);
+    RangeTblEntry* rte = planner_rt_fetch(result_relation, root); // NOLINT (macro expansion)
     Relation rel = table_open(rte->relid, NoLock);
     TupleDesc tuple_desc = RelationGetDescr(rel);
     Bitmapset* modified_cols = nullptr;

--- a/production/sql/src/type_mapping.cpp
+++ b/production/sql/src/type_mapping.cpp
@@ -11,8 +11,8 @@ Datum flatbuffers_string_to_text_datum(flatbuffers_string_t str)
     size_t text_len = str_len + VARHDRSZ;
     text* t = reinterpret_cast<text*>(palloc(text_len));
 
-    SET_VARSIZE(t, text_len);
-    memcpy(VARDATA(t), str, str_len);
+    SET_VARSIZE(t, text_len); // NOLINT (macro expansion)
+    memcpy(VARDATA(t), str, str_len); // NOLINT (macro expansion)
 
-    return CStringGetDatum(t);
+    return CStringGetDatum(t); // NOLINT (macro expansion)
 }


### PR DESCRIPTION
Just adding some minor NOLINT comments to stop outputting warnings during build. 