### PR TITLE
Replace reference fields with relationship in gaiat

### DIFF
--- a/production/tools/gaia_translate/src/main.cpp
+++ b/production/tools/gaia_translate/src/main.cpp
@@ -34,8 +34,10 @@ using namespace clang::ast_matchers;
 using namespace gaia;
 
 cl::OptionCategory g_translation_engine_category("Use translation engine options");
-cl::opt<string> g_translation_engine_output_option("output", cl::init(""), cl::desc("output file name"), cl::cat(g_translation_engine_category));
-cl::opt<bool> g_translation_engine_verbose_option("v", cl::desc("print parse tokens"), cl::cat(g_translation_engine_category));
+cl::opt<string> g_translation_engine_output_option(
+    "output", cl::init(""), cl::desc("output file name"), cl::cat(g_translation_engine_category));
+cl::opt<bool> g_translation_engine_verbose_option(
+    "v", cl::desc("print parse tokens"), cl::cat(g_translation_engine_category));
 
 std::string g_current_ruleset;
 bool g_verbose = false;
@@ -86,7 +88,14 @@ string generate_general_subscription_code()
 
     for (const string& ruleset : g_rulesets)
     {
-        return_value.append("if (strcmp(ruleset_name, \"").append(ruleset).append("\") == 0)\n{\n::").append(ruleset).append("::subscribeRuleset_").append(ruleset).append("();\nreturn;\n}\n");
+        return_value
+            .append("if (strcmp(ruleset_name, \"")
+            .append(ruleset)
+            .append("\") == 0)\n{\n::")
+            .append(ruleset)
+            .append("::subscribeRuleset_")
+            .append(ruleset)
+            .append("();\nreturn;\n}\n");
     }
 
     return_value += "throw ruleset_not_found(ruleset_name);\n}\n"
@@ -94,14 +103,26 @@ string generate_general_subscription_code()
 
     for (const string& ruleset : g_rulesets)
     {
-        return_value.append("if (strcmp(ruleset_name, \"").append(ruleset).append("\") == 0)\n{\n::").append(ruleset).append("::unsubscribeRuleset_").append(ruleset).append("();\nreturn;\n}\n");
+        return_value
+            .append("if (strcmp(ruleset_name, \"")
+            .append(ruleset)
+            .append("\") == 0)\n{\n::")
+            .append(ruleset)
+            .append("::unsubscribeRuleset_")
+            .append(ruleset)
+            .append("();\nreturn;\n}\n");
     }
 
     return_value += "throw ruleset_not_found(ruleset_name);\n}\n"
                     "extern \"C\" void initialize_rules()\n{\n";
     for (const string& ruleset : g_rulesets)
     {
-        return_value.append("::").append(ruleset).append("::subscribeRuleset_").append(ruleset).append("();\n");
+        return_value
+            .append("::")
+            .append(ruleset)
+            .append("::subscribeRuleset_")
+            .append(ruleset)
+            .append("();\n");
     }
     return_value += "}\n}\n}";
 
