### PR TITLE
Enable ASan in SDK and incubator demo

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -30,6 +30,12 @@ set(GAIA_INC "${GAIA_PROD}/inc")
 set(FLATBUFFERS "${GAIA_REPO}/third_party/production/flatbuffers")
 set(FLATBUFFERS_INC "${FLATBUFFERS}/include")
 
+# Enable AddressSanitizer in debug mode.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address")
+endif()
+
 # Helper function for setting up our tests.
 function(set_test target arg result)
   add_test(NAME ${target}_${arg} COMMAND ${target} ${arg})

--- a/demos/incubator/CMakeLists.txt
+++ b/demos/incubator/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(translate_incubator_ruleset ALL
 add_library(gaia SHARED IMPORTED GLOBAL)
 set_target_properties(gaia PROPERTIES IMPORTED_LOCATION ${GAIA_PROD_BUILD}/sdk/libgaia.so)
 
-add_executable(incubator 
+add_executable(incubator
     main.cpp
     ${GENERATED_OUTPUTS}/incubator_rules.cpp
 )
@@ -62,5 +62,6 @@ configure_file("${PROJECT_SOURCE_DIR}/gaia_log.conf" "${PROJECT_BINARY_DIR}/gaia
 
 add_dependencies(incubator translate_incubator_ruleset)
 set_target_properties(incubator PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS}")
+set_target_properties(incubator PROPERTIES LINK_FLAGS "${GAIA_LINK_FLAGS}")
 target_include_directories(incubator PRIVATE ${GAIA_INCUBATOR_DEMO_INCLUDES})
 target_link_libraries(incubator PRIVATE gaia rt pthread)

--- a/production/db/storage_engine/CMakeLists.txt
+++ b/production/db/storage_engine/CMakeLists.txt
@@ -190,6 +190,9 @@ if(JAVA_FOUND AND JNI_FOUND AND EXISTS "${GREMLIN_CONSOLE_PATH}")
     se_jni_headers)
   set_target_properties(jni_se_client PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -Wno-deprecated-register -Wno-unused-parameter")
   set_target_properties(jni_se_client PROPERTIES LINK_FLAGS "${GAIA_LINK_FLAGS}")
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_options(jni_se_client PRIVATE "-shared-libasan")
+  endif()
 endif()
 
 set(GAIA_DB_CATALOG_TEST_PRIVATE_INCLUDES

--- a/production/sdk/CMakeLists-incubator.txt
+++ b/production/sdk/CMakeLists-incubator.txt
@@ -16,6 +16,12 @@ set(GAIA_LINK_FLAGS "-ggdb -pthread")
 set(GENERATED_OUTPUTS "${CMAKE_BINARY_DIR}")
 set(GAIA_INC "${GAIA}/include")
 
+# Enable AddressSanitizer in debug mode.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address")
+endif()
+
 set(GAIA_INCUBATOR_DEMO_INCLUDES
   ${GAIA_INC}/common
   ${GAIA_INC}/direct_access

--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -16,10 +16,13 @@ set(SDK_LINK_LIBRARIES
   gaia_system
   -Wl,--no-whole-archive
 )
-
 target_link_libraries(gaia PRIVATE
   ${SDK_LINK_LIBRARIES}
 )
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_options(gaia PRIVATE "-shared-libasan")
+endif()
 
 install(TARGETS gaia DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/production/tools/gaia_translate/CMakeLists.txt
+++ b/production/tools/gaia_translate/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.17)
 enable_testing()
 project(gaiat VERSION 0.0.0)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
-
 set(TRANSLATION_ENGINE_INCLUDES
   ${GAIA_REPO}/third_party/production/TranslationEngineLLVM/clang/include
   ${GAIA_REPO}/third_party/production/TranslationEngineLLVM/llvm/include
@@ -31,6 +29,8 @@ link_directories(
 
 add_executable(gaiat ${GAIAT_SRCS})
 target_include_directories(gaiat PRIVATE ${TRANSLATION_ENGINE_INCLUDES})
+set_target_properties(gaiat PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS}")
+set_target_properties(gaiat PROPERTIES LINK_FLAGS "${GAIA_LINK_FLAGS}")
 target_link_libraries(gaiat
   PRIVATE
   rt


### PR DESCRIPTION
I have tested building the whole SDK and incubator demo locally with `CMAKE_BUILD_TYPE=Debug` to enable ASan.