### PR TITLE
Fix rules integration test failure

### DIFF
--- a/production/rules/event_manager/tests/test_rule_integration.cpp
+++ b/production/rules/event_manager/tests/test_rule_integration.cpp
@@ -252,6 +252,7 @@ protected:
 
     static void TearDownTestSuite()
     {
+        gaia::rules::shutdown_rules_engine();
         end_session();
         gaia_log::shutdown();
     }


### PR DESCRIPTION
At @daxhaw's suggestion, I added a call to `shutdown_rules_engine()` to the `TearDownTestSuite()` override in this class, to fix the following sporadic failure. (The failure was frequent enough that I have good confidence this fix resolves the issue, although I don't know if there are deeper root causes to address.)

```
[       OK ] rule_integration_test.test_parallel (1106 ms)
AddressSanitizer:DEADLYSIGNAL
=================================================================
==52537==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x00000052e285 bp 0x7efc7427e8d0 sp 0x7efc7427e8c0 T4)
==52537==The signal is caused by a READ memory access.
==52537==Hint: address points to the zero page.
[----------] 1 test from rule_integration_test (1106 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1471 ms total)
[  PASSED  ] 1 test.
    #0 0x52e284 in std::__shared_ptr<spdlog::logger, (__gnu_cxx::_Lock_policy)2>::get() const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h
    #1 0x52e244 in std::__shared_ptr_access<spdlog::logger, (__gnu_cxx::_Lock_policy)2, false, false>::_M_get() const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:1021:66
    #2 0x52e1f4 in std::__shared_ptr_access<spdlog::logger, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:1015:9
    #3 0x6b8844 in void gaia::common::logging::logger_t::trace<unsigned int>(char const*, unsigned int const&) /source/production/inc/internal/common/logger.hpp:120:9
    #4 0x6b5c1b in gaia::db::type_registry_t::create(unsigned int) /source/production/db/storage_engine/src/type_metadata.cpp:239:20
    #5 0x6b5692 in gaia::db::type_registry_t::get(unsigned int) /source/production/db/storage_engine/src/type_metadata.cpp:207:12
    #6 0x68eaad in gaia::db::gaia_ptr::create(unsigned long, unsigned int, unsigned long, void const*) /source/production/db/storage_engine/src/gaia_ptr.cpp:38:50
    #7 0x68c864 in gaia::direct_access::gaia_base_t::insert(unsigned int, unsigned long, void const*) /source/production/direct_access/src/gaia_base.cpp:183:5
    #8 0x605516 in gaia::direct_access::gaia_object_t<4294963200u, gaia::event_log::event_log_t, gaia::event_log::event_log, gaia::event_log::event_logT, 0ul>::insert_row(flatbuffers::FlatBufferBuilder&) /source/production/inc/public/direct_access/gaia_object.inc:133:12
    #9 0x602a3c in gaia::event_log::event_log_t::insert_row(unsigned int, unsigned int, unsigned long, unsigned short, unsigned long, bool) /build/production/schemas/generated/gaia_event_log.h:46:16
    #10 0x5ff350 in gaia::rules::rule_thread_pool_t::log_events(gaia::rules::rule_thread_pool_t::invocation_t&) /source/production/rules/event_manager/src/rule_thread_pool.cpp:48:13
    #11 0x6037e5 in gaia::rules::rule_thread_pool_t::invoke_rule(gaia::rules::rule_thread_pool_t::invocation_t&) /source/production/rules/event_manager/inc/rule_thread_pool.hpp:119:13
    #12 0x600a45 in gaia::rules::rule_thread_pool_t::rule_worker() /source/production/rules/event_manager/src/rule_thread_pool.cpp:159:9
    #13 0x60227c in gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0::operator()() const /source/production/rules/event_manager/src/rule_thread_pool.cpp:66:32
    #14 0x60222c in void std::__invoke_impl<void, gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0>(std::__invoke_other, gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:60:14
    #15 0x6021bc in std::__invoke_result<gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0>::type std::__invoke<gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0>(gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:95:14
    #16 0x602194 in void std::thread::_Invoker<std::tuple<gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:244:13
    #17 0x602164 in std::thread::_Invoker<std::tuple<gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:251:11
    #18 0x602048 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&)::$_0> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:195:13
    #19 0x7efc8f809d83  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6d83)
    #20 0x7efc8f5ca608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9608)
    #21 0x7efc8f4ce292 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x122292)
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h in std::__shared_ptr<spdlog::logger, (__gnu_cxx::_Lock_policy)2>::get() const
Thread T4 created by T0 here:
    #0 0x4c304d in pthread_create (/build/production/rules/event_manager/test_rule_integration+0x4c304d)
    #1 0x7efc8f80a048 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd7048)
    #2 0x5ff6ae in gaia::rules::rule_thread_pool_t::rule_thread_pool_t(unsigned long, gaia::rules::rule_stats_manager_t&) /source/production/rules/event_manager/src/rule_thread_pool.cpp:66:16
    #3 0x5d42c0 in std::_MakeUniq<gaia::rules::rule_thread_pool_t>::__single_object std::make_unique<gaia::rules::rule_thread_pool_t, unsigned long&, gaia::rules::rule_stats_manager_t&>(unsigned long&, gaia::rules::rule_stats_manager_t&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:857:34
    #4 0x5cc92a in gaia::rules::event_manager_t::init(gaia::rules::event_manager_settings_t&) /source/production/rules/event_manager/src/event_manager.cpp:80:21
    #5 0x54f718 in gaia::rules::test::initialize_rules_engine(gaia::rules::event_manager_settings_t&) /source/production/rules/event_manager/tests/event_manager_test_helpers.cpp:13:43
    #6 0x542743 in rule_integration_test::SetUpTestSuite() /source/production/rules/event_manager/tests/test_rule_integration.cpp:250:9
    #7 0x5ad5a5 in testing::TestSuite::RunSetUpTestSuite() /source/third_party/production/googletest/googletest/include/gtest/gtest.h:947:7
    #8 0x5c584d in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::TestSuite, void>(testing::TestSuite*, void (testing::TestSuite::*)(), char const*) /source/third_party/production/googletest/googletest/src/gtest.cc:2433:10
    #9 0x5ad32a in void testing::internal::HandleExceptionsInMethodIfSupported<testing::TestSuite, void>(testing::TestSuite*, void (testing::TestSuite::*)(), char const*) /source/third_party/production/googletest/googletest/src/gtest.cc:2469:14
    #10 0x58dd04 in testing::TestSuite::Run() /source/third_party/production/googletest/googletest/src/gtest.cc:2811:3
    #11 0x59ac12 in testing::internal::UnitTestImpl::RunAllTests() /source/third_party/production/googletest/googletest/src/gtest.cc:5338:44
    #12 0x5c701d in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /source/third_party/production/googletest/googletest/src/gtest.cc:2433:10
    #13 0x5aec5a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /source/third_party/production/googletest/googletest/src/gtest.cc:2469:14
    #14 0x59a753 in testing::UnitTest::Run() /source/third_party/production/googletest/googletest/src/gtest.cc:4925:10
    #15 0x5cc390 in RUN_ALL_TESTS() /source/third_party/production/googletest/googletest/include/gtest/gtest.h:2473:46
    #16 0x5cc375 in main /source/third_party/production/googletest/googletest/src/gtest_main.cc:45:10
    #17 0x7efc8f3d30b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```