### PR TITLE
Add some FDW support for NULL

### DIFF
--- a/production/sql/inc/gaia_fdw_adapter.hpp
+++ b/production/sql/inc/gaia_fdw_adapter.hpp
@@ -177,7 +177,7 @@ public:
     // Scan API.
     bool initialize_scan();
     bool has_scan_ended();
-    Datum extract_field_value(size_t field_index);
+    NullableDatum extract_field_value(size_t field_index);
     bool scan_forward();
 
 protected:
@@ -211,7 +211,7 @@ protected:
 public:
     // Modify API.
     void initialize_payload();
-    void set_field_value(size_t field_index, const Datum& field_value);
+    void set_field_value(size_t field_index, const NullableDatum& field_value);
     bool insert_record(uint64_t gaia_id);
     bool update_record(uint64_t gaia_id);
     bool delete_record(uint64_t gaia_id);


### PR DESCRIPTION
The issue of how to handle NULL in our database remains an open issue. This change does not attempt to resolve that issue, but it enables the FDW to read the NULL values that can be written through EDC.

Brief history:

- For strings, EDC uses a custom string class that represents NULL as a nullptr. Such values would crash the FDW when attempting to map them to Postgres strings - this is one of the issues addressed by this change - these values would now be correctly surfaced as NULL.
- For numerical types, we never had a solution for how to represent NULL. Tobin proposed encoding NULL as missing values, but that would prevent in-place updates of the only type of values that can be updated in-place. Nick had proposed maintaining a vector of booleans in the record, but that remains just a proposal. So the behavior of the current FDW when using NULL is that it would reset a field value to its default value (0 for numerical values, empty string for strings).
- With references in the picture, NULL can be used for removing a reference - this is the scenario that partially motivates this change - I needed the FDW adapter to know whether we're trying to set NULL values or not, so this information is now passed to the adapter via a NullableDatum structure. At the moment, we don't do much with it, but when I'll add reference support, it will be helpful.

So, to summarize, there are two motivations for this change:

1. To enable the FDW to properly surface the NULL string values set through EDC.
2. To prepare support for removing references by setting them to NULL.

Outside the scope of these changes: a solution for handling NULL for all data types. For that, we'd probably want to go with something like Nick's proposal and add an array of flags to the database records, for capturing null information (at that point, we can also update the current approach we take with null strings).