### PR TITLE
Fix sdk break

### DIFF
--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -155,4 +155,4 @@ install(FILES ${GAIA_REPO}/demos/incubator/incubator.ddl DESTINATION examples/in
 install(FILES ${GAIA_REPO}/demos/incubator/incubator.ruleset DESTINATION examples/incubator)
 install(FILES ${GAIA_REPO}/demos/incubator/incubator.cpp DESTINATION examples/incubator)
 install(FILES ${GAIA_REPO}/demos/incubator/README.md DESTINATION examples/incubator)
-install(FILES ${PROJECT_SOURCE_DIR}/CMakeLists_incubator.txt DESTINATION examples/incubator RENAME CMakeLists.txt)
+install(FILES ${PROJECT_BINARY_DIR}/CMakeLists_incubator.txt DESTINATION examples/incubator RENAME CMakeLists.txt)


### PR DESCRIPTION
Sloppily did not fix up the sdk CMake file to deal with incubator demo changes.  Thanks to @waynelwarren for finding.