@@ -321,7 +342,8 @@ bool find_navigation_path(const string& src, const string& dst, vector<navigatio
 navigation_code_data_t generate_navigation_code(string anchor_table)
 {
     navigation_code_data_t return_value;
-    return_value.prefix = "\nauto " + anchor_table + " = " + "gaia::" + g_table_db_data[anchor_table] + "::" + anchor_table + "_t::get(context->record);\n";
+    return_value.prefix = "\nauto " + anchor_table
+        + " = " + "gaia::" + g_table_db_data[anchor_table] + "::" + anchor_table + "_t::get(context->record);\n";
     //single table used in the rule
     if (g_used_tables.size() == 1 && g_used_tables.find(anchor_table) != g_used_tables.end())
     {
@@ -341,10 +363,12 @@ navigation_code_data_t generate_navigation_code(string anchor_table)
         return navigation_code_data_t();
     }
 
-    if (g_table_relationship_1.find(anchor_table) == g_table_relationship_1.end() && g_table_relationship_n.find(anchor_table) == g_table_relationship_n.end())
+    if (g_table_relationship_1.find(anchor_table) == g_table_relationship_1.end()
+        && g_table_relationship_n.find(anchor_table) == g_table_relationship_n.end())
     {
         g_generation_error = true;
-        llvm::errs() << "Table " << anchor_table << " doesn't reference any table and not referenced by any other tables";
+        llvm::errs()
+            << "Table " << anchor_table << " doesn't reference any table and not referenced by any other tables";
         return navigation_code_data_t();
     }
     auto parent_itr = g_table_relationship_1.equal_range(anchor_table);
@@ -416,22 +440,29 @@ navigation_code_data_t generate_navigation_code(string anchor_table)
                         {
                             if (p.linking_field.empty())
                             {
-                                return_value.prefix += "auto " + p.name + " = " + source_table + "." + p.name + "();\n";
+                                return_value.prefix
+                                    += "auto " + p.name + " = "
+                                    + source_table + "." + p.name + "();\n";
                             }
                             else
                             {
-                                return_value.prefix += "auto " + p.name + " = " + source_table + "." + p.linking_field + "_" + p.name + "();\n";
+                                return_value.prefix
+                                    += "auto " + p.name + " = "
+                                    + source_table + "." + p.linking_field + "_" + p.name + "();\n";
                             }
                         }
                         else
                         {
                             if (p.linking_field.empty())
                             {
-                                return_value.prefix += "for (auto " + p.name + " : " + source_table + "." + p.name + "_list())\n{\n";
+                                return_value.prefix
+                                    += "for (auto " + p.name + " : " + source_table + "." + p.name + "_list())\n{\n";
                             }
                             else
                             {
-                                return_value.prefix += "for (auto " + p.name + " : " + source_table + "." + p.linking_field + "_" + p.name + "_list())\n{\n";
+                                return_value.prefix
+                                    += "for (auto " + p.name + " : "
+                                    + source_table + "." + p.linking_field + "_" + p.name + "_list())\n{\n";
                             }
 
                             return_value.postfix += "}\n";
@@ -453,22 +484,54 @@ navigation_code_data_t generate_navigation_code(string anchor_table)
             {
                 if (linking_field.empty())
                 {
-                    return_value.prefix.append("auto ").append(table).append(" = ").append(anchor_table).append(".").append(table).append("();\n");
+                    return_value.prefix
+                        .append("auto ")
+                        .append(table)
+                        .append(" = ")
+                        .append(anchor_table)
+                        .append(".")
+                        .append(table)
+                        .append("();\n");
                 }
                 else
                 {
-                    return_value.prefix.append("auto ").append(table).append(" = ").append(anchor_table).append(".").append(linking_field).append("_").append(table).append("();\n");
+                    return_value.prefix
+                        .append("auto ")
+                        .append(table)
+                        .append(" = ")
+                        .append(anchor_table)
+                        .append(".")
+                        .append(linking_field)
+                        .append("_")
+                        .append(table)
+                        .append("();\n");
                 }
             }
             else
             {
                 if (linking_field.empty())
                 {
-                    return_value.prefix.append("for (auto ").append(table).append(" : ").append(anchor_table).append(".").append(table).append("_list())\n{\n");
+                    return_value.prefix
+                        .append("for (auto ")
+                        .append(table)
+                        .append(" : ")
+                        .append(anchor_table)
+                        .append(".")
+                        .append(table)
+                        .append("_list())\n{\n");
                 }
                 else
                 {
-                    return_value.prefix.append("for (auto ").append(table).append(" : ").append(anchor_table).append(".").append(linking_field).append("_").append(table).append("_list())\n{\n");
+                    return_value.prefix
+                        .append("for (auto ")
+                        .append(table)
+                        .append(" : ")
+                        .append(anchor_table)
+                        .append(".")
+                        .append(linking_field)
+                        .append("_")
+                        .append(table)
+                        .append("_list())\n{\n");
                 }
 
                 return_value.postfix += "}\n";
@@ -508,13 +571,27 @@ void generate_rules(Rewriter& rewriter)
             g_generation_error = true;
             return;
         }
-        string rule_name = g_current_ruleset + "_" + g_current_rule_declaration->getName().str() + "_" + to_string(rule_count);
-        common_subscription_code.append("rule_binding_t ").append(rule_name).append("binding(\"").append(g_current_ruleset).append("\",\"").append(g_current_ruleset).append("::").append(to_string(g_current_ruleset_rule_number));
+        string rule_name
+            = g_current_ruleset + "_" + g_current_rule_declaration->getName().str() + "_" + to_string(rule_count);
+        common_subscription_code
+            .append("rule_binding_t ")
+            .append(rule_name)
+            .append("binding(\"")
+            .append(g_current_ruleset)
+            .append("\",\"")
+            .append(g_current_ruleset)
+            .append("::")
+            .append(to_string(g_current_ruleset_rule_number));
         if (g_active_fields.size() > 1)
         {
             common_subscription_code.append("_").append(table);
         }
-        common_subscription_code.append("\",").append(g_current_ruleset).append("::").append(rule_name).append(");\n");
+        common_subscription_code
+            .append("\",")
+            .append(g_current_ruleset)
+            .append("::")
+            .append(rule_name)
+            .append(");\n");
         field_subscription_code = "field_position_list_t fields_" + rule_name + ";\n";
 
         if (fd.second.find("LastOperation") != fd.second.end())
@@ -542,7 +619,8 @@ void generate_rules(Rewriter& rewriter)
                     return;
                 }
 
-                field_subscription_code += "fields_" + rule_name + ".push_back(" + to_string(g_field_data.position) + ");\n";
+                field_subscription_code
+                    += "fields_" + rule_name + ".push_back(" + to_string(g_field_data.position) + ");\n";
             }
         }
 
