### PR TITLE
Fix `gdev build` break with LSAN enabled.

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -43,7 +43,16 @@ cmake -DCMAKE_MODULE_PATH={source_dir('production/cmake')} \
     {enable_if('GaiaRelease')}-DBUILD_GAIA_RELEASE=ON \
     {enable_if('GaiaRelease')}-G "Unix Makefiles" \
     {source_dir('production')}
-make -j$(nproc)
+
+# LSAN will cause failures during docker build time since we cannot allow the
+# build context to have privileged information about the host system.  Doing so
+# would make it impossible to make these builds repeatable. It only needs to be
+# disabled during `gdev build` (`docker build` under the hood), but the same is
+# not true while inside a container built by `gdev run` (`docker run` under the
+# hood) since we do enable privileged information about the host system in that
+# context.
+LSAN_OPTIONS=detect_leaks=0 \
+    make -j$(nproc)
 
 # Storage engine needs to be in well-known path for tests to pass.
 cd {build_dir('production/db/storage_engine')}


### PR DESCRIPTION
We now disable LSAN during `gdev build` (`docker build` under the hood).
It's not possible to expose the privileged host information required to
make LSAN work properly at build time, so we disable it. We actually
only care about sanitizers at test time, so it's fine to have it
disabled here.