### PR TITLE
Remove gdev.cfg dependency on incubator now that it is under production

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -32,7 +32,6 @@ third_party/production/spdlog_setup
 third_party/production/tabulate
 {enable_if_any('GaiaRelease','GaiaLLVMTests')}third_party/production/TranslationEngineLLVM
 {enable_if('GaiaRelease')}third_party/production/CPackDebHelper
-demos/incubator
 dev_tools/hooks
 
 {enable_if('GaiaLLVMTests')}[pip]


### PR DESCRIPTION
The production gdev.cfg file was pulling in demos/incubator/gdev.cfg so that the SDK could pull in those files when building the SDK package.  Now that the incubator demo was pulled in under production, we no longer need this dependency.  This caused Teamcity to skip the test running and publishing portion of the builds.  It also led to super fast (too fast) build times.

For those who care:

TeamCity was reporting Success (on Production_gdev) but no tests were being run (so it didn't say "Tests passed: 305, ignored :1").  If you look at the log for step 2 (ctest),  it had:
```
53
Step 2/3: ctest (Command Line)
15:37:53
  Starting: /opt/TeamCity/buildAgent/temp/agentTmp/custom_script11363796875326007051
15:37:53
  in directory: /opt/TeamCity/buildAgent/work/439cfbd06ea3043d
15:37:55
  rm: cannot remove '/tmp/build.gdev': Device or resource busy
15:37:56
  (production) Creating dockerfile /opt/TeamCity/buildAgent/work/439cfbd06ea3043d/.gdev/production/run.dockerfile.gdev
15:37:56
  
15:37:56
  Abort: File "<repo_root>/demos/incubator/gdev.cfg" must exist.
15:37:56
  Process exited with code 0
15:37:56
Step 3/3: push (Command Line)
```
