### PR TITLE
Fix SIGILL from rocksdb

### DIFF
--- a/third_party/production/rocksdb/CMakeLists.txt
+++ b/third_party/production/rocksdb/CMakeLists.txt
@@ -205,13 +205,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   endif(HAS_ARMV8_CRC)
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
 
+option(PORTABLE "build a portable binary" OFF)
+option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
+
 # Avoid SIGILL in rocksdb::LRUCache
 # https://github.com/cockroachdb/cockroach/issues/16843
 set(PORTABLE ON)
-#set(FORCE_SSE42 ON)
+set(FORCE_SSE42 ON)
 
-option(PORTABLE "build a portable binary" OFF)
-option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 if(PORTABLE)
   # MSVC does not need a separate compiler flag to enable SSE4.2; if nmmintrin.h
   # is available, it is available by default.


### PR DESCRIPTION
We've seen illegal instruction segmentation faults with our teamcity builds of `gaia_se_server` when run on our own machines.  @senderista did a little digging and found this issue:  [16843](https://github.com/cockroachdb/cockroach/issues/16843).  This fix follows their own recommendation to turn PORTABLE and FORCE_SSE42 both ON.  

I have verified that the binary produced by teamcity from this branch executes on my Ubuntu20.04 (Ubuntu).
