### PR TITLE
Add --disable-persistence-after-recovery flag to SE server

### DIFF
--- a/production/db/storage_engine/inc/se_server.hpp
+++ b/production/db/storage_engine/inc/se_server.hpp
@@ -53,9 +53,17 @@ class server
         size_t size);
 
 public:
-    static void run(bool disable_persistence = false, bool reinitialize_persistent_store = false);
+    enum class persistence_mode_t : uint8_t
+    {
+        e_default,
+        e_disabled,
+        e_disabled_after_recovery,
+        e_reinitialized_on_startup,
+    };
+    static void run(persistence_mode_t persistence_mode = persistence_mode_t::e_default);
     static void register_object_deallocator(std::function<void(gaia_offset_t)>);
     static constexpr char c_disable_persistence_flag[] = "--disable-persistence";
+    static constexpr char c_disable_persistence_after_recovery_flag[] = "--disable-persistence-after-recovery";
     static constexpr char c_reinitialize_persistent_store_flag[] = "--reinitialize-persistent-store";
 
 private:
@@ -82,8 +90,9 @@ private:
     thread_local static inline bool s_session_shutdown = false;
     thread_local static inline int s_session_shutdown_eventfd = -1;
     thread_local static inline std::vector<std::thread> s_session_owned_threads{};
-    static inline bool s_disable_persistence = false;
-    static inline bool s_reinitialize_persistent_store = false;
+
+    static inline persistence_mode_t s_persistence_mode{persistence_mode_t::e_default};
+
     static inline std::unique_ptr<gaia::db::memory_manager::memory_manager_t> s_memory_manager{};
 
     // Keeps track of stack allocators belonging to the current transaction executing on this thread.

--- a/production/db/storage_engine/src/se_server_exec.cpp
+++ b/production/db/storage_engine/src/se_server_exec.cpp
@@ -18,6 +18,8 @@ static void usage()
         << "Usage: gaia_se_server ["
         << gaia::db::server::c_disable_persistence_flag
         << " | "
+        << gaia::db::server::c_disable_persistence_after_recovery_flag
+        << " | "
         << gaia::db::server::c_reinitialize_persistent_store_flag
         << "]"
         << std::endl
@@ -27,8 +29,7 @@ static void usage()
 
 int main(int argc, char* argv[])
 {
-    bool disable_persistence = false;
-    bool reinitialize_persistent_store = false;
+    server::persistence_mode_t persistence_mode{server::persistence_mode_t::e_default};
 
     // We currently accept only one argument.
     if (argc > 2)
@@ -44,11 +45,15 @@ int main(int argc, char* argv[])
     {
         if (strcmp(argv[i], gaia::db::server::c_disable_persistence_flag) == 0)
         {
-            disable_persistence = true;
+            persistence_mode = server::persistence_mode_t::e_disabled;
+        }
+        else if (strcmp(argv[i], gaia::db::server::c_disable_persistence_after_recovery_flag) == 0)
+        {
+            persistence_mode = server::persistence_mode_t::e_disabled_after_recovery;
         }
         else if (strcmp(argv[i], gaia::db::server::c_reinitialize_persistent_store_flag) == 0)
         {
-            reinitialize_persistent_store = true;
+            persistence_mode = server::persistence_mode_t::e_reinitialized_on_startup;
         }
         else
         {
@@ -60,5 +65,5 @@ int main(int argc, char* argv[])
         }
     }
 
-    gaia::db::server::run(disable_persistence, reinitialize_persistent_store);
+    gaia::db::server::run(persistence_mode);
 }


### PR DESCRIPTION
This flag allows you to read the persistent image into memory at startup but then avoid logging any updates into the persistent image. It should be useful for test and debugging scenarios where we have added schema to the catalog so need to read it on startup, but don't want to invoke persistence for any of our own updates.