### PR TITLE
Enable FDW testing of references

### DIFF
--- a/production/sql/tests/setup.sql
+++ b/production/sql/tests/setup.sql
@@ -169,131 +169,75 @@ FROM
     rawdata_airports;
 
 -- Create a Postgres copy of Gaia airports table.
--- CREATE TABLE airports_copy (
---     gaia_id bigint,
---     ap_id int PRIMARY KEY,
---     name text,
---     city text,
---     country text,
---     iata char(3),
---     icao char(4) UNIQUE,
---     latitude double precision,
---     longitude double precision,
---     altitude int,
---     timezone float,
---     dst char(1),
---     tztext text,
---     type text,
---     source text
--- );
+CREATE TABLE airports_copy (
+    gaia_id bigint,
+    ap_id int PRIMARY KEY,
+    name text,
+    city text,
+    country text,
+    iata char(3),
+    icao char(4) UNIQUE,
+    latitude double precision,
+    longitude double precision,
+    altitude int,
+    timezone float,
+    dst char(1),
+    tztext text,
+    type text,
+    source text
+);
 
--- INSERT INTO airports_copy (
---     gaia_id,
---     ap_id,
---     name,
---     city,
---     country,
---     iata,
---     icao,
---     latitude,
---     longitude,
---     altitude,
---     timezone,
---     dst,
---     tztext,
---     TYPE,
---     source)
--- SELECT
---     gaia_id,
---     ap_id,
---     name,
---     city,
---     country,
---     iata,
---     icao,
---     latitude,
---     longitude,
---     altitude,
---     timezone,
---     dst,
---     tztext,
---     TYPE,
---     source
--- FROM
---     airport_fdw.airports;
+INSERT INTO airports_copy (
+    gaia_id,
+    ap_id,
+    name,
+    city,
+    country,
+    iata,
+    icao,
+    latitude,
+    longitude,
+    altitude,
+    timezone,
+    dst,
+    tztext,
+    TYPE,
+    source)
+SELECT
+    gaia_id,
+    ap_id,
+    name,
+    city,
+    country,
+    iata,
+    icao,
+    latitude,
+    longitude,
+    altitude,
+    timezone,
+    dst,
+    tztext,
+    TYPE,
+    source
+FROM
+    airport_fdw.airports;
 
 -- Create intermediate routes table.
--- CREATE TABLE intermediate_routes (
---     gaia_src_id bigint,
---     gaia_dst_id bigint,
---     airline text,
---     al_id int,
---     src_ap varchar(4),
---     src_ap_id int,
---     dst_ap varchar(4),
---     dst_ap_id int,
---     codeshare char(1),
---     stops int,
---     equipment text
--- );
+CREATE TABLE intermediate_routes (
+    gaia_src_id bigint,
+    gaia_dst_id bigint,
+    airline text,
+    al_id int,
+    src_ap varchar(4),
+    src_ap_id int,
+    dst_ap varchar(4),
+    dst_ap_id int,
+    codeshare char(1),
+    stops int,
+    equipment text
+);
 
