### PR TITLE
Update instructions for executing FDW tests

### DIFF
--- a/production/sql/README.md
+++ b/production/sql/README.md
@@ -17,7 +17,7 @@ To get there, the code will be rewritten in stages:
 
 ### Instructions for running unit test
 
-* Edit Postgres login configuration to change postgres account authentication method from "peer" to "trust". To find the location of the configuration file, execute this command in Postgres: `SHOW hba_file;`. By default, the file is located in `/etc/postgresql/12/main/pg_hba.conf`.
+* Edit Postgres login configuration to change local account authentication method from "peer" to "trust". To find the location of the configuration file, execute this command in Postgres: `SHOW hba_file;`. By default, the file is located in `/etc/postgresql/12/main/pg_hba.conf`. You can also edit the file with this command: `sed -i '/^local/ s/peer/trust/' ``pg_conftool -s 12 main show hba_file``.
 * Execute`umask 0` to ensure that `/tmp/gaia_lib/boot_parameters.bin` is writable by all accounts. This will allow it to be accessed by Postgres.
 * Run `cmake` with `-DEXECUTE_FDW_TESTS=ON` option.
 * After building, install the FDW by running `sudo make install` in the `build/sql/` folder.


### PR DESCRIPTION
FDW test setup instructions were missing the step of enabling trust authentication for postgres account. Adding that step and some minor comment cleanup.