### PR TITLE
Add gdev clion mixin

### DIFF
--- a/dev_tools/gdev/README.md
+++ b/dev_tools/gdev/README.md
@@ -95,10 +95,9 @@ XXX The testing registry uses `http` and is not secure.
 
 (Optional, Linux only) Enable multiarch building.
 ```bash
+sudo apt install qemu-user-static
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx create --name gdev_builder
-docker buildx use gdev_builder
-docker buildx inspect --bootstrap
+sudo service docker restart
 ```
 
 ## Creating build rules with `gdev.cfg` files
@@ -348,6 +347,7 @@ TODO
 
 ## enable_if and enable_if_not
 
+```
 {enable_if('translation_engine')}# This is an example line of what could be run \
     # if we use `gdev build --cfg-enables translation_engine`.
 {enable_if_not('translation_engine')}# This is an example line of what could be \
@@ -372,3 +372,4 @@ cmake \
     {enable_if_not_any('debug', 'production_debug')}-DCMAKE_BUILD_TYPE=Release \
     {enable_if_any('debug', 'production_debug')}-DCMAKE_BUILD_TYPE=Debug \
     {source_dir('production')}
+```

--- a/dev_tools/gdev/gdev/cmd/gen/_abc/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/dockerfile.py
@@ -44,8 +44,19 @@ class GenAbcDockerfile(Dependency, ABC):
                 && groupadd -r -g 102 postgres \
                 && groupadd -r -g 103 ssh \
                 && groupadd -r -g 104 ssl-cert \
+                && groupadd -r -g 105 systemd-timesync \
+                && groupadd -r -g 106 systemd-journal \
+                && groupadd -r -g 107 systemd-network \
+                && groupadd -r -g 108 systemd-resolve \
                 && useradd messagebus -l -r -u 101 -g 101 \
-                && useradd postgres -l -r -u 102 -g 102 -G ssl-cert
+                && useradd postgres -l -r -u 102 -g 102 -G ssl-cert \
+                && useradd systemd-timesync -l -r -u 103 -g 105 -d /run/systemd \
+                    -s /usr/sbin/nologin \
+                && useradd systemd-network -l -r -u 104 -g 107 -d /run/systemd \
+                    -s /usr/sbin/nologin \
+                && useradd systemd-resolve -l -r -u 105 -g 108 -d /run/systemd \
+                    -s /usr/sbin/nologin \
+                && useradd sshd -l -r -u 106 -d /run/sshd -s /usr/sbin/nologin
 
             FROM base AS apt_base
             RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries \

--- a/dev_tools/gdev/gdev/cmd/gen/_custom/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_custom/dockerfile.py
@@ -16,6 +16,16 @@ class GenCustomDockerfile(GenAbcDockerfile):
         return GenCustomCfg(self.options)
 
     @memoize
+    async def get_env_section(self) -> str:
+        from ..pre_run.dockerfile import GenPreRunDockerfile
+
+        env_section = await GenPreRunDockerfile(self.options).get_env_section()
+
+        self.log.debug(f'{env_section = }')
+
+        return env_section
+
+    @memoize
     async def get_input_dockerfiles(self) -> Iterable[GenAbcDockerfile]:
         from ..run.dockerfile import GenRunDockerfile
 
@@ -32,7 +42,7 @@ class GenCustomDockerfile(GenAbcDockerfile):
     async def get_text(self) -> str:
         text_parts = [await super().get_text()]
 
-        if 'sudo' in self.options.mixins:
+        if {'clion', 'sudo', 'vscode'} & self.options.mixins:
             uid = os.getuid()
             gid = os.getgid()
             home = Path.home()

--- a/dev_tools/gdev/gdev/cmd/gen/_custom/run.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_custom/run.py
@@ -16,12 +16,12 @@ class GenCustomRun(GenAbcRun):
         flags_parts = [await super()._get_flags()]
         # gdb needs ptrace enabled in order to attach to a process. Additionally,
         # seccomp=unconfined is recommended for gdb, and we don't run in a hostile environment.
-        if 'gdb' in self.options.mixins:
+        if {'clion', 'gdb', 'vscode'} & self.options.mixins:
             flags_parts += [
                 '--cap-add=SYS_PTRACE',
                 '--security-opt seccomp=unconfined'
             ]
-        if 'sudo' in self.options.mixins:
+        if {'clion', 'sudo', 'vscode'} & self.options.mixins:
             flags_parts.append(f'--user {os.getuid()}:{os.getgid()}')
 
         flags = ' '.join(flags_parts)

--- a/dev_tools/gdev/gdev/dependency.py
+++ b/dev_tools/gdev/gdev/dependency.py
@@ -173,7 +173,6 @@ class Dependency:
             parser.add_argument(
                 '--mounts',
                 default=[],
-                dest='mounts',
                 nargs='*',
                 help=(
                     f'<host_path>:<container_path> mounts to be created (or if already created,'
@@ -193,6 +192,14 @@ class Dependency:
                 default=platform_default,
                 choices=['amd64', 'arm64'],
                 help=f'Platform to build upon. Default: "{platform_default}"'
+            )
+            ports_default = []
+            parser.add_argument(
+                '-p', '--ports',
+                default=ports_default,
+                nargs='*',
+                type=int,
+                help=f'Ports to expose in underlying docker container. Default: "{ports_default}"'
             )
             registry_default = '192.168.0.250:5000'
             parser.add_argument(
@@ -262,6 +269,7 @@ class Dependency:
         parsed_args['args'] = ' '.join(parsed_args['args'])
         parsed_args['cfg_enables'] = frozenset(parsed_args['cfg_enables'])
         parsed_args['mixins'] = frozenset(parsed_args['mixins'])
+        parsed_args['ports'] = frozenset(str(port) for port in parsed_args['ports'])
 
         mounts = []
         for mount in parsed_args['mounts']:

--- a/dev_tools/gdev/gdev/options.py
+++ b/dev_tools/gdev/gdev/options.py
@@ -24,5 +24,6 @@ class Options:
     mixins: FrozenSet[str]
     mounts: FrozenSet[Mount]
     platform: str
+    ports: FrozenSet[str]
     registry: str
     target: str

--- a/dev_tools/gdev/mixin/clion/gdev.cfg
+++ b/dev_tools/gdev/mixin/clion/gdev.cfg
@@ -1,0 +1,5 @@
+[apt]
+gdb
+openssh-server
+rsync
+sudo


### PR DESCRIPTION
This includes a new mixing for clion support and a fix specific to the `sudo` mixin where environment variables weren't being set correctly. It also fixes a problem where I wasn't correctly adding users and groups in the base layer of our build.

Note that I modified the base layer of the build. This will cause a complete rebuild of everything.