--- INSERT INTO intermediate_routes (
---     airline,
---     al_id,
---     src_ap,
---     src_ap_id,
---     dst_ap,
---     dst_ap_id,
---     codeshare,
---     stops,
---     equipment)
--- SELECT
---     airline,
---     al_id,
---     src_ap,
---     src_ap_id,
---     dst_ap,
---     dst_ap_id,
---     codeshare,
---     stops,
---     equipment
--- FROM
---     rawdata_routes;
-
--- Collect the foreign keys from airports_copy table.
--- UPDATE
---     intermediate_routes
--- SET
---     (gaia_src_id) = (
---         SELECT
---             gaia_id
---         FROM
---             airports_copy
---         WHERE
---             airports_copy.ap_id = intermediate_routes.src_ap_id);
-
--- UPDATE
---     intermediate_routes
--- SET
---     (gaia_dst_id) = (
---         SELECT
---             gaia_id
---         FROM
---             airports_copy
---         WHERE
---             airports_copy.ap_id = intermediate_routes.dst_ap_id);
-
--- Remove records that are missing foreign keys.
--- DELETE FROM intermediate_routes
--- WHERE gaia_src_id IS NULL
---     OR gaia_dst_id IS NULL;
-
--- DROP TABLE airports_copy;
-
--- Finally, we can insert the data into the routes table.
-INSERT INTO airport_fdw.routes (
-    -- gaia_src_id,
-    -- gaia_dst_id,
+INSERT INTO intermediate_routes (
     airline,
     al_id,
     src_ap,
@@ -304,8 +248,6 @@ INSERT INTO airport_fdw.routes (
     stops,
     equipment)
 SELECT
-    -- gaia_src_id,
-    -- gaia_dst_id,
     airline,
     al_id,
     src_ap,
@@ -316,10 +258,68 @@ SELECT
     stops,
     equipment
 FROM
-    -- intermediate_routes;
     rawdata_routes;
 
--- DROP TABLE intermediate_routes;
+-- Collect the foreign keys from airports_copy table.
+UPDATE
+    intermediate_routes
+SET
+    (gaia_src_id) = (
+        SELECT
+            gaia_id
+        FROM
+            airports_copy
+        WHERE
+            airports_copy.ap_id = intermediate_routes.src_ap_id);
+
+UPDATE
+    intermediate_routes
+SET
+    (gaia_dst_id) = (
+        SELECT
+            gaia_id
+        FROM
+            airports_copy
+        WHERE
+            airports_copy.ap_id = intermediate_routes.dst_ap_id);
+
+-- Remove records that are missing foreign keys.
+DELETE FROM intermediate_routes
+WHERE gaia_src_id IS NULL
+    OR gaia_dst_id IS NULL;
+
+DROP TABLE airports_copy;
+
+-- Finally, we can insert the data into the routes table.
+INSERT INTO airport_fdw.routes (
+    gaia_src_id,
+    gaia_dst_id,
+    airline,
+    al_id,
+    src_ap,
+    src_ap_id,
+    dst_ap,
+    dst_ap_id,
+    codeshare,
+    stops,
+    equipment)
+SELECT
+    gaia_src_id,
+    gaia_dst_id,
+    airline,
+    al_id,
+    src_ap,
+    src_ap_id,
+    dst_ap,
+    dst_ap_id,
+    codeshare,
+    stops,
+    equipment
+FROM
+    intermediate_routes;
+    -- rawdata_routes;
+
+DROP TABLE intermediate_routes;
 
 -- Alternative approach: update airport_fdw.routes data in-place.
 -- This approach exercises the UPDATE path rather than the INSERT path.

--- a/production/sql/tests/test.sql
+++ b/production/sql/tests/test.sql
@@ -14,9 +14,9 @@ FROM
     airport_fdw.airports a
 WHERE
     r1.src_ap = 'SEA'
-    AND r1.dst_ap_id = r2.src_ap_id
+    AND r1.gaia_dst_id = r2.gaia_src_id
     AND r2.dst_ap = 'OTP'
-    AND a.ap_id = r1.dst_ap_id
+    AND a.gaia_id = r1.gaia_dst_id
 ORDER BY
     a.name;
 
@@ -29,10 +29,10 @@ FROM
     airport_fdw.airports a
 WHERE
     r1.src_ap = 'SEA'
-    AND r1.dst_ap_id = r2.src_ap_id
+    AND r1.gaia_dst_id = r2.gaia_src_id
     AND r2.dst_ap = 'OTP'
     AND r2.airline = 'RO'
-    AND r1.dst_ap_id = a.ap_id
+    AND r1.gaia_dst_id = a.gaia_id
 ORDER BY
     a.city;
 
@@ -48,7 +48,7 @@ FROM
     airport_fdw.routes r2
 WHERE
     r1.src_ap = 'SEA'
-    AND r1.dst_ap_id = r2.src_ap_id
+    AND r1.gaia_dst_id = r2.gaia_src_id
     AND r2.dst_ap = 'OTP'
 ORDER BY
     r1.src_ap,
@@ -69,7 +69,7 @@ FROM
     airport_fdw.routes r2
 WHERE
     r1.src_ap = 'SEA'
-    AND r1.dst_ap_id = r2.src_ap_id
+    AND r1.gaia_dst_id = r2.gaia_src_id
     AND r2.dst_ap = 'OTP'
     AND r1.airline <> 'RO'
     AND r2.airline <> 'RO'


### PR DESCRIPTION
This change enables the validation of reference updating and access in the FDW:

- the setup script now initializes the references of the routes table to the airport table. This also exercises the read of the gaia_id field.
- the test script now joins on these references and gaia_id, where possible, instead of using the original data identifiers.

Note that due to the additional database operations, the execution time of the script has increased to ~40s on my system.