### PR TITLE
Detect database name error early on in gaiac

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -301,20 +301,27 @@ int main(int argc, char* argv[])
     if (!valid_db_name(db_name))
     {
         cerr << c_error_prompt
-             << "The databse name '" + db_name + "' supplied from the command line is incorrectly formatted."
+             << "The database name '" + db_name + "' supplied from the command line is incorrectly formatted."
              << endl;
         exit(EXIT_FAILURE);
     }
 
+    // This indicates if we should try to create the database automatically. If
+    // the database name is derived from the ddl file name, we will try to
+    // create the database for the user. This is to keep backward compatible
+    // with existing build scripts. Use '-d <db_name>' to avoid this behavior.
+    // GAIAPLAT-585 tracks the work to remove this behavior.
+    bool create_db = false;
     if (!ddl_filename.empty() && db_name.empty())
     {
         db_name = get_db_name_from_filename(ddl_filename);
+        create_db = true;
     }
 
     if (!valid_db_name(db_name))
     {
         cerr << c_error_prompt
-             << "The databse name '" + db_name + "' derived from the filename is incorrectly formatted."
+             << "The database name '" + db_name + "' derived from the filename is incorrectly formatted."
              << endl;
         exit(EXIT_FAILURE);
     }
@@ -332,7 +339,7 @@ int main(int argc, char* argv[])
 
             if (!ddl_filename.empty())
             {
-                load_catalog(parser, ddl_filename, db_name);
+                load_catalog(parser, ddl_filename, db_name, create_db);
             }
 
             if (mode == operate_mode_t::generation)

--- a/production/inc/gaia_internal/catalog/ddl_execution.hpp
+++ b/production/inc/gaia_internal/catalog/ddl_execution.hpp
@@ -72,7 +72,9 @@ inline std::string get_db_name_from_filename(const std::string& ddl_filename)
     return db_name;
 }
 
-inline void load_catalog(ddl::parser_t& parser, const std::string& ddl_filename, const std::string& db_name)
+inline void load_catalog(
+    ddl::parser_t& parser, const std::string& ddl_filename,
+    const std::string& db_name, bool create_db = false)
 {
     common::retail_assert(!ddl_filename.empty(), "No ddl file specified.");
     common::retail_assert(!db_name.empty(), "No database specified.");
@@ -87,7 +89,7 @@ inline void load_catalog(ddl::parser_t& parser, const std::string& ddl_filename,
     int parsing_result = parser.parse(file_path.string());
     common::retail_assert(parsing_result == EXIT_SUCCESS, "Fail to parse the ddl file '" + ddl_filename + "'");
 
-    if (!ddl_filename.empty())
+    if (create_db)
     {
         create_database(db_name, false);
     }
@@ -100,7 +102,7 @@ inline void load_catalog(const char* ddl_filename)
     ddl::parser_t parser;
     std::string filename(ddl_filename);
     std::string db_name = get_db_name_from_filename(ddl_filename);
-    load_catalog(parser, filename, db_name);
+    load_catalog(parser, filename, db_name, true);
 }
 
 } // namespace catalog


### PR DESCRIPTION
Fix for the following issue:

[GAIAPLAT-514](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-514) [gaiac] A DDL file name cannot start with a number

`gaiac` generates the following error message for incorrectly formmated database name right now.
```
ERROR: Invalid FlatBuffers schema!
```

This change should detect database name error early on and report a more meaningful message to the user.