@@ -558,28 +636,97 @@ void generate_rules(Rewriter& rewriter)
 
         if (contains_fields)
         {
-            g_current_ruleset_subscription.append(field_subscription_code).append("subscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_update, fields_").append(rule_name).append(",").append(rule_name).append("binding);\n");
-            g_current_ruleset_unsubscription.append(field_subscription_code).append("unsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_update, fields_").append(rule_name).append(",").append(rule_name).append("binding);\n");
+            g_current_ruleset_subscription
+                .append(field_subscription_code)
+                .append("subscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_update, fields_")
+                .append(rule_name)
+                .append(",")
+                .append(rule_name)
+                .append("binding);\n");
+            g_current_ruleset_unsubscription
+                .append(field_subscription_code)
+                .append("unsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_update, fields_")
+                .append(rule_name)
+                .append(",")
+                .append(rule_name)
+                .append("binding);\n");
         }
 
         if (contains_last_operation)
         {
-            g_current_ruleset_subscription.append("subscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_update, gaia::rules::empty_fields,").append(rule_name).append("binding);\nsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_insert, gaia::rules::empty_fields,").append(rule_name).append("binding);\nsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_delete, gaia::rules::empty_fields,").append(rule_name).append("binding);\n");
+            g_current_ruleset_subscription
+                .append("subscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_update, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\nsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_insert, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\nsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_delete, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\n");
 
-            g_current_ruleset_unsubscription.append("unsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_update, gaia::rules::empty_fields,").append(rule_name).append("binding);\nunsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_insert, gaia::rules::empty_fields,").append(rule_name).append("binding);\nunsubscribe_rule(gaia::").append(g_table_db_data[table]).append("::").append(table).append("_t::s_gaia_type, event_type_t::row_delete, gaia::rules::empty_fields,").append(rule_name).append("binding);\n");
+            g_current_ruleset_unsubscription
+                .append("unsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_update, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\nunsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_insert, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\nunsubscribe_rule(gaia::")
+                .append(g_table_db_data[table])
+                .append("::")
+                .append(table)
+                .append("_t::s_gaia_type, event_type_t::row_delete, gaia::rules::empty_fields,")
+                .append(rule_name)
+                .append("binding);\n");
         }
 
         navigation_code_data_t navigation_code = generate_navigation_code(table);
 
         if (rule_count == 1)
         {
-            rewriter.InsertText(g_current_rule_declaration->getLocation(), "\nvoid " + rule_name + "(const rule_context_t* context)\n");
-            rewriter.InsertTextAfterToken(g_current_rule_declaration->getLocation(), navigation_code.prefix);
-            rewriter.InsertText(g_current_rule_declaration->getEndLoc(), navigation_code.postfix);
+            rewriter.InsertText(
+                g_current_rule_declaration->getLocation(),
+                "\nvoid " + rule_name + "(const rule_context_t* context)\n");
+            rewriter.InsertTextAfterToken(
+                g_current_rule_declaration->getLocation(),
+                navigation_code.prefix);
+            rewriter.InsertText(
+                g_current_rule_declaration->getEndLoc(),
+                navigation_code.postfix);
         }
         else
         {
-            rewriter.InsertTextBefore(g_current_rule_declaration->getLocation(), "\nvoid " + rule_name + "(const rule_context_t* context)\n" + insert_rule_preamble(rule_code + navigation_code.postfix, navigation_code.prefix));
+            rewriter.InsertTextBefore(
+                g_current_rule_declaration->getLocation(),
+                "\nvoid " + rule_name + "(const rule_context_t* context)\n"
+                    + insert_rule_preamble(
+                        rule_code + navigation_code.postfix,
+                        navigation_code.prefix));
         }
 
         rule_count++;
