### PR TITLE
Fix gaiac build warning

### DIFF
--- a/production/catalog/gaiac/src/command.cpp
+++ b/production/catalog/gaiac/src/command.cpp
@@ -167,7 +167,7 @@ void describe_table(const string& name)
     gaia_id_t table_id = c_invalid_gaia_id;
     {
         auto_transaction_t tx;
-        for (auto table : gaia_table_t::list())
+        for (auto& table : gaia_table_t::list())
         {
             string table_name{table.name()};
             string qualified_name{table.gaia_database().name()};


### PR DESCRIPTION
Quick fix for a build warning that I noticed earlier:

[ 85%] Building CXX object catalog/gaiac/CMakeFiles/gaiac.dir/home/laur/GitHub/GaiaPlatform/third_party/production/flatbuffers/src/code_generators.cpp.o
/home/laur/GitHub/GaiaPlatform/production/catalog/gaiac/src/command.cpp:170:19: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
        for (auto table : gaia_table_t::list())
                  ^
             const  &
[ 85%] Linking CXX executable gaiac
