### PR TITLE
Add hello example code to SDK package

### DIFF
--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -74,8 +74,9 @@ set(CPACK_RPM_PACKAGE_ARCHITECTURE amd64)
 set(CPACK_RPM_PACKAGE_DESCRIPTION "Gaia Platform SDK")
 set(CPACK_RPM_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.rpm)
 
-# Note: set this variable to use a custom RPM spec file. ATM the file does not work. https://gaiaplatform.atlassian.net/browse/GAIAPLAT-592
-# set(CPACK_RPM_USER_BINARY_SPECFILE ${PROJECT_SOURCE_DIR}/rpm/gaia.spec).
+# Note: set this variable to use a custom RPM spec file.
+# ATM the file does not work. https://gaiaplatform.atlassian.net/browse/GAIAPLAT-592
+# set(CPACK_RPM_USER_BINARY_SPECFILE ${PROJECT_SOURCE_DIR}/rpm/gaia.spec)
 
 # Set CPackDebHelper variables:
 #


### PR DESCRIPTION
Just packaging the hello code into the SDK package. Unlike the incubator project, there is no need to generate any file, however there are shell files that need to be copied as PROGRAMS, to ensure that their permissions are set to enable execution.