### PR TITLE
Fix duplicate table creation in global db

### DIFF
--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "gaia/common.hpp"
+#include "gaia/db/catalog.hpp"
 #include "gaia/exception.hpp"
 #include "db_helpers.hpp"
 #include "fbs_generator.hpp"
@@ -693,7 +694,7 @@ inline gaia_id_t ddl_executor_t::find_db_id_no_lock(const string& dbname) const
 
 string ddl_executor_t::get_full_table_name(const string& db, const string& table)
 {
-    if (db.empty())
+    if (db.empty() || db == c_empty_db_name)
     {
         return table;
     }


### PR DESCRIPTION
A minor bug fix. Currently, there is a bug in loading table name caches that makes it possible to create a table of the same name in the global database, i.e. the following commands will create two `test` table in the global database.

```
./catalog/gaiac/gaiac -i
gaiac> create table test (name string);
gaiac> \q
./catalog/gaiac/gaiac -i
gaiac> create table test (name string);
```

The change should fix the issue by correcting the table names in the reloaded cache.