### PR TITLE
Warn on skipping table creation

### DIFF
--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -522,7 +522,7 @@ gaia_id_t ddl_executor_t::create_table_impl(
                 // because current implementation will try to re-create all
                 // system tables on every startup and expect the creation to be
                 // skipped normally if the tables already exist.
-                gaia_log::catalog().warn("table \"{}\" (id: {}) already exists, skipping", full_table_name, id);
+                gaia_log::catalog().warn("Table '{}' (id: {}) already exists, skipping.", full_table_name, id);
             }
             return id;
         }


### PR DESCRIPTION
Fix for the following issue:

GAIAPLAT-577 [gaiac] should output if schema changes are not applied because a table already exists