### PR TITLE
Fix race conditions in shared memory deallocation leading to sporadic test failures

### DIFF
--- a/production/inc/internal/common/fd_helpers.hpp
+++ b/production/inc/internal/common/fd_helpers.hpp
@@ -1,0 +1,35 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#pragma once
+
+#include <unistd.h>
+
+#include <stdexcept>
+
+#include <libexplain/close.h>
+
+#include "gaia_exception.hpp"
+#include "system_error.hpp"
+
+namespace gaia
+{
+namespace common
+{
+
+inline void close_fd(int& fd)
+{
+    int tmp = fd;
+    fd = -1;
+    if (-1 == ::close(tmp))
+    {
+        int err = errno;
+        const char* reason = ::explain_close(fd);
+        throw system_error(reason, err);
+    }
+}
+
+} // namespace common
+} // namespace gaia

--- a/production/inc/internal/common/mmap_helpers.hpp
+++ b/production/inc/internal/common/mmap_helpers.hpp
@@ -5,11 +5,11 @@
 
 #pragma once
 
+#include <stdexcept>
+
 #include <libexplain/mmap.h>
 #include <libexplain/munmap.h>
 #include <sys/mman.h>
-
-#include <stdexcept>
 
 #include "gaia_exception.hpp"
 #include "system_error.hpp"
@@ -31,9 +31,13 @@ inline void* map_fd(size_t length, int protection, int flags, int fd, size_t off
     return mapping;
 }
 
-inline void unmap_fd(void* addr, size_t length)
+// We have to use a template because the compiler won't convert T* to void*&.
+template <typename T>
+inline void unmap_fd(T*& addr, size_t length)
 {
-    if (-1 == ::munmap(addr, length))
+    void* tmp = addr;
+    addr = nullptr;
+    if (-1 == ::munmap(tmp, length))
     {
         int err = errno;
         const char* reason = ::explain_munmap(addr, length);

--- a/production/inc/internal/db/db_test_helpers.hpp
+++ b/production/inc/internal/db/db_test_helpers.hpp
@@ -44,7 +44,8 @@ void wait_for_server_init()
 {
     constexpr int c_poll_interval_millis = 10;
     constexpr int c_print_error_interval = 1000;
-    int counter = 0;
+    // Initialize to 1 to avoid printing a spurious wait message.
+    int counter = 1;
 
     // quick fix to initialize the server.
     gaia_log::initialize({});


### PR DESCRIPTION
Now we always invalidate any shared resource pointer before freeing the resource it pointed to, so it's impossible for a caller to access a freed resource through the pointer.