### PR TITLE
Fix llvm test build break

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -48,6 +48,7 @@ cmake \
     -DFAIL_ON_WARNINGS:BOOL=OFF \
     --log-level=VERBOSE -Wno-dev \
     {enable_if('GaiaRelease')}-DCMAKE_MODULE_PATH=/usr/local/lib/cmake/CPackDebHelper \
+    {enable_if('GaiaLLVMTests')}-DBUILD_GAIA_LLVM_TESTS=ON \
     {enable_if_any('GaiaRelease','GaiaLLVMTests')}-DLLVM_ENABLE_EH=ON \
     {enable_if_any('GaiaRelease','GaiaLLVMTests')}-DLLVM_BUILD_TOOLS=OFF \
     {enable_if_any('GaiaRelease','GaiaLLVMTests')}-DCLANG_BUILD_TOOLS=OFF \

--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -96,7 +96,7 @@ set(CPACK_DEBHELPER_VERBOSE ON)
 # Build rpm
 set(CPACK_GENERATOR "RPM")
 
-if(BUILD_GAIA_RELEASE)
+if((BUILD_GAIA_RELEASE) AND (NOT BUILD_GAIA_LLVM_TESTS))
   # Load the CPackDebHelper module, this will:
   #   - Add "DEB" to the CPACK_GENERATOR variable.
   #   - Parse the files in CPACK_DEBHELPER_INPUT with configure_file().


### PR DESCRIPTION
Fix the GaiaLLVMTests build flavor. We should not load the CPackDebHelper module under this mode. 