### PR TITLE
Hide debug only options in gaiac

### DIFF
--- a/production/catalog/gaiac/src/command.cpp
+++ b/production/catalog/gaiac/src/command.cpp
@@ -437,7 +437,7 @@ string command_usage()
          name, "Generate fbs for a given database."});
     output_table.add_row(
         {string() + c_command_prefix + c_generate_command + c_table_subcommand,
-         name, "Generate fbs for a given database."});
+         name, "Generate fbs for a given table."});
 #endif
     output_table.add_row(
         {string() + c_command_prefix + c_help_command, "", "Print help information."});

--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -183,12 +183,14 @@ string usage()
     ss << "Usage: gaiac [options] [ddl_file]\n\n"
           "  -d|--db-name <dbname>    Specify the database name.\n"
           "  -i|--interactive         Interactive prompt, as a REPL.\n"
-          "  -g|--generate            Generate fbs and gaia headers.\n"
+          "  -g|--generate            Generate direct access API header files.\n"
           "  -o|--output <path>       Set the path to all generated files.\n"
-          "  -t|--db-server-path      Start the Gaia DB server (for testing purposes).\n"
+#ifdef DEBUG
           "  -p|--parse-trace         Print parsing trace.\n"
           "  -s|--scan-trace          Print scanning trace.\n"
+          "  -t|--db-server-path      Start the DB server (for testing purposes).\n"
           "  --destroy-db             Destroy the persistent store.\n"
+#endif
           "  <ddl_file>               Process the DDLs in the file.\n"
           "                           In the absence of <dbname>, the ddl file basename will be used as the database name.\n"
           "                           The database will be created automatically.\n"


### PR DESCRIPTION
This PR merely hides the debug/build only options in gaiac help message. They will still be available in release build (as they are still needed for release build). More specifically, the following options won't be shown in the release build.

```
  -p|--parse-trace         Print parsing trace.
  -s|--scan-trace          Print scanning trace.
  -t|--db-server-path      Start the DB server (for testing purposes).
  --destroy-db             Destroy the persistent store.
```

https://gaiaplatform.atlassian.net/browse/GAIAPLAT-353