### PR TITLE
Pass db name from the 'gaiac -d' option to drop statements

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -36,7 +36,7 @@ enum class operate_mode_t
     loading,
 };
 
-void start_repl(parser_t& parser, const string& dbname)
+void start_repl(parser_t& parser, const string& db_name)
 {
     gaia::db::begin_session();
     initialize_catalog();
@@ -72,7 +72,7 @@ void start_repl(parser_t& parser, const string& dbname)
             int parsing_result = parser.parse_line(line);
             if (parsing_result == EXIT_SUCCESS)
             {
-                execute(dbname, parser.statements);
+                execute(db_name, parser.statements);
             }
             else
             {

--- a/production/inc/gaia_internal/catalog/ddl_execution.hpp
+++ b/production/inc/gaia_internal/catalog/ddl_execution.hpp
@@ -48,7 +48,14 @@ inline void execute(const std::string& db_name, std::vector<std::unique_ptr<ddl:
             auto drop_stmt = dynamic_cast<ddl::drop_statement_t*>(stmt.get());
             if (drop_stmt->type == ddl::drop_type_t::drop_table)
             {
-                drop_table(drop_stmt->database, drop_stmt->name);
+                if (!drop_stmt->database.empty())
+                {
+                    drop_table(drop_stmt->database, drop_stmt->name);
+                }
+                else
+                {
+                    drop_table(db_name, drop_stmt->name);
+                }
             }
             else if (drop_stmt->type == ddl::drop_type_t::drop_database)
             {


### PR DESCRIPTION
Fix for the following issue.

[GAIAPLAT-578](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-578) [gaiac] Unable to drop a table even though I used the -d option in gaiac.

Summary: create statements are aware of the database name passed in from `gaiac -d` option while drop statements are not. This should fix the issue.