### PR TITLE
Disable treating warnings as errors for RocksDB build

### DIFF
--- a/third_party/production/rocksdb/CMakeLists.txt
+++ b/third_party/production/rocksdb/CMakeLists.txt
@@ -265,7 +265,7 @@ if(HAVE_THREAD_LOCAL)
   add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
 endif()
 
-option(FAIL_ON_WARNINGS "Treat compile warnings as errors" ON)
+option(FAIL_ON_WARNINGS "Treat compile warnings as errors" OFF)
 if(FAIL_ON_WARNINGS)
   if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")


### PR DESCRIPTION
This fixes a build error with clang-10:
```
/source/third_party/production/rocksdb/db/db_impl/db_impl_compaction_flush.cc:1039:21: error: loop variable 'newf' of type 'const std::pair<int, rocksdb::FileMetaData>' creates a copy from type 'const std::pair<int, rocksdb::FileMetaData>' [-Werror,-Wrange-loop-construct]
    for (const auto newf : c->edit()->GetNewFiles()) {
                    ^
/source/third_party/production/rocksdb/db/db_impl/db_impl_compaction_flush.cc:1039:10: note: use reference type 'const std::pair<int, rocksdb::FileMetaData> &' to prevent copying
    for (const auto newf : c->edit()->GetNewFiles()) {
         ^~~~~~~~~~~~~~~~~
                    &
/source/third_party/production/rocksdb/db/db_impl/db_impl_compaction_flush.cc:1139:21: error: loop variable 'newf' of type 'const std::pair<int, rocksdb::FileMetaData>' creates a copy from type 'const std::pair<int, rocksdb::FileMetaData>' [-Werror,-Wrange-loop-construct]
    for (const auto newf : c->edit()->GetNewFiles()) {
                    ^
/source/third_party/production/rocksdb/db/db_impl/db_impl_compaction_flush.cc:1139:10: note: use reference type 'const std::pair<int, rocksdb::FileMetaData> &' to prevent copying
    for (const auto newf : c->edit()->GetNewFiles()) {
```