### PR TITLE
Replace libdw with libdwarf as backward-cpp DWARF backend

### DIFF
--- a/third_party/production/backward/CMakeLists.txt
+++ b/third_party/production/backward/CMakeLists.txt
@@ -1,6 +1,8 @@
 # backward-cpp dependencies (one of several options):
-# "libdw provides access to DWARF debug information stored inside ELF files."
-find_library(LIBDW_LIBRARY dw REQUIRED)
+# "libdwarf is a library to consume and produce DWARF debug information."
+# (libelf is a dependency of libdwarf)
+find_library(LIBELF_LIBRARY elf REQUIRED)
+find_library(LIBDWARF_LIBRARY dwarf REQUIRED)
 
 message(CHECK_START "Looking for backward")
 find_package(Backward QUIET CONFIG)

--- a/third_party/production/backward/gdev.cfg
+++ b/third_party/production/backward/gdev.cfg
@@ -1,5 +1,6 @@
 [apt]
-libdw-dev
+libelf-dev
+libdwarf-dev
 
 [gaia]
 third_party/production/cmake


### PR DESCRIPTION
I've been getting inexplicable segfaults in `libdw` when `backward-cpp` produces an unhandled exception stack trace, so I'm switching to `libdwarf`, which should provide equivalent functionality. In my tests, the repro scenario no longer segfaulted and the stack trace looked just as detailed.