### PR TITLE
[GAIAPLAT-530] gaiac prints help when executed with no arguments

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -242,8 +242,8 @@ int main(int argc, char* argv[])
     // If no arguments are specified print the help.
     if (argc == 1)
     {
-        cout << usage() << endl;
-        exit(EXIT_SUCCESS);
+        cerr << usage() << endl;
+        exit(EXIT_FAILURE);
     }
 
     for (int i = 1; i < argc; ++i)


### PR DESCRIPTION
Note: the alternative is to start the `REPL`, as python and similar do. I opted for printing the help for 2 reasons:
1. It is in line with `gaiat`
2. Users may not be familiar with the REPL, and find it confusing as the default option.