### PR TITLE
Improve field_access error handling for null string data

### DIFF
--- a/production/db/inc/payload_types/field_access.hpp
+++ b/production/db/inc/payload_types/field_access.hpp
@@ -51,6 +51,18 @@ public:
     unhandled_field_type(size_t field_type);
 };
 
+class cannot_set_null_string_value : public gaia::common::gaia_exception
+{
+public:
+    cannot_set_null_string_value();
+};
+
+class cannot_update_null_string_value : public gaia::common::gaia_exception
+{
+public:
+    cannot_update_null_string_value();
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // GENERAL FIELD ACCESS API NOTES
 //


### PR DESCRIPTION
This change does some cleanup around how null string values are handled by the field_access API. There is no functional change - I just changed what kind of exceptions would be raised in some scenarios involving null string values.

Here's a summary:

1. strings as scalar attributes: The API can handle reading null values (set through EDC via `nullable_string`), but does not support updating null to non-null or setting a non-null string to null. The latter 2 scenarios, which I call updating and setting in the exception names, now throw explicit exceptions instead of failing in less pleasant ways.

2. strings as array elements: The API cannot read a null value - it works differently than the API for scalar value, so that it would always return a valid pointer even if the offset value is set to 0 (this case receives special handling in the scalar case). So this situation is flagged as an invalid serialization error. It already was handled like this in one place, but in another it was handled as if it could happen, which was the wrong handling. I added some comments on this as well. Setting null values has also been updated to raise an exception.