### PR TITLE
Fix LLVM tests to expect quoted catalog identifiers in error messages.

### DIFF
--- a/production/tools/tests/gaiat/integration_test_expected_hide_variable_warning_1.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_hide_variable_warning_1.ruleset
@@ -10,4 +10,4 @@ ruleset test
     }
 }
 
-// CHECK: Local variable declaration value hides catalog field entity of the same name.
+// CHECK: Local variable declaration 'value' hides catalog field entity of the same name.

--- a/production/tools/tests/gaiat/integration_test_expected_hide_variable_warning_2.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_hide_variable_warning_2.ruleset
@@ -11,4 +11,4 @@ ruleset test
     }
 }
 
-// CHECK: Local variable declaration incubator hides database table of the same name.
+// CHECK: Local variable declaration 'incubator' hides database table of the same name.

--- a/production/tools/tests/gaiat/integration_test_expected_no_relationship_error_1.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_no_relationship_error_1.ruleset
@@ -9,4 +9,4 @@ ruleset test
 	}
     }
 }
-// CHECK: No path between animal and other tables.
+// CHECK: No path between 'animal' and other tables.

--- a/production/tools/tests/gaiat/integration_test_expected_no_relationship_error_2.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_no_relationship_error_2.ruleset
@@ -9,4 +9,4 @@ ruleset test
 	}
     }
 }
-// CHECK: No path between tables actuator and animal.
+// CHECK: No path between tables 'actuator' and 'animal'.


### PR DESCRIPTION
Fix trivial LLVM test break.  This could only have been caught if LLVM specific tests were executed.  I only saw this because I took at look at TeamCity and saw that `ProductionGaiaLLVMTests_gdev` was failing.