### PR TITLE
[GAIAPLAT-464] Add a system shutdown function

### DIFF
--- a/demos/incubator/main.cpp
+++ b/demos/incubator/main.cpp
@@ -577,4 +577,5 @@ int main(int argc, const char**argv) {
 
     init_storage();
     sim.run();
+    gaia::system::shutdown();
 }

--- a/production/inc/gaia/rules/rules.hpp
+++ b/production/inc/gaia/rules/rules.hpp
@@ -244,7 +244,7 @@ public:
 class initialization_error : public gaia::common::gaia_exception
 {
 public:
-    initialization_error(bool is_already_initialized);
+    initialization_error();
 };
 
 /**

--- a/production/inc/gaia/system.hpp
+++ b/production/inc/gaia/system.hpp
@@ -27,6 +27,11 @@ namespace system
  */
 void initialize(const char* gaia_config_file = nullptr);
 
+/**
+ *  Shutdown the Gaia sub systems
+ */
+void shutdown();
+
 /*@}*/
 } // namespace system
 /*@}*/

--- a/production/rules/event_manager/inc/event_manager.hpp
+++ b/production/rules/event_manager/inc/event_manager.hpp
@@ -41,7 +41,7 @@ public:
      */
     event_manager_t(event_manager_t&) = delete;
     void operator=(event_manager_t const&) = delete;
-    static event_manager_t& get(bool is_initializing = false);
+    static event_manager_t& get(bool require_initialized = true);
     static const char* s_gaia_log_event_rule;
 
     /**
@@ -91,9 +91,9 @@ private:
     std::atomic_bool m_is_initialized = false;
 
     // Protect initialization and shutdown from happening concurrently.
-    // Note, that the public rules engine APIs are not designed to be
+    // Note that the public rules engine APIs are not designed to be
     // thread safe.
-    std::mutex m_init_lock;
+    std::recursive_mutex m_init_lock;
 
     // Hash table of all rules registered with the system.
     // The key is the rulset_name::rule_name.

--- a/production/rules/event_manager/src/rule_checker.cpp
+++ b/production/rules/event_manager/src/rule_checker.cpp
@@ -37,16 +37,9 @@ duplicate_rule::duplicate_rule(const rule_binding_t& binding, bool duplicate_key
     m_message = message.str();
 }
 
-initialization_error::initialization_error(bool is_already_initialized)
+initialization_error::initialization_error()
 {
-    if (is_already_initialized)
-    {
-        m_message = "The event manager has already been initialized.";
-    }
-    else
-    {
-        m_message = "The event manager has not been initialized yet.";
-    }
+    m_message = "The rules engine has not been initialized yet.";
 }
 
 invalid_subscription::invalid_subscription(gaia::db::triggers::event_type_t event_type, const char* reason)

--- a/production/rules/event_manager/tests/event_manager_test_helpers.cpp
+++ b/production/rules/event_manager/tests/event_manager_test_helpers.cpp
@@ -9,8 +9,8 @@
 
 void gaia::rules::test::initialize_rules_engine(event_manager_settings_t& settings)
 {
-    bool is_initializing = true;
-    event_manager_t::get(is_initializing).init(settings);
+    bool require_initialized = false;
+    event_manager_t::get(require_initialized).init(settings);
     initialize_rules();
 }
 

--- a/production/rules/event_manager/tests/test_rule_integration.cpp
+++ b/production/rules/event_manager/tests/test_rule_integration.cpp
@@ -464,8 +464,12 @@ TEST_F(rule_integration_test, test_parallel)
 
 TEST_F(rule_integration_test, test_reinit)
 {
+    // Should be okay to call shutdown twice.
     gaia::rules::shutdown_rules_engine();
-    EXPECT_THROW(gaia::rules::shutdown_rules_engine(), initialization_error);
+    gaia::rules::shutdown_rules_engine();
+
+    // Should be okay to call init twice.
+    gaia::rules::initialize_rules_engine();
     gaia::rules::initialize_rules_engine();
 }
 

--- a/production/rules/event_manager/tests/test_system_init.cpp
+++ b/production/rules/event_manager/tests/test_system_init.cpp
@@ -67,8 +67,12 @@ void rule(const rule_context_t*)
 
 TEST_F(system_init_test, system_initialized_valid_conf)
 {
+
     rule_binding_t binding("ruleset", "rulename", rule);
     subscription_list_t subscriptions;
+
+    // Should be a no-op if the system has not been initialized
+    gaia::system::shutdown();
 
     gaia::system::initialize("./gaia.conf");
     gaia_id_t table_id = load_catalog();
@@ -81,7 +85,7 @@ TEST_F(system_init_test, system_initialized_valid_conf)
     unsubscribe_rules();
     list_subscribed_rules(nullptr, nullptr, nullptr, nullptr, subscriptions);
 
-    end_session();
+    gaia::system::shutdown();
 }
 
 TEST_F(system_init_test, system_invalid_conf_path)

--- a/production/system/src/gaia_system.cpp
+++ b/production/system/src/gaia_system.cpp
@@ -6,6 +6,7 @@
 #include "gaia/db/catalog.hpp"
 #include "gaia/db/db.hpp"
 #include "gaia/exception.hpp"
+#include "gaia/rules/rules.hpp"
 #include "gaia/system.hpp"
 #include "cpptoml.h"
 #include "logger.hpp"
@@ -93,4 +94,13 @@ void gaia::system::initialize(const char* gaia_config_file)
     gaia::rules::initialize_rules_engine(root_config);
 
     cleanup_init_state.dismiss();
+}
+
+void gaia::system::shutdown()
+{
+    // Shutdown in reverse order of initialization. Shutdown functions should
+    // not fail even if the component has not been initialized.
+    gaia::rules::shutdown_rules_engine();
+    gaia::db::end_session();
+    gaia_log::shutdown();
 }


### PR DESCRIPTION
Adding a system shutdown will allow the user to clean up our system "nicely" and avoid a potential segfault on shutdown.  A deeper investigation is warranted post-November release to look at our bring up and tear down design wrt to static singletons and order of construction/destruction.  The core issue is that rules that are executing can execute functions on database objects that have already been cleaned up.  See [GAIAPLAT-464](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-464) for further details.

These changes include:

- Adding a `gaia::system::shutdown()` function
- Changing the rules engine to allow multiple calls to `initialize_rules_engine` or `shutdown_rules_engine` without erroring
- Changes to tests to verify intended behavior.
- Adding shutdown call to the incubator demo