### PR TITLE
Fix llvm test config

### DIFF
--- a/third_party/production/TranslationEngineLLVM/clang/test/lit.site.cfg.py.in
+++ b/third_party/production/TranslationEngineLLVM/clang/test/lit.site.cfg.py.in
@@ -28,7 +28,7 @@ config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.use_z3_solver = lit_config.params.get('USE_Z3_SOLVER', "@USE_Z3_SOLVER@")
 config.gaia_binary_dir = "@GAIA_PROD_BUILD@"
-config.gaia_source_dir = "@GAIA_SOURCE@"
+config.gaia_source_dir = "@GAIA_REPO@"
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
One more fix is needed for LLVM tests as we no longer pass in GAIA_SOURCE from cmake command.