### PR TITLE
Fix issue due to adjustment of raw memory allocation sizes

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -107,6 +107,8 @@ private:
     // due to other metadata created by the stack allocator, which is why we allot an additional 128 bytes of memory
     // to the initial stack allocator size per transaction.
     static constexpr size_t c_initial_txn_memory_size_bytes = 64 * 1024 + 128;
+    // Memory request sizes for stack allocators must be multiples of 64B.
+    static_assert(c_initial_txn_memory_size_bytes % 64 == 0);
 
     // Note that the transaction will incrementally request more memory for the stack allocator upto a certain maximum size
     // if it keeps running out of memory.

--- a/production/db/inc/memory_manager/base_memory_manager.hpp
+++ b/production/db/inc/memory_manager/base_memory_manager.hpp
@@ -52,9 +52,8 @@ public:
     // Sets stack_allocator_t execution flags.
     void set_execution_flags(const execution_flags_t& execution_flags);
 
-    // Helper functions for allocation alignment.
+    // Helper function for allocation alignment.
     static size_t calculate_allocation_size(size_t requested_size);
-    static size_t calculate_raw_allocation_size(size_t requested_size);
 
     // Sanity checks.
     static void validate_address_alignment(const uint8_t* const memory_address);

--- a/production/db/memory_manager/src/base_memory_manager.cpp
+++ b/production/db/memory_manager/src/base_memory_manager.cpp
@@ -73,30 +73,6 @@ size_t base_memory_manager_t::calculate_allocation_size(size_t requested_size)
     return (allocation_size < requested_size) ? 0 : allocation_size;
 }
 
-// Raw allocations need to be offset by 56B from 64B boundaries
-// and need to end the same way, which means that they should be adjusted
-// to the nearest higher alignment multiplier.
-size_t base_memory_manager_t::calculate_raw_allocation_size(size_t requested_size)
-{
-    if (requested_size < c_allocation_alignment)
-    {
-        return c_allocation_alignment;
-    }
-
-    size_t allocation_size = requested_size;
-    size_t extra_block_size = requested_size % c_allocation_alignment;
-
-    if (extra_block_size > 0)
-    {
-        // Bump the size to the next multiple of the allocation alignment.
-        allocation_size = requested_size - extra_block_size + c_allocation_alignment;
-    }
-
-    // Handle the extreme case in which the requested size is so large
-    // that we'd get an integer overflow in the preceding calculations.
-    return (allocation_size < requested_size) ? 0 : allocation_size;
-}
-
 void base_memory_manager_t::validate_address_alignment(const uint8_t* const memory_address)
 {
     auto memory_address_as_integer = reinterpret_cast<size_t>(memory_address);

--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -83,7 +83,9 @@ address_offset_t memory_manager_t::allocate_internal(
     }
     else
     {
-        memory_size = calculate_raw_allocation_size(memory_size);
+        retail_assert(
+            memory_size % c_allocation_alignment == 0,
+            "Requested raw memory size is not a multiple of 64B!");
     }
 
     validate_size(memory_size);

--- a/production/db/memory_manager/tests/test_memory_manager.cpp
+++ b/production/db/memory_manager/tests/test_memory_manager.cpp
@@ -90,7 +90,7 @@ TEST(memory_manager, advanced_operation)
     memory_manager.set_execution_flags(execution_flags);
     memory_manager.manage(memory, c_memory_size);
 
-    constexpr size_t c_stack_allocator_memory_size = 2000;
+    constexpr size_t c_stack_allocator_memory_size = 2048;
 
     // Make 3 allocations using a stack_allocator_t.
     unique_ptr<stack_allocator_t> stack_allocator = make_unique<stack_allocator_t>();

--- a/production/db/memory_manager/tests/test_stack_allocator.cpp
+++ b/production/db/memory_manager/tests/test_stack_allocator.cpp
@@ -51,7 +51,7 @@ TEST(memory_manager, stack_allocator)
     memory_manager.set_execution_flags(execution_flags);
     memory_manager.manage(memory, c_memory_size);
 
-    constexpr size_t c_stack_allocator_memory_size = 2000;
+    constexpr size_t c_stack_allocator_memory_size = 2048;
 
     unique_ptr<stack_allocator_t> stack_allocator = make_unique<stack_allocator_t>();
     stack_allocator->set_execution_flags(execution_flags);


### PR DESCRIPTION
A change proposed by Mihir made me realize that there is a current issue with the memory manager raw allocation interface: if it is used to request memory in sizes that are not a multiple of 64, an adjustment would be made, but because the adjusted size was not taken into consideration by the memory allocator, the adjustment would get leaked when the stack allocator would get deallocated.

To fix this in the simplest way, raw memory allocations are now required to be multiples of 64B. This also allows us to remove a memory size adjustment helper, so the code is simplified overall.

Note that this is not an issue with the current implementation, which does request memory in sizes that are 64B multiples. To ensure that this remains the case, I also added a static_assert.