@@ -625,7 +772,8 @@ public:
             }
             else if (decl->hasAttr<GaiaFieldValueAttr>())
             {
-                expression_source_range = SourceRange(expression->getLocation().getLocWithOffset(-1), expression->getEndLoc());
+                expression_source_range
+                    = SourceRange(expression->getLocation().getLocWithOffset(-1), expression->getEndLoc());
             }
         }
         else if (member_expression != nullptr)
@@ -643,11 +791,17 @@ public:
 
                 if (declaration_expression->getDecl()->hasAttr<GaiaFieldValueAttr>())
                 {
-                    expression_source_range = SourceRange(member_expression->getBeginLoc().getLocWithOffset(-1), member_expression->getEndLoc());
+                    expression_source_range
+                        = SourceRange(
+                            member_expression->getBeginLoc().getLocWithOffset(-1),
+                            member_expression->getEndLoc());
                 }
                 else
                 {
-                    expression_source_range = SourceRange(member_expression->getBeginLoc(), member_expression->getEndLoc());
+                    expression_source_range
+                        = SourceRange(
+                            member_expression->getBeginLoc(),
+                            member_expression->getEndLoc());
                     g_active_fields[table_name].insert(field_name);
                 }
             }
@@ -667,7 +821,11 @@ public:
         {
             if (is_last_operation)
             {
-                m_rewriter.ReplaceText(expression_source_range, "context->last_operation(gaia::" + g_table_db_data[table_name] + "::" + table_name + "_t::s_gaia_type)");
+                m_rewriter.ReplaceText(
+                    expression_source_range,
+                    "context->last_operation(gaia::"
+                        + g_table_db_data[table_name] + "::"
+                        + table_name + "_t::s_gaia_type)");
             }
             else
             {
@@ -736,7 +894,8 @@ public:
                     g_used_dbs.insert(g_table_db_data[table_name]);
 
                     tok::TokenKind token_kind;
-                    std::string replacement_text = "[&]() mutable {auto w = " + table_name + ".writer(); w." + field_name;
+                    std::string replacement_text
+                        = "[&]() mutable {auto w = " + table_name + ".writer(); w." + field_name;
 
                     switch (op->getOpcode())
                     {
@@ -822,11 +981,13 @@ public:
 
                     if (op->getOpcode() != BO_Assign)
                     {
-                        m_rewriter.InsertTextAfterToken(op->getEndLoc(), "; w.update_row();return w." + field_name + ";}() ");
+                        m_rewriter.InsertTextAfterToken(
+                            op->getEndLoc(), "; w.update_row();return w." + field_name + ";}() ");
                     }
                     else
                     {
-                        m_rewriter.InsertTextAfterToken(op->getEndLoc(), "; w.update_row();return w." + field_name + ";}()");
+                        m_rewriter.InsertTextAfterToken(
+                            op->getEndLoc(), "; w.update_row();return w." + field_name + ";}()");
                     }
                 }
                 else
@@ -946,22 +1107,31 @@ public:
                     {
                         if (op->isIncrementOp())
                         {
-                            replace_string = "[&]() mutable {auto t=" + table_name + "." + field_name + "();auto w = " + table_name + ".writer(); w." + field_name + "++; w.update_row();return t;}()";
+                            replace_string
+                                = "[&]() mutable {auto t="
+                                + table_name + "." + field_name + "();auto w = "
+                                + table_name + ".writer(); w." + field_name + "++; w.update_row();return t;}()";
                         }
                         else if (op->isDecrementOp())
                         {
-                            replace_string = "[&]() mutable {auto t=" + table_name + "." + field_name + "();auto w = " + table_name + ".writer(); w." + field_name + "--; w.update_row();return t;}()";
+                            replace_string
+                                = "[&]() mutable {auto t=" + table_name + "." + field_name + "();auto w = "
+                                + table_name + ".writer(); w." + field_name + "--; w.update_row();return t;}()";
                         }
                     }
                     else
                     {
                         if (op->isIncrementOp())
                         {
-                            replace_string = "[&]() mutable {auto w = " + table_name + ".writer(); ++ w." + field_name + ";w.update_row(); return w." + field_name + ";}()";
+                            replace_string
+                                = "[&]() mutable {auto w = " + table_name + ".writer(); ++ w." + field_name
+                                + ";w.update_row(); return w." + field_name + ";}()";
                         }
                         else if (op->isDecrementOp())
                         {
-                            replace_string = "[&]() mutable {auto w = " + table_name + ".writer(); -- w." + field_name + ";w.update_row(); return w." + field_name + ";}()";
+                            replace_string
+                                = "[&]() mutable {auto w = " + table_name + ".writer(); -- w." + field_name
+                                + ";w.update_row(); return w." + field_name + ";}()";
                         }
                     }
 
@@ -1048,7 +1218,12 @@ public:
         {
             if (!g_current_ruleset.empty())
             {
-                g_generated_subscription_code += "namespace " + g_current_ruleset + "{\nvoid subscribeRuleset_" + ruleset_declaration->getName().str() + "()\n{\n" + g_current_ruleset_subscription + "}\nvoid unsubscribeRuleset_" + ruleset_declaration->getName().str() + "()\n{\n" + g_current_ruleset_unsubscription + "}\n}\n";
+                g_generated_subscription_code
+                    += "namespace " + g_current_ruleset
+                    + "{\nvoid subscribeRuleset_" + ruleset_declaration->getName().str()
+                    + "()\n{\n" + g_current_ruleset_subscription
+                    + "}\nvoid unsubscribeRuleset_" + ruleset_declaration->getName().str()
+                    + "()\n{\n" + g_current_ruleset_unsubscription + "}\n}\n";
             }
             g_current_ruleset = ruleset_declaration->getName().str();
             g_rulesets.push_back(g_current_ruleset);
@@ -1056,7 +1231,9 @@ public:
             g_current_ruleset_unsubscription.clear();
             g_current_ruleset_rule_number = 1;
             m_rewriter.ReplaceText(
-                SourceRange(ruleset_declaration->getBeginLoc(), ruleset_declaration->decls_begin()->getBeginLoc().getLocWithOffset(-2)),
+                SourceRange(
+                    ruleset_declaration->getBeginLoc(),
+                    ruleset_declaration->decls_begin()->getBeginLoc().getLocWithOffset(-2)),
                 "namespace " + g_current_ruleset + "\n{\n");
         }
     }
@@ -1157,28 +1334,74 @@ class translation_engine_consumer_t : public clang::ASTConsumer
 {
 public:
     explicit translation_engine_consumer_t(ASTContext* context, Rewriter& r)
-        : m_field_get_match_handler(r), m_field_set_match_handler(r), m_rule_match_handler(r), m_ruleset_match_handler(r), m_field_unary_operator_match_handler(r), m_update_match_handler(r), m_insert_match_handler(r), m_delete_match_handler(r), m_none_match_handler(r)
+        : m_field_get_match_handler(r)
+        , m_field_set_match_handler(r)
+        , m_rule_match_handler(r)
+        , m_ruleset_match_handler(r)
+        , m_field_unary_operator_match_handler(r)
+        , m_update_match_handler(r)
+        , m_insert_match_handler(r)
+        , m_delete_match_handler(r)
+        , m_none_match_handler(r)
 
     {
-        StatementMatcher field_get_matcher = declRefExpr(to(varDecl(anyOf(hasAttr(attr::GaiaField), hasAttr(attr::GaiaFieldValue)), unless(hasAttr(attr::GaiaFieldLValue))))).bind("fieldGet");
-        StatementMatcher field_set_matcher = binaryOperator(allOf(
-                                                                isAssignmentOperator(),
-                                                                hasLHS(declRefExpr(to(varDecl(hasAttr(attr::GaiaFieldLValue)))))))
-                                                 .bind("fieldSet");
+        StatementMatcher field_get_matcher
+            = declRefExpr(to(varDecl(
+                              anyOf(
+                                  hasAttr(attr::GaiaField),
+                                  hasAttr(attr::GaiaFieldValue)),
+                              unless(hasAttr(attr::GaiaFieldLValue)))))
+                  .bind("fieldGet");
+        StatementMatcher field_set_matcher
+            = binaryOperator(
+                  allOf(
+                      isAssignmentOperator(),
+                      hasLHS(declRefExpr(to(varDecl(hasAttr(attr::GaiaFieldLValue)))))))
+                  .bind("fieldSet");
         DeclarationMatcher rule_matcher = functionDecl(hasAttr(attr::Rule)).bind("ruleDecl");
         DeclarationMatcher ruleset_matcher = rulesetDecl().bind("rulesetDecl");
-        StatementMatcher field_unary_operator_matcher = unaryOperator(allOf(anyOf(hasOperatorName("++"), hasOperatorName("--")), hasUnaryOperand(declRefExpr(to(varDecl(hasAttr(attr::GaiaFieldLValue))))))).bind("fieldUnaryOp");
-        StatementMatcher table_field_get_matcher = memberExpr(member(allOf(hasAttr(attr::GaiaField), unless(hasAttr(attr::GaiaFieldLValue)))), hasDescendant(declRefExpr(to(varDecl(anyOf(hasAttr(attr::GaiaField), hasAttr(attr::FieldTable), hasAttr(attr::GaiaFieldValue), hasAttr(attr::GaiaLastOperation)))))))
-                                                       .bind("tableFieldGet");
-        StatementMatcher table_field_set_matcher = binaryOperator(allOf(
-                                                                      isAssignmentOperator(),
-                                                                      hasLHS(memberExpr(member(hasAttr(attr::GaiaFieldLValue))))))
-                                                       .bind("fieldSet");
-        StatementMatcher table_field_unary_operator_matcher = unaryOperator(allOf(anyOf(hasOperatorName("++"), hasOperatorName("--")), hasUnaryOperand(memberExpr(member(hasAttr(attr::GaiaFieldLValue)))))).bind("fieldUnaryOp");
-        StatementMatcher update_matcher = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationUPDATE)))).bind("UPDATE");
-        StatementMatcher insert_matcher = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationINSERT)))).bind("INSERT");
-        StatementMatcher delete_matcher = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationDELETE)))).bind("DELETE");
-        StatementMatcher none_matcher = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationNONE)))).bind("NONE");
+        StatementMatcher field_unary_operator_matcher
+            = unaryOperator(
+                  allOf(
+                      anyOf(
+                          hasOperatorName("++"),
+                          hasOperatorName("--")),
+                      hasUnaryOperand(declRefExpr(to(varDecl(hasAttr(attr::GaiaFieldLValue)))))))
+                  .bind("fieldUnaryOp");
+
+        StatementMatcher table_field_get_matcher
+            = memberExpr(
+                  member(
+                      allOf(
+                          hasAttr(attr::GaiaField),
+                          unless(hasAttr(attr::GaiaFieldLValue)))),
+                  hasDescendant(declRefExpr(
+                      to(varDecl(anyOf(
+                          hasAttr(attr::GaiaField),
+                          hasAttr(attr::FieldTable),
+                          hasAttr(attr::GaiaFieldValue),
+                          hasAttr(attr::GaiaLastOperation)))))))
+                  .bind("tableFieldGet");
+        StatementMatcher table_field_set_matcher
+            = binaryOperator(allOf(
+                                 isAssignmentOperator(),
+                                 hasLHS(memberExpr(member(hasAttr(attr::GaiaFieldLValue))))))
+                  .bind("fieldSet");
+        StatementMatcher table_field_unary_operator_matcher
+            = unaryOperator(allOf(
+                                anyOf(
+                                    hasOperatorName("++"),
+                                    hasOperatorName("--")),
+                                hasUnaryOperand(memberExpr(member(hasAttr(attr::GaiaFieldLValue))))))
+                  .bind("fieldUnaryOp");
+        StatementMatcher update_matcher
+            = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationUPDATE)))).bind("UPDATE");
+        StatementMatcher insert_matcher
+            = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationINSERT)))).bind("INSERT");
+        StatementMatcher delete_matcher
+            = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationDELETE)))).bind("DELETE");
+        StatementMatcher none_matcher
+            = declRefExpr(to(varDecl(hasAttr(attr::GaiaLastOperationNONE)))).bind("NONE");
 
         m_matcher.addMatcher(field_get_matcher, &m_field_get_match_handler);
         m_matcher.addMatcher(table_field_get_matcher, &m_field_get_match_handler);
@@ -1234,7 +1457,11 @@ public:
             return;
         }
 
-        g_generated_subscription_code += "namespace " + g_current_ruleset + "{\nvoid subscribeRuleset_" + g_current_ruleset + "()\n{\n" + g_current_ruleset_subscription + "}\n" + "void unsubscribeRuleset_" + g_current_ruleset + "()\n{\n" + g_current_ruleset_unsubscription + "}\n}\n" + generate_general_subscription_code();
+        g_generated_subscription_code
+            += "namespace " + g_current_ruleset
+            + "{\nvoid subscribeRuleset_" + g_current_ruleset + "()\n{\n" + g_current_ruleset_subscription + "}\n"
+            + "void unsubscribeRuleset_" + g_current_ruleset + "()\n{\n" + g_current_ruleset_unsubscription + "}\n}\n"
+            + generate_general_subscription_code();
 
         if (!shouldEraseOutputFiles() && !g_generation_error && !g_translation_engine_output_option.empty())
         {


### PR DESCRIPTION
Switch to use `gaia_relationship` table in catalog to build up table links in gaiat.

The changes are minor, and all in `fill_table_db_data`. The rest are auto formated by clang-format.