### PR TITLE
Fix error handling in mmap/fd helpers

### DIFF
--- a/production/inc/internal/common/fd_helpers.hpp
+++ b/production/inc/internal/common/fd_helpers.hpp
@@ -26,7 +26,7 @@ inline void close_fd(int& fd)
     if (-1 == ::close(tmp))
     {
         int err = errno;
-        const char* reason = ::explain_close(fd);
+        const char* reason = ::explain_close(tmp);
         throw system_error(reason, err);
     }
 }

--- a/production/inc/internal/common/mmap_helpers.hpp
+++ b/production/inc/internal/common/mmap_helpers.hpp
@@ -40,7 +40,7 @@ inline void unmap_fd(T*& addr, size_t length)
     if (-1 == ::munmap(tmp, length))
     {
         int err = errno;
-        const char* reason = ::explain_munmap(addr, length);
+        const char* reason = ::explain_munmap(tmp, length);
         throw system_error(reason, err);
     }
 }


### PR DESCRIPTION
I forgot to use the `tmp` variable for calling the `explain_*` functions.