### PR TITLE
Fix timing issue in Release build

### DIFF
--- a/production/tools/gaia_translate/CMakeLists.txt
+++ b/production/tools/gaia_translate/CMakeLists.txt
@@ -61,6 +61,9 @@ add_custom_command(
       -I /usr/include/clang/10/include/
       -std=c++17
   COMMAND pkill -f -KILL gaia_db_server &
+  # In some contexts, the next attempt to start gaia_db_server precedes this kill, leading
+  # to a build failure. A short sleep is currently fixing that, but may not be the
+  # correct long-term solution.
   COMMAND sleep 1
   DEPENDS gaiac
   DEPENDS gaiat
@@ -99,6 +102,9 @@ add_custom_command(
     -I ${FLATBUFFERS_INC}
     -I /usr/include/clang/10/include/
   COMMAND pkill -f -KILL gaia_db_server &
+  # In some contexts, the next attempt to start gaia_db_server precedes this kill, leading
+  # to a build failure. A short sleep is currently fixing that, but may not be the
+  # correct long-term solution.
   COMMAND sleep 1
   DEPENDS gaiac
   DEPENDS gaiat


### PR DESCRIPTION
Performing native Release builds regularly resulted in a build issue near the end. The assumption was that a pkill command hadn't had the chance to operate before the next invocation of gaia_db_server, which would fail to start and then the build would stop.

This change adds two 1-second sleeps to a makefile. The build completes without problems this way.