### PR TITLE
Err on parsing illegal characters in DDL

### DIFF
--- a/demos/incubator/incubator.ddl
+++ b/demos/incubator/incubator.ddl
@@ -1,14 +1,14 @@
 create table if not exists incubator (
-      name : string,
-      is_on :  bool active,
-      min_temp : float active,
-      max_temp : float active
+      name string,
+      is_on bool active,
+      min_temp float active,
+      max_temp float active
 );
 
 create table if not exists sensor (
-      name : string,
-      timestamp : uint64,
-      value : float active,
+      name string,
+      timestamp uint64,
+      value float active,
       references incubator
 );
 

--- a/production/catalog/parser/src/lexer.ll
+++ b/production/catalog/parser/src/lexer.ll
@@ -78,38 +78,49 @@ blank [ \t\r]
 
 <<EOF>>      return yy::parser::make_END(loc);
 
+.            throw yy::parser::syntax_error(loc, "invalid character '" + std::string(yytext) + "'");
+
 %%
 
 yy::parser::symbol_type
-make_NUMBER (const std::string &s, const yy::parser::location_type& loc) {
+make_NUMBER(const std::string &s, const yy::parser::location_type& loc)
+{
     errno = 0;
-    long n = strtol (s.c_str(), NULL, 10);
-    if (! (INT_MIN <= n && n <= INT_MAX && errno != ERANGE)) {
-        throw yy::parser::syntax_error (loc, "integer is out of range: " + s);
+    long n = strtol(s.c_str(), NULL, 10);
+    if (! (INT_MIN <= n && n <= INT_MAX && errno != ERANGE))
+    {
+        throw yy::parser::syntax_error(loc, "integer is out of range: " + s);
     }
     return yy::parser::make_NUMBER ((int) n, loc);
 }
 
-void gaia::catalog::ddl::parser_t::scan_begin () {
+void gaia::catalog::ddl::parser_t::scan_begin()
+{
     yy_flex_debug = trace_scanning;
-    if (file.empty () || file == "-") {
+    if (file.empty () || file == "-")
+    {
         yyin = stdin;
-    } else if (!(yyin = fopen(file.c_str (), "r"))) {
+    }
+    else if (!(yyin = fopen(file.c_str (), "r")))
+    {
         std::cerr << "cannot open " << file << ": " << strerror(errno) << '\n';
         exit (EXIT_FAILURE);
     }
 }
 
-void gaia::catalog::ddl::parser_t::scan_end () {
+void gaia::catalog::ddl::parser_t::scan_end()
+{
     fclose(yyin);
     yylex_destroy();
 }
 
-void gaia::catalog::ddl::parser_t::scan_string_begin (const std::string& input) {
+void gaia::catalog::ddl::parser_t::scan_string_begin(const std::string& input)
+{
     yy_flex_debug = trace_scanning;
     yy_scan_string(input.c_str());
 }
 
-void gaia::catalog::ddl::parser_t::scan_string_end () {
+void gaia::catalog::ddl::parser_t::scan_string_end()
+{
     yylex_destroy();
 }

--- a/production/catalog/parser/tests/test_ddl_parser.cpp
+++ b/production/catalog/parser/tests/test_ddl_parser.cpp
@@ -223,3 +223,11 @@ TEST(catalog_ddl_parser_test, drop_database)
     EXPECT_EQ(drop_stmt->type, drop_type_t::drop_database);
     EXPECT_EQ(drop_stmt->name, "d");
 }
+
+TEST(catalog_ddl_parser_test, illegal_characters)
+{
+    parser_t parser;
+    EXPECT_NE(EXIT_SUCCESS, parser.parse_line("CREATE TABLE t(id : int8);"));
+    EXPECT_NE(EXIT_SUCCESS, parser.parse_line("CREATE : TABLE t(id int8);"));
+    EXPECT_NE(EXIT_SUCCESS, parser.parse_line("CREATE TABLE t(id - int8);"));
+}

--- a/production/schemas/test/addr_book/addr_book.ddl
+++ b/production/schemas/test/addr_book/addr_book.ddl
@@ -1,28 +1,28 @@
 create table if not exists employee (
-    name_first: string active,
-    name_last: string,
-    ssn: string,
-    hire_date: int64,
-    email: string,
-    web: string,
+    name_first string active,
+    name_last string,
+    ssn string,
+    hire_date int64,
+    email string,
+    web string,
     manages references employee
 );
 
 create table if not exists address (
-    street: string,
-    apt_suite: string,
-    city: string,
-    state: string,
-    postal: string,
-    country: string,
-    current: bool,
+    street string,
+    apt_suite string,
+    city string,
+    state string,
+    postal string,
+    country string,
+    current bool,
     addressee references employee
 );
 
 create table if not exists phone (
-    phone_number: string active,
-    type: string active,
-    primary: bool active,
+    phone_number string active,
+    type string active,
+    primary bool active,
     references address,
     references employee
 );


### PR DESCRIPTION
Previously, we used default rule in flex for unmatched characters. They are simply copied to the standard output and no error is thrown. (Reference link: http://westes.github.io/flex/manual/Matching.html#Matching)

As a result, all the following DDLs are accepted. 

```
CREATE TABLE t(id : int8);
CREATE : TABLE t(id int8);
CREATE TABLE t(id - int8);
```

This change adds a rule to capture all characters that are not matched, and throw an error on such encounters. 