### PR TITLE
Fix two build breaks

### DIFF
--- a/production/db/storage_engine/CMakeLists.txt
+++ b/production/db/storage_engine/CMakeLists.txt
@@ -200,6 +200,7 @@ set(GAIA_DB_CATALOG_TEST_PRIVATE_INCLUDES
 add_library(gaia_db_catalog_test "tests/db_catalog_test_base.cpp")
 target_include_directories(gaia_db_catalog_test PRIVATE ${GAIA_DB_CATALOG_TEST_PRIVATE_INCLUDES})
 target_link_libraries(gaia_db_catalog_test PRIVATE gaia_common gaia_se_client gaia_schema_loader gtest)
+set_target_properties(gaia_db_catalog_test PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS}")
 
 add_gtest(test_rdb_object_converter "tests/test_rdb_object_converter.cpp" "${FLATBUFFERS_INC};${GEN_DIR};${GAIA_STORAGE_ENGINE_TEST_INCLUDES}" "rocks_wrapper")
 add_gtest(test_record_list tests/test_record_list.cpp "${GAIA_STORAGE_ENGINE_TEST_INCLUDES}" "gaia_common;gaia_storage")

--- a/production/sql/src/gaia_fdw_adapter.cpp
+++ b/production/sql/src/gaia_fdw_adapter.cpp
@@ -5,6 +5,14 @@
 
 #include "gaia_fdw_adapter.hpp"
 
+/*
+ * PostgresSQL "port.h" tries to replace printf() and friends with macros to
+ * their own versions. This leads to build error in other headers like spdlog.
+ */
+#ifdef fprintf
+#undef fprintf
+#endif
+
 #include <sstream>
 
 #include "catalog_core.hpp"


### PR DESCRIPTION
Two minor build fixes to pass local build on my machine.

1. The C++ build flat need to include `-DSPDLOG_FMT_EXTERNAL`.
2. It seems postgres headers defines their own macro for printf family of methods. I need to undefine fprintf otherwise will have a build error from spdlog headers.
