### PR TITLE
remove db_test_helper local machine hack

### DIFF
--- a/production/inc/gaia_internal/db/db_test_helpers.hpp
+++ b/production/inc/gaia_internal/db/db_test_helpers.hpp
@@ -136,8 +136,6 @@ public:
         {
             cmd.append(" ");
             cmd.append(c_reinitialize_persistent_store_flag);
-            cmd.append(" ");
-            cmd.append("--data-dir /tmp/gaia_db");
         }
         std::cerr << cmd << std::endl;
         ::system(cmd.c_str());


### PR DESCRIPTION
Accidently checked this as part of the internal header re_org.  My bad.