### PR TITLE
Add gdev output stage

### DIFF
--- a/dev_tools/gdev/README.md
+++ b/dev_tools/gdev/README.md
@@ -208,13 +208,19 @@ outputs are made available while building production.
 * `[web]`
     List of web dependencies to download into build folder. One dependency per line.
 * `[pre_run]`
-    List of commands to run before the main run. Commands are run in the build folder in the Docker
-    image for the current build rule. One command per line. The dependencies defined in `[apt]`,
-    `[env]`, `[gaia]`, `[git]`, `[pip]`, and `[web]` sections become available for use in this
-    section.
+    List of commands to run before `[run]` section. Commands are run in the build folder in the
+    Docker image for the current build rule. One command per line. The dependencies defined in
+    `[apt]`, `[env]`, `[gaia]`, `[git]`, `[pip]`, and `[web]` sections become available for use in
+    this section.
 * `[run]`
-    List of commands to run after pre_run. This is the final stage for the build rule. Commands are
-    run in the build folder in the Docker image for the current build rule. One command per line.
+    List of commands to run after `[pre_run]` section. This is the final stage for the build rule.
+    Commands are run in the build folder in the Docker image for the current build rule. One command
+    per line.
+* `[output]`
+    List of outputs after the `[run]` section. By default, the entire filesystem (`/`) is the
+    single output of the `gdev.cfg`. If another `gdev.cfg` lists the current target as a
+    dependency in its `[gaia]` section, only the outputs defined here (or `/` if no outputs are
+    defined) are copied. One output file or folder per line.
 
 ### Docker image `/source` and `/build`
 Source code from `<repo_root>` is copied to the Docker image in the `[pre_run]` step. In the Docker

--- a/dev_tools/gdev/gdev/cmd/gen/gaia/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/gaia/dockerfile.py
@@ -13,12 +13,29 @@ class GenGaiaDockerfile(GenAbcDockerfile):
         return GenGaiaCfg(self.options)
 
     @memoize
+    async def get_copy_section(self) -> str:
+        copy_section_parts = []
+        if copy_section := await super()._get_copy_section():
+            copy_section_parts.append(copy_section)
+        if set(self.cfg.path.parent.iterdir()) - {self.cfg.path}:
+            copy_section_parts.append(
+                f'COPY {self.cfg.path.parent.context()} {self.cfg.path.parent.image_source()}'
+            )
+        copy_section = '\n'.join(copy_section_parts)
+
+        self.log.debug(f'{copy_section = }')
+
+        return copy_section
+
+    @memoize
     async def get_input_dockerfiles(self) -> Iterable[GenAbcDockerfile]:
-        from ..run.dockerfile import GenRunDockerfile
+        from ..output.dockerfile import GenOutputDockerfile
 
         input_dockerfiles = []
         for section_line in await self.cfg.get_section_lines():
-            input_dockerfiles.append(GenRunDockerfile(replace(self.options, target=section_line)))
+            input_dockerfiles.append(
+                GenOutputDockerfile(replace(self.options, target=section_line))
+            )
         input_dockerfiles = tuple(input_dockerfiles)
 
         self.log.debug(f'{input_dockerfiles = }')

--- a/dev_tools/gdev/gdev/cmd/gen/output/__init__.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/__init__.py
@@ -1,0 +1,1 @@
+"""Commands for building and running docker images with direct output dependencies."""

--- a/dev_tools/gdev/gdev/cmd/gen/output/build.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/build.py
@@ -1,0 +1,9 @@
+from .dockerfile import GenOutputDockerfile
+from .._abc.build import GenAbcBuild
+
+
+class GenOutputBuild(GenAbcBuild):
+
+    @property
+    def dockerfile(self) -> GenOutputDockerfile:
+        return GenOutputDockerfile(self.options)

--- a/dev_tools/gdev/gdev/cmd/gen/output/cfg.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/cfg.py
@@ -1,0 +1,5 @@
+from .._abc.cfg import GenAbcCfg
+
+
+class GenOutputCfg(GenAbcCfg):
+    pass

