### PR TITLE
Update .gitignore after SDK changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # Build files.
 build/
+bin/
+target/
 cmake-build-*/
 
 # Emacs backups.
@@ -27,3 +29,9 @@ dist/
 
 # Mac OS index files.
 .DS_Store
+
+# Java IDE files.
+.classpath
+.factorypath
+.project
+.settings/


### PR DESCRIPTION
After I merged the SDK changes and did a clean build, my `git status` view looked like this:
```
Untracked files:

../third_party/production/flatbuffers/.classpath
../third_party/production/rocksdb/java/jmh/.classpath
../third_party/production/rocksdb/java/jmh/.factorypath
../third_party/production/rocksdb/java/jmh/.project
../third_party/production/rocksdb/java/jmh/.settings/
../third_party/production/rocksdb/java/jmh/bin/
../third_party/production/rocksdb/java/jmh/target/
```
I'm adding these extensions and directory names to `.gitignore`, assuming that they don't conflict with anything we need to check in.