### PR TITLE
Remove steps that copy conf files for hello example

### DIFF
--- a/production/examples/hello/CMakeLists.txt
+++ b/production/examples/hello/CMakeLists.txt
@@ -62,10 +62,6 @@ add_executable(hello
   ${PROJECT_BINARY_DIR}/hello_rules.cpp
 )
 
-# The hello example uses a system configuration and logger configuration file.
-configure_file(${GAIA}/etc/gaia.conf ${PROJECT_BINARY_DIR}/gaia.conf)
-configure_file(${GAIA}/etc/gaia_log.conf ${PROJECT_BINARY_DIR}/gaia_log.conf)
-
 add_dependencies(hello translate_hello_ruleset)
 set_target_properties(hello PROPERTIES COMPILE_FLAGS ${GAIA_COMPILE_FLAGS})
 set_target_properties(hello PROPERTIES LINK_FLAGS ${GAIA_LINK_FLAGS})

--- a/production/examples/hello/run.sh
+++ b/production/examples/hello/run.sh
@@ -5,6 +5,4 @@
 # All rights reserved.
 #############################################
 
-cp /opt/gaia/etc/*.conf .
-
 ./hello


### PR DESCRIPTION
These steps are no longer necessary, now that initialize() knows to look under /opt/gaia/etc by itself. I have updated the documentation already.