### PR TITLE
Fix memory manager allocate methods to no longer required sizes that are 8B multiples

### DIFF
--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -88,12 +88,6 @@ error_code_t memory_manager_t::allocate_internal(
 {
     allocated_memory_offset = c_invalid_offset;
 
-    error_code_t error_code = validate_size(memory_size);
-    if (error_code != error_code_t::success)
-    {
-        return error_code;
-    }
-
     // Adjust the requested memory size, to ensure proper alignment.
     if (add_allocation_metadata)
     {
@@ -103,6 +97,10 @@ error_code_t memory_manager_t::allocate_internal(
     {
         memory_size = calculate_raw_allocation_size(memory_size);
     }
+
+    retail_assert(
+        validate_size(memory_size) == error_code_t::success,
+        "Adjusted memory sizes should always be multiples of 8 bytes!");
 
     // Then factor in the metadata size, if we need to add that.
     size_t size_to_allocate = memory_size

--- a/production/db/memory_manager/src/stack_allocator.cpp
+++ b/production/db/memory_manager/src/stack_allocator.cpp
@@ -104,13 +104,6 @@ error_code_t stack_allocator_t::allocate(
         return error_code_t::not_initialized;
     }
 
-    // A memory_size of 0 indicates a deletion - handle specially.
-    error_code_t error_code = validate_size(memory_size);
-    if (memory_size != 0 && error_code != error_code_t::success)
-    {
-        return error_code;
-    }
-
     if (old_slot_offset != c_invalid_offset
         && !validate_offset_alignment(old_slot_offset))
     {
@@ -121,6 +114,9 @@ error_code_t stack_allocator_t::allocate(
     if (memory_size != 0)
     {
         memory_size = calculate_allocation_size(memory_size);
+        retail_assert(
+            validate_size(memory_size) == error_code_t::success,
+            "Adjusted memory sizes should always be multiples of 8 bytes!");
     }
 
     // Each allocation will get its own metadata.

--- a/production/db/memory_manager/tests/test_memory_manager.cpp
+++ b/production/db/memory_manager/tests/test_memory_manager.cpp
@@ -41,7 +41,7 @@ TEST(memory_manager, basic_operation)
     ASSERT_EQ(error_code_t::success, error_code);
 
     constexpr size_t c_first_allocation_size = 64;
-    constexpr size_t c_second_allocation_size = 256;
+    constexpr size_t c_second_allocation_size = 250;
     constexpr size_t c_third_allocation_size = 128;
 
     size_t first_adjusted_allocation_size
@@ -108,7 +108,7 @@ TEST(memory_manager, advanced_operation)
     ASSERT_EQ(error_code_t::success, error_code);
 
     constexpr size_t c_first_allocation_size = 64;
-    constexpr size_t c_second_allocation_size = 256;
+    constexpr size_t c_second_allocation_size = 250;
     constexpr size_t c_third_allocation_size = 128;
 
     size_t first_adjusted_allocation_size
@@ -163,7 +163,7 @@ TEST(memory_manager, advanced_operation)
     ASSERT_EQ(error_code_t::success, error_code);
 
     constexpr size_t c_fourth_allocation_size = 256;
-    constexpr size_t c_fifth_allocation_size = 64;
+    constexpr size_t c_fifth_allocation_size = 66;
 
     size_t fourth_adjusted_allocation_size
         = base_memory_manager_t::calculate_allocation_size(c_fourth_allocation_size);

--- a/production/db/memory_manager/tests/test_stack_allocator.cpp
+++ b/production/db/memory_manager/tests/test_stack_allocator.cpp
@@ -63,8 +63,8 @@ TEST(memory_manager, stack_allocator)
     ASSERT_EQ(error_code_t::success, error_code);
 
     constexpr size_t c_first_allocation_size = 64;
-    constexpr size_t c_second_allocation_size = 256;
-    constexpr size_t c_third_allocation_size = 128;
+    constexpr size_t c_second_allocation_size = 253;
+    constexpr size_t c_third_allocation_size = 122;
     constexpr size_t c_fourth_allocation_size = 24;
     constexpr size_t c_fifth_allocation_size = 72;
 


### PR DESCRIPTION
Now that allocation sizes get padded anyway for 64B alignment, it does not make sense to maintain the checks that required sizes to be multiples of 8B. Instead, those checks have now become retail asserts that are performed after the size adjustments.