### PR TITLE
Create boot_parameters.bin with rw-rw-rw- and never remove it (truncate instead).

### DIFF
--- a/production/db/storage_engine/inc/gaia_boot.hpp
+++ b/production/db/storage_engine/inc/gaia_boot.hpp
@@ -24,7 +24,7 @@ class gaia_boot_t
 {
 public:
     // Permissions on boot file.
-    static constexpr mode_t c_rw_rw_r = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;
+    static constexpr mode_t c_rw_rw_rw = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
     gaia_boot_t(gaia_boot_t&) = delete;
     void operator=(gaia_boot_t const&) = delete;
     static gaia_boot_t& get();

--- a/production/db/storage_engine/src/gaia_boot.cpp
+++ b/production/db/storage_engine/src/gaia_boot.cpp
@@ -28,7 +28,7 @@ void gaia_boot_t::open_gaia_boot()
     string boot_file_name(PERSISTENT_DIRECTORY_PATH);
     boot_file_name += "/boot_parameters.bin";
     errno = 0;
-    if ((m_boot_fd = open(boot_file_name.c_str(), O_RDWR | O_CREAT, c_rw_rw_r)) == -1)
+    if ((m_boot_fd = open(boot_file_name.c_str(), O_RDWR | O_CREAT, c_rw_rw_rw)) == -1)
     {
         // gaia_log::db().critical("I/O failure, cannot create {}, error: {}\n", boot_file_name, strerror(errno));
         throw_system_error("cannot create " + boot_file_name);

--- a/production/inc/internal/db/db_test_helpers.hpp
+++ b/production/inc/internal/db/db_test_helpers.hpp
@@ -102,7 +102,7 @@ void reset_server()
     // WLW Note: This is temporary.
     string boot_file_name(PERSISTENT_DIRECTORY_PATH);
     boot_file_name += "/boot_parameters.bin";
-    unlink(boot_file_name.c_str());
+    truncate(boot_file_name.c_str(), 0);
     wait_for_server_init();
 }
 


### PR DESCRIPTION
This is a temporary workaround until there is a better solution for storing the gaia_id_t and gaia_type_t next values.