### PR TITLE
[SCRATCH] Use hackathon demo to test multi-anonymous-reference tables

### DIFF
--- a/scratch/wayne/hack/hack-comments.ddl
+++ b/scratch/wayne/hack/hack-comments.ddl
@@ -58,9 +58,9 @@ create table FaceScanLog (
     ScanSignatureId string,  // References a Person? Not used.
     ScanDate string,
     ScanTime int32,
-    person_scan references Person,
-    building_scan references Building,
-    stranger_scan references Stranger
+    references Person,
+    references Building,
+    references Stranger
 );
 create table Room (
     RoomId string,

--- a/scratch/wayne/hack/hack.ruleset
+++ b/scratch/wayne/hack/hack.ruleset
@@ -856,12 +856,12 @@ ruleset hack_ruleset
 
             // Connect the M:N relationship between Building and Person.
             auto scan_log = gaia::hack::FaceScanLog_t::get(FaceScanLog.gaia_id());
-            building.building_scan_FaceScanLog_list().insert(scan_log);
+            building.FaceScanLog_list().insert(scan_log);
 
             // If Person was found, connect. Otherwise it's a Stranger.
             if (person)
             {
-                person.person_scan_FaceScanLog_list().insert(scan_log);
+                person.FaceScanLog_list().insert(scan_log);
             }
             else {
                 // Find or Create the Stranger record and connect it.
@@ -879,7 +879,7 @@ ruleset hack_ruleset
                     // There's a rule triggered here.
                     sw.update_row();
                 }
-                stranger.stranger_scan_FaceScanLog_list().insert(scan_log);
+                stranger.FaceScanLog_list().insert(scan_log);
             }
 
             send_message(ScanLogId, time(NULL));

--- a/scratch/wayne/hack/main.cpp
+++ b/scratch/wayne/hack/main.cpp
@@ -93,17 +93,17 @@ void dump_db() {
     for (auto& f : FaceScanLog_t::list())
     {
         printf("FACESCANLOG: ID=%s, %s %d\n", f.ScanLogId(), f.ScanDate(), f.ScanTime());
-        auto building = f.building_scan_Building();
+        auto building = f.Building();
         if (building)
         {
             printf("   BUILDING: ID=%s, %s\n", building.BuildingId(), building.BuildingName());
         }
-        auto person = f.person_scan_Person();
+        auto person = f.Person();
         if (person)
         {
             printf("   PERSON: ID=%s, %s %s\n", person.PersonId(), person.FirstName(), person.LastName());
         }
-        auto stranger = f.stranger_scan_Stranger();
+        auto stranger = f.Stranger();
         if (stranger)
         {
             printf("   STRANGER: ID=%s, %d\n", stranger.StrangerId(), stranger.ScanCount());
@@ -112,7 +112,7 @@ void dump_db() {
     for (auto& s : Stranger_t::list())
     {
         printf("STRANGER: ID=%s, count=%d\n", s.StrangerId(), s.ScanCount());
-        for (auto& f : s.stranger_scan_FaceScanLog_list())
+        for (auto& f : s.FaceScanLog_list())
         {
             printf("   FACESCANLOG: ID=%s, %s %d\n", f.ScanLogId(), f.ScanDate(), f.ScanTime());
         }


### PR DESCRIPTION
After PR-440 merges, it will be permissible to have multiple anonymous reference statements in the same table, provided all of the owners are different tables.