### PR TITLE
Fix gdev mixins not working with non-run stages

### DIFF
--- a/dev_tools/gdev/gdev/cmd/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/dockerfile.py
@@ -1,6 +1,5 @@
 from gdev.dependency import Dependency
 from gdev.third_party.atools import memoize
-from .gen._custom.dockerfile import GenCustomDockerfile
 from .gen.run.dockerfile import GenRunDockerfile
 
 
@@ -8,7 +7,4 @@ class Dockerfile(Dependency):
 
     @memoize
     async def cli_entrypoint(self) -> None:
-        if self.options.mixins:
-            await GenCustomDockerfile(self.options).cli_entrypoint()
-        else:
-            await GenRunDockerfile(self.options).cli_entrypoint()
+        await GenRunDockerfile(self.options).cli_entrypoint()

--- a/dev_tools/gdev/gdev/cmd/gen/_abc/build.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/build.py
@@ -210,3 +210,13 @@ class GenAbcBuild(Dependency, ABC):
             f' {Path.repo()}'
         )
         await Host.execute(f'docker image prune -f')
+
+    @memoize
+    async def cli_entrypoint(self) -> None:
+        if not self.options.mixins:
+            build = self
+        else:
+            from .._custom.build import GenCustomBuild
+            build = GenCustomBuild(options=self.options, base_build=self)
+
+        await build.run()

--- a/dev_tools/gdev/gdev/cmd/gen/_abc/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/dockerfile.py
@@ -226,5 +226,11 @@ class GenAbcDockerfile(Dependency, ABC):
     @memoize
     async def cli_entrypoint(self) -> None:
         """If actual CLI command is `gdev ... dockerfile`, run as normal and then print contents."""
-        await self.run()
-        print(await self.get_text())
+        if not self.options.mixins:
+            dockerfile = self
+        else:
+            from .._custom.dockerfile import GenCustomDockerfile
+            dockerfile = GenCustomDockerfile(options=self.options, base_dockerfile=self)
+
+        await dockerfile.run()
+        print(await dockerfile.get_text())

--- a/dev_tools/gdev/gdev/cmd/gen/_abc/run.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/run.py
@@ -110,3 +110,13 @@ class GenAbcRun(Dependency, ABC):
         self.log.debug(f'execvpe {command = }')
 
         os.execvpe(command[0], command, os.environ)
+
+    @memoize
+    async def cli_entrypoint(self) -> None:
+        if not self.options.mixins:
+            run = self
+        else:
+            from .._custom.run import GenCustomRun
+            run = GenCustomRun(options=self.options, base_run=self)
+
+        await run.run()

--- a/dev_tools/gdev/gdev/cmd/gen/_custom/build.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_custom/build.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Mapping
 
 from gdev.third_party.atools import memoize
@@ -5,11 +6,13 @@ from .dockerfile import GenCustomDockerfile
 from .._abc.build import GenAbcBuild
 
 
+@dataclass(frozen=True, repr=False)
 class GenCustomBuild(GenAbcBuild):
+    base_build: GenAbcBuild
 
     @property
     def dockerfile(self) -> GenCustomDockerfile:
-        return GenCustomDockerfile(self.options)
+        return GenCustomDockerfile(self.options, self.base_build.dockerfile)
 
     @memoize
     async def _get_wanted_label_value_by_name(self) -> Mapping[str, str]:

--- a/dev_tools/gdev/gdev/cmd/gen/_custom/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_custom/dockerfile.py
@@ -1,4 +1,4 @@
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import os
 from textwrap import dedent
 from typing import Iterable
@@ -9,7 +9,9 @@ from .cfg import GenCustomCfg
 from .._abc.dockerfile import GenAbcDockerfile
 
 
+@dataclass(frozen=True, repr=False)
 class GenCustomDockerfile(GenAbcDockerfile):
+    base_dockerfile: GenAbcDockerfile
 
     @property
     def cfg(self) -> GenCustomCfg:
@@ -29,7 +31,7 @@ class GenCustomDockerfile(GenAbcDockerfile):
     async def get_input_dockerfiles(self) -> Iterable[GenAbcDockerfile]:
         from ..run.dockerfile import GenRunDockerfile
 
-        input_dockerfiles = [GenRunDockerfile(self.options)]
+        input_dockerfiles = [self.base_dockerfile]
         for line in await self.cfg.get_lines():
             input_dockerfiles.append(GenRunDockerfile(replace(self.options, target=line)))
         input_dockerfiles = tuple(input_dockerfiles)

--- a/dev_tools/gdev/gdev/cmd/gen/_custom/run.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_custom/run.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import os
 
 from gdev.third_party.atools import memoize
@@ -5,11 +6,13 @@ from .build import GenCustomBuild
 from .._abc.run import GenAbcRun
 
 
+@dataclass(frozen=True, repr=False)
 class GenCustomRun(GenAbcRun):
+    base_run: GenAbcRun
 
     @property
     def build(self) -> GenCustomBuild:
-        return GenCustomBuild(self.options)
+        return GenCustomBuild(options=self.options, base_build=self.base_run.build)
 
     @memoize
     async def _get_flags(self) -> str:

--- a/dev_tools/gdev/gdev/cmd/run.py
+++ b/dev_tools/gdev/gdev/cmd/run.py
@@ -1,6 +1,5 @@
 from gdev.dependency import Dependency
 from gdev.third_party.atools import memoize
-from .gen._custom.run import GenCustomRun
 from .gen.run.run import GenRunRun
 
 
@@ -8,7 +7,4 @@ class Run(Dependency):
 
     @memoize
     async def cli_entrypoint(self) -> None:
-        if self.options.mixins:
-            await GenCustomRun(self.options).cli_entrypoint()
-        else:
-            await GenRunRun(self.options).cli_entrypoint()
+        await GenRunRun(self.options).cli_entrypoint()


### PR DESCRIPTION
Commands such as `gdev run --mixin sudo` were working as expected, but
`gdev gen pre_run run --mixin sudo` were not properly adding mixins the
the custom image. The `--mixin` flag should now work properly with all
of `gen run {apt|env|gaia|git|pip|pre_run|run} {dockerfile|build|run}`
commands.