### PR TITLE
Fix ubuntu 18.04 gdev build

### DIFF
--- a/dev_tools/gdev/gdev/cmd/gen/_abc/run.py
+++ b/dev_tools/gdev/gdev/cmd/gen/_abc/run.py
@@ -32,9 +32,7 @@ class GenAbcRun(Dependency, ABC):
 
             f'--hostname {await self.build.dockerfile.get_name()}',
             f'--platform linux/{self.options.platform}',
-
-            # We use shared memory in production. Just assume we'll always need this.
-            f'--shm-size 1gb',
+            f'--privileged',
 
             # Mount our current repo as /source/. Modifications to source in the container
             # are reflected on host.

--- a/dev_tools/gdev/gdev/dependency.py
+++ b/dev_tools/gdev/gdev/dependency.py
@@ -267,7 +267,9 @@ class Dependency:
         if parsed_args['args'] and parsed_args['args'][0] == '--':
             parsed_args['args'] = parsed_args['args'][1:]
         parsed_args['args'] = ' '.join(parsed_args['args'])
-        parsed_args['cfg_enables'] = frozenset(parsed_args['cfg_enables'])
+        parsed_args['cfg_enables'] = frozenset([
+            parsed_args['base_image'], *parsed_args['cfg_enables'], *parsed_args['mixins']
+        ])
         parsed_args['mixins'] = frozenset(parsed_args['mixins'])
         parsed_args['ports'] = frozenset(str(port) for port in parsed_args['ports'])
 

--- a/production/common/CMakeLists.txt
+++ b/production/common/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(gaia_common cpptoml)
 target_link_libraries(gaia_common fmt)
 target_link_libraries(gaia_common spdlog)
 target_link_libraries(gaia_common spdlog_setup)
+target_link_libraries(gaia_common stdc++fs)
 
 # SYSLOG logging is temporarily disabled: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-387
 # (To enable syslog logging -DSPDLOG_ENABLE_SYSLOG)

--- a/production/db/storage_engine/inc/rdb_object_converter.hpp
+++ b/production/db/storage_engine/inc/rdb_object_converter.hpp
@@ -46,21 +46,21 @@ public:
     inline void write_uint64(uint64_t value)
     {
         // Convert to network order (big endian).
-        u_int64_t result = ::htobe64(value);
+        u_int64_t result = htobe64(value);
         write(reinterpret_cast<const char* const>(&result), sizeof(result));
     }
 
     inline void write_uint32(uint32_t value)
     {
         // Convert to network order (big endian).
-        uint32_t result = ::htobe32(value);
+        uint32_t result = htobe32(value);
         write(reinterpret_cast<const char* const>(&result), sizeof(result));
     }
 
     inline void write_uint16(uint16_t value)
     {
         // Convert to network order (big endian).
-        u_int16_t result = ::htobe16(value);
+        u_int16_t result = htobe16(value);
         write(reinterpret_cast<const char* const>(&result), sizeof(result));
     }
 
@@ -119,7 +119,7 @@ public:
         const char* value_ptr = read(sizeof(uint64_t));
         uint64_t value = *(reinterpret_cast<const uint64_t*>(value_ptr));
         // Convert to host byte order.
-        out = ::be64toh(value);
+        out = be64toh(value);
     }
 
     inline void read_uint32(uint32_t& out)
@@ -127,7 +127,7 @@ public:
         const char* value_ptr = read(sizeof(uint32_t));
         uint32_t value = *(reinterpret_cast<const uint32_t*>(value_ptr));
         // Convert to host byte order.
-        out = ::be32toh(value);
+        out = be32toh(value);
     }
 
     inline void read_uint16(uint16_t& out)
@@ -135,7 +135,7 @@ public:
         const char* value_ptr = read(sizeof(uint16_t));
         uint16_t value = *(reinterpret_cast<const uint16_t*>(value_ptr));
         // Convert to host byte order.
-        out = ::be16toh(value);
+        out = be16toh(value);
     }
 
     inline void read_byte(uint8_t& out)

--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -1,14 +1,15 @@
 [apt]
-flatbuffers-compiler
+clang-format
+clang-tidy
+{enable_if('GaiaRelease')}debhelper
+{enable_if('ubuntu:20.04')}flatbuffers-compiler
 libcap-dev
 {enable_if_not_any('GaiaRelease', 'GaiaLLVMTests')}libexplain-dev
-libstdc++-10-dev
+{enable_if('ubuntu:18.04')}libstdc++-8-dev
+{enable_if('ubuntu:20.04')}libstdc++-10-dev
 openjdk-8-jdk
 python3-dev
-clang-tidy
-clang-format
 {enable_if('GaiaRelease')}rpm
-{enable_if('GaiaRelease')}debhelper
 
 [gaia]
 # FIXME production/sql/src has a dependency on demos/airport_q1.
@@ -43,6 +44,13 @@ psutil
 # We can't put this in third_party/production/postgresql/gdev.cfg because clang-8 isn't yet available when that is run.
 echo "LD_PRELOAD = '$(clang -print-file-name=libclang_rt.asan-$(uname -m).so)'" >> /etc/postgresql/12/main/environment
 echo "ASAN_OPTIONS = 'detect_leaks=0'" >> /etc/postgresql/12/main/environment
+
+# Ubuntu 18.04 still defaults python to Python2. We want to detect python as Python3.
+{enable_if('ubuntu:18.04')}update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
+
+{enable_if('ubuntu:18.04')}apt-add-repository ppa:hnakamur/flatbuffers \
+    && apt-get update \
+    && apt-get install -y flatbuffers-compiler
 
 [run]
 cmake \

--- a/third_party/production/rocksdb/CMakeLists.txt
+++ b/third_party/production/rocksdb/CMakeLists.txt
@@ -211,7 +211,6 @@ option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 # Avoid SIGILL in rocksdb::LRUCache
 # https://github.com/cockroachdb/cockroach/issues/16843
 set(PORTABLE ON)
-set(FORCE_SSE42 ON)
 
 if(PORTABLE)
   # MSVC does not need a separate compiler flag to enable SSE4.2; if nmmintrin.h


### PR DESCRIPTION
Fixes a few problems with building on ubuntu 18.04.
1. Python must by Python3, not Python2. Our cmake for pybind gets confused otherwise.
2. Install `flabuffers-compiler' and `libstdc++-{8|10}-dev` based on which ubuntu we're on.
3. Explicitly link `libstdc++-fs` so that it works with `libstdc++-8-dev`.
4. Fixed a compile error with `<endian.h>` macro causing unexpected unqualified id.


`gdev build --base-image ubuntu:18.04` 
and
`gdev run --base-image ubuntu:18.04 -- ctest`
both succeed.