--- a/dev_tools/gdev/gdev/cmd/gen/output/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/dockerfile.py
@@ -1,0 +1,49 @@
+from typing import Iterable
+
+from gdev.third_party.atools import memoize
+from .cfg import GenOutputCfg
+from .._abc.dockerfile import GenAbcDockerfile
+
+
+class GenOutputDockerfile(GenAbcDockerfile):
+
+    @property
+    def cfg(self) -> GenOutputCfg:
+        return GenOutputCfg(self.options)
+
+    @memoize
+    async def get_copy_section(self) -> str:
+        copy_section_parts = []
+        for input_dockerfile in await self.get_input_dockerfiles():
+            if lines := await self.cfg.get_section_lines():
+                for line in lines:
+                    copy_section_parts.append(
+                        f'COPY --from={await input_dockerfile.get_name()} {line} {line}'
+                    )
+            elif copy_section := await super()._get_copy_section():
+                copy_section_parts.append(copy_section)
+        copy_section = '\n'.join(copy_section_parts)
+
+        self.log.debug(f'{copy_section = }')
+
+        return copy_section
+
+    @memoize
+    async def get_env_section(self) -> str:
+        from ..pre_run.dockerfile import GenPreRunDockerfile
+
+        env_section = await GenPreRunDockerfile(self.options).get_env_section()
+
+        self.log.debug(f'{env_section = }')
+
+        return env_section
+
+    @memoize
+    async def get_input_dockerfiles(self) -> Iterable[GenAbcDockerfile]:
+        from ..run.dockerfile import GenRunDockerfile
+
+        input_dockerfiles = tuple([GenRunDockerfile(self.options)])
+
+        self.log.debug(f'{input_dockerfiles = }')
+
+        return input_dockerfiles

--- a/dev_tools/gdev/gdev/cmd/gen/output/push.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/push.py
@@ -1,0 +1,9 @@
+from .build import GenOutputBuild
+from .._abc.push import GenAbcPush
+
+
+class GenOutputPush(GenAbcPush):
+
+    @property
+    def build(self) -> GenOutputBuild:
+        return GenOutputBuild(self.options)

--- a/dev_tools/gdev/gdev/cmd/gen/output/run.py
+++ b/dev_tools/gdev/gdev/cmd/gen/output/run.py
@@ -1,0 +1,9 @@
+from .build import GenOutputBuild
+from .._abc.run import GenAbcRun
+
+
+class GenOutputRun(GenAbcRun):
+
+    @property
+    def build(self) -> GenOutputBuild:
+        return GenOutputBuild(self.options)

--- a/dev_tools/gdev/gdev/cmd/gen/pre_run/dockerfile.py
+++ b/dev_tools/gdev/gdev/cmd/gen/pre_run/dockerfile.py
@@ -48,10 +48,10 @@ class GenPreRunDockerfile(GenAbcDockerfile):
         input_dockerfiles = tuple([
             GenAptDockerfile(self.options),
             GenEnvDockerfile(self.options),
-            GenGaiaDockerfile(self.options),
             GenGitDockerfile(self.options),
             GenPipDockerfile(self.options),
             GenWebDockerfile(self.options),
+            GenGaiaDockerfile(self.options),
         ])
 
         self.log.debug(f'{input_dockerfiles = }')


### PR DESCRIPTION
The `[output]` stage allows us to specify the outputs of a `gdev.cfg`
after everything has finished running. By default, omitting the
`[output]` definition is equivalent to specifying the entire filesystem
as the output like so.
```
[output]
/
```

We may instead specify specific files or folders.
```
[output]
{build_dir('bar')}/
/opt/some_file
```

When we then include these targets in the `[gaia]` section of another
`gdev.cfg` like so...
```
[gaia]
foo
bar
```
the resulting Dockerfile would have contents similar to
```
COPY --from=foo__run / /
COPY --from=bar__run /build/ /build/
COPY --from=bar__run /opt/some_file /opt/some_file
```

Utilizing this can help us discard intermediate build artifacts that we
don't wish to propagate to later build stages.