### PR TITLE
Add back the fmt linking directive

### DIFF
--- a/production/common/CMakeLists.txt
+++ b/production/common/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(gaia_common STATIC
   src/logger_manager.cpp)
 target_include_directories(gaia_common PUBLIC ${GAIA_COMMON_INCLUDES})
 
+target_link_libraries(gaia_common fmt)
+
 target_link_libraries(gaia_common spdlog)
 
 target_link_libraries(gaia_common spdlog_setup)


### PR DESCRIPTION
To enable non-RELEASE builds again.