### PR TITLE
Improve NOLINT comments for FDW code

### DIFF
--- a/production/sql/src/gaia_fdw.cpp
+++ b/production/sql/src/gaia_fdw.cpp
@@ -29,7 +29,8 @@ extern "C" Datum gaia_fdw_handler(PG_FUNCTION_ARGS)
     // To silence unused argument warning.
     fcinfo = nullptr;
 
-    FdwRoutine* routine = makeNode(FdwRoutine); // NOLINT (macro expansion)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    FdwRoutine* routine = makeNode(FdwRoutine);
 
     // Functions for scanning foreign tables.
     routine->GetForeignRelSize = gaia_get_foreign_rel_size;
@@ -81,7 +82,8 @@ extern "C" Datum gaia_fdw_handler(PG_FUNCTION_ARGS)
     routine->GetForeignRowMarkType = gaia_get_foreign_row_mark_type;
     routine->RefetchForeignRow = gaia_refetch_foreign_row;
 
-    PG_RETURN_POINTER(routine); // NOLINT (macro expansion)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    PG_RETURN_POINTER(routine);
 }
 
 /**
@@ -519,7 +521,8 @@ extern "C" List* gaia_plan_foreign_modify(
     // We don't return any private data from this method, just check that
     // gaia_id is not an INSERT or UPDATE target.
     CmdType operation = plan->operation;
-    RangeTblEntry* rte = planner_rt_fetch(result_relation, root); // NOLINT (macro expansion)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    RangeTblEntry* rte = planner_rt_fetch(result_relation, root);
     Relation rel = table_open(rte->relid, NoLock);
     TupleDesc tuple_desc = RelationGetDescr(rel);
     Bitmapset* modified_cols = nullptr;

--- a/production/sql/src/gaia_fdw_adapter.cpp
+++ b/production/sql/src/gaia_fdw_adapter.cpp
@@ -127,10 +127,13 @@ NullableDatum convert_to_nullable_datum(const data_holder_t& value)
         size_t pg_text_length = string_length + VARHDRSZ;
         text* pg_text = reinterpret_cast<text*>(palloc(pg_text_length));
 
-        SET_VARSIZE(pg_text, pg_text_length); // NOLINT (macro expansion)
-        memcpy(VARDATA(pg_text), value.hold.string_value, string_length); // NOLINT (macro expansion)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        SET_VARSIZE(pg_text, pg_text_length);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        memcpy(VARDATA(pg_text), value.hold.string_value, string_length);
 
-        nullable_datum.value = CStringGetDatum(pg_text); // NOLINT (macro expansion)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        nullable_datum.value = CStringGetDatum(pg_text);
         return nullable_datum;
     }
 
@@ -216,7 +219,8 @@ data_holder_t convert_to_data_holder(const Datum& value, data_type_t value_type)
         break;
 
     case data_type_t::e_string:
-        data_holder.hold.string_value = TextDatumGetCString(value); // NOLINT (macro expansion)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        data_holder.hold.string_value = TextDatumGetCString(value);
         break;
 
     default:


### PR DESCRIPTION
This PR changes FDW NOLINT comments into NOLINTNEXTLINE and restricts their impact to the specific warnings for which they were added.