### PR TITLE
Set active txn state to terminated on abrupt session shutdown

### DIFF
--- a/production/db/storage_engine/inc/se_server.hpp
+++ b/production/db/storage_engine/inc/se_server.hpp
@@ -84,7 +84,7 @@ private:
     thread_local static inline std::vector<std::thread> s_session_owned_threads{};
     static inline bool s_disable_persistence = false;
     static inline bool s_reinitialize_persistent_store = false;
-    static inline std::unique_ptr<gaia::db::memory_manager::memory_manager_t> memory_manager{};
+    static inline std::unique_ptr<gaia::db::memory_manager::memory_manager_t> s_memory_manager{};
 
     // Keeps track of stack allocators belonging to the current transaction executing on this thread.
     // On commit/rollback, all stack allocators belonging to a transaction are removed from this list.


### PR DESCRIPTION
This fixes an fd leak when a transaction was orphaned due to rude termination (either the client called `end_session()` without calling `commit_transaction()` or `rollback_transaction()`, or the client crashed). This happened during build, so presumably there's an issue with `gaiac` not properly terminating transactions, but we need to be robust to this scenario regardless.

@mihirj1993 please review the `REVIEW` comments in this checkin, since I'm not entirely sure how we should be calling the MM interfaces when we effectively rollback an active transaction.