### PR TITLE
Add more asserts to memory manager allocation interfaces

### DIFF
--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -74,6 +74,8 @@ address_offset_t memory_manager_t::allocate_internal(
     size_t memory_size,
     bool add_allocation_metadata)
 {
+    retail_assert(memory_size > 0, "Allocated memory size should not be zero!");
+
     address_offset_t allocated_memory_offset = c_invalid_offset;
 
     // Adjust the requested memory size, to ensure proper alignment.

--- a/production/db/memory_manager/src/stack_allocator.cpp
+++ b/production/db/memory_manager/src/stack_allocator.cpp
@@ -99,9 +99,15 @@ address_offset_t stack_allocator_t::allocate(
         validate_offset_alignment(old_slot_offset);
     }
 
-    // Adjust the requested memory size, to ensure proper alignment.
-    if (memory_size != 0)
+    if (memory_size == 0)
     {
+        retail_assert(
+            old_slot_offset != c_invalid_offset,
+            "A deallocation call was made without providing the address offset to deallocate!");
+    }
+    else
+    {
+        // Adjust the requested memory size, to ensure proper alignment.
         memory_size = calculate_allocation_size(memory_size);
         validate_size(memory_size);
     }


### PR DESCRIPTION
This change adds some asserts for flagging invalid calling scenarios of the memory manager interfaces.