### PR TITLE
[GAIAPLAT-613] Rename underlying EDC gaia_* objects to edc_*

### DIFF
--- a/production/catalog/src/gaia_generate.cpp
+++ b/production/catalog/src/gaia_generate.cpp
@@ -269,9 +269,9 @@ static string generate_edc_struct(
     code.SetValue("TABLE_NAME", table_record.name());
     code.SetValue("POSITION", to_string(table_type_id));
 
-    code += "typedef gaia::direct_access::gaia_writer_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, internal::{{TABLE_NAME}}, internal::{{TABLE_NAME}}T> "
+    code += "typedef gaia::direct_access::edc_writer_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, internal::{{TABLE_NAME}}, internal::{{TABLE_NAME}}T> "
             "{{TABLE_NAME}}_writer;";
-    code += "struct {{TABLE_NAME}}_t : public gaia::direct_access::gaia_object_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, "
+    code += "struct {{TABLE_NAME}}_t : public gaia::direct_access::edc_object_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, "
             "internal::{{TABLE_NAME}}, internal::{{TABLE_NAME}}T> {";
 
     code.IncrementIdentLevel();
@@ -301,7 +301,7 @@ static string generate_edc_struct(
     }
 
     // Default public constructor.
-    code += "{{TABLE_NAME}}_t() : gaia_object_t(\"{{TABLE_NAME}}_t\") {}";
+    code += "{{TABLE_NAME}}_t() : edc_object_t(\"{{TABLE_NAME}}_t\") {}";
 
     // Below, a flatbuffer method is invoked as Create{{TABLE_NAME}}() or
     // as Create{{TABLE_NAME}}Direct. The choice is determined by whether any of the
@@ -327,7 +327,7 @@ static string generate_edc_struct(
         code += "{{TYPE}} {{FIELD_NAME}}() const {return {{FCN_NAME}}({{FIELD_NAME}});}";
     }
 
-    code += "using gaia_object_t::insert_row;";
+    code += "using edc_object_t::insert_row;";
 
     // The typed insert_row().
     string param_list("static gaia::common::gaia_id_t insert_row(");
@@ -357,7 +357,7 @@ static string generate_edc_struct(
     }
     param_list += "));";
     code += param_list;
-    code += "return gaia_object_t::insert_row(b);";
+    code += "return edc_object_t::insert_row(b);";
     code.DecrementIdentLevel();
     code += "}";
 
@@ -388,9 +388,9 @@ static string generate_edc_struct(
     }
 
     // The table range.
-    code += "static gaia::direct_access::gaia_container_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t>& list() {";
+    code += "static gaia::direct_access::edc_container_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t>& list() {";
     code.IncrementIdentLevel();
-    code += "static gaia::direct_access::gaia_container_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t> list;";
+    code += "static gaia::direct_access::edc_container_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t> list;";
     code += "return list;";
     code.DecrementIdentLevel();
     code += "}";
@@ -430,11 +430,11 @@ static string generate_edc_struct(
     code.DecrementIdentLevel();
     code += "private:";
     code.IncrementIdentLevel();
-    code += "friend struct gaia_object_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, internal::{{TABLE_NAME}}, "
+    code += "friend struct edc_object_t<c_gaia_type_{{TABLE_NAME}}, {{TABLE_NAME}}_t, internal::{{TABLE_NAME}}, "
             "internal::{{TABLE_NAME}}T>;";
 
     // The constructor.
-    code += "explicit {{TABLE_NAME}}_t(gaia::common::gaia_id_t id) : gaia_object_t(id, \"{{TABLE_NAME}}_t\") {}";
+    code += "explicit {{TABLE_NAME}}_t(gaia::common::gaia_id_t id) : edc_object_t(id, \"{{TABLE_NAME}}_t\") {}";
 
     // Finishing brace.
     code.DecrementIdentLevel();

--- a/production/direct_access/src/edc_base.cpp
+++ b/production/direct_access/src/edc_base.cpp
@@ -63,40 +63,40 @@ edc_already_inserted::edc_already_inserted(gaia_id_t parent, const char* parent_
 }
 
 //
-// gaia_base_t implementation
+// edc_base_t implementation
 //
 
 static_assert(sizeof(gaia_handle_t) == sizeof(gaia_ptr));
 
 template <typename T_ptr>
-constexpr T_ptr* gaia_base_t::to_ptr()
+constexpr T_ptr* edc_base_t::to_ptr()
 {
     return reinterpret_cast<T_ptr*>(&m_record);
 }
 
 template <typename T_ptr>
-constexpr const T_ptr* gaia_base_t::to_const_ptr() const
+constexpr const T_ptr* edc_base_t::to_const_ptr() const
 {
     return reinterpret_cast<const T_ptr*>(&m_record);
 }
 
 // We only support a single specialization of our ptr functions above using gaia_ptr
-template gaia_ptr* gaia_base_t::to_ptr();
-template const gaia_ptr* gaia_base_t::to_const_ptr() const;
+template gaia_ptr* edc_base_t::to_ptr();
+template const gaia_ptr* edc_base_t::to_const_ptr() const;
 
-gaia_base_t::gaia_base_t(const char* gaia_typename)
+edc_base_t::edc_base_t(const char* gaia_typename)
     : m_typename(gaia_typename)
 {
     *(to_ptr<gaia_ptr>()) = gaia_ptr();
 }
 
-gaia_base_t::gaia_base_t(const char* gaia_typename, gaia_id_t id)
+edc_base_t::edc_base_t(const char* gaia_typename, gaia_id_t id)
     : m_typename(gaia_typename)
 {
     *(to_ptr<gaia_ptr>()) = gaia_ptr(id);
 }
 
-gaia_id_t gaia_base_t::id() const
+gaia_id_t edc_base_t::id() const
 {
     auto ptr = to_const_ptr<gaia_ptr>();
     if (*ptr)
@@ -107,22 +107,22 @@ gaia_id_t gaia_base_t::id() const
     return c_invalid_gaia_id;
 }
 
-bool gaia_base_t::exists() const
+bool edc_base_t::exists() const
 {
     return static_cast<bool>(*to_const_ptr<gaia_ptr>());
 }
 
-const char* gaia_base_t::data() const
+const char* edc_base_t::data() const
 {
     return to_const_ptr<gaia_ptr>()->data();
 }
 
-bool gaia_base_t::equals(const gaia_base_t& other) const
+bool edc_base_t::equals(const edc_base_t& other) const
 {
     return (*(to_const_ptr<gaia_ptr>()) == *(other.to_const_ptr<gaia_ptr>()));
 }
 
-gaia_id_t* gaia_base_t::references() const
+gaia_id_t* edc_base_t::references() const
 {
     return to_const_ptr<gaia_ptr>()->references();
 }
@@ -145,7 +145,7 @@ bool edc_db_t::get_type(gaia_id_t id, gaia_type_t& type)
     return false;
 }
 
-gaia_id_t gaia_base_t::find_next()
+gaia_id_t edc_base_t::find_next()
 {
     gaia_ptr node = to_ptr<gaia_ptr>()->find_next();
     if (node)

--- a/production/direct_access/tests/test_direct_access.cpp
+++ b/production/direct_access/tests/test_direct_access.cpp
@@ -20,10 +20,10 @@ using namespace gaia::direct_access;
 using namespace gaia::common;
 using namespace gaia::addr_book;
 
-class gaia_object_test : public db_catalog_test_base_t
+class edc_object_test : public db_catalog_test_base_t
 {
 protected:
-    gaia_object_test()
+    edc_object_test()
         : db_catalog_test_base_t(std::string("addr_book.ddl")){};
 };
 
@@ -61,7 +61,7 @@ employee_t create_employee(const char* name)
 // ================================
 
 // Create, write & read, one row
-TEST_F(gaia_object_test, create_employee)
+TEST_F(edc_object_test, create_employee)
 {
     begin_transaction();
     create_employee("Harold");
@@ -69,7 +69,7 @@ TEST_F(gaia_object_test, create_employee)
 }
 
 // Delete one row
-TEST_F(gaia_object_test, create_employee_delete)
+TEST_F(edc_object_test, create_employee_delete)
 {
     begin_transaction();
     auto e = create_employee("Jameson");
@@ -78,7 +78,7 @@ TEST_F(gaia_object_test, create_employee_delete)
 }
 
 // Scan multiple rows
-TEST_F(gaia_object_test, new_set_ins)
+TEST_F(edc_object_test, new_set_ins)
 {
     begin_transaction();
     create_employee("Harold");
@@ -88,7 +88,7 @@ TEST_F(gaia_object_test, new_set_ins)
 }
 
 // Read back from new, unsaved object
-TEST_F(gaia_object_test, net_set_get)
+TEST_F(edc_object_test, net_set_get)
 {
     // Note no transaction needed to create & use writer.
     auto w = employee_writer();
@@ -103,7 +103,7 @@ TEST_F(gaia_object_test, net_set_get)
 }
 
 // Read original value from an inserted object
-TEST_F(gaia_object_test, read_original_from_copy)
+TEST_F(edc_object_test, read_original_from_copy)
 {
     begin_transaction();
     auto e = create_employee("Zachary");
@@ -112,7 +112,7 @@ TEST_F(gaia_object_test, read_original_from_copy)
 }
 
 // Insert a row with no field values
-TEST_F(gaia_object_test, new_insert_get)
+TEST_F(edc_object_test, new_insert_get)
 {
     begin_transaction();
 
@@ -127,7 +127,7 @@ TEST_F(gaia_object_test, new_insert_get)
 }
 
 // Read values from a non-inserted writer
-TEST_F(gaia_object_test, new_get)
+TEST_F(edc_object_test, new_get)
 {
     begin_transaction();
     auto w = employee_writer();
@@ -140,7 +140,7 @@ TEST_F(gaia_object_test, new_get)
 }
 
 // Attempt to insert with an update writer, this should work.
-TEST_F(gaia_object_test, existing_insert_field)
+TEST_F(edc_object_test, existing_insert_field)
 {
     begin_transaction();
     auto e = employee_t::get(employee_writer().insert_row());
@@ -156,7 +156,7 @@ TEST_F(gaia_object_test, existing_insert_field)
 // ====================================
 
 // Create, write two rows, read back by scan and verify
-TEST_F(gaia_object_test, read_back_scan)
+TEST_F(edc_object_test, read_back_scan)
 {
     begin_transaction();
     auto eid = create_employee("Howard").gaia_id();
@@ -228,19 +228,19 @@ void update_read_back(bool update_flag)
 }
 
 // Create, write two rows, set fields, update, read, verify
-TEST_F(gaia_object_test, update_read_back)
+TEST_F(edc_object_test, update_read_back)
 {
     update_read_back(true);
 }
 
 // Create, write two rows, set fields, update, read, verify
-TEST_F(gaia_object_test, no_update_read_back)
+TEST_F(edc_object_test, no_update_read_back)
 {
     update_read_back(false);
 }
 
 // Delete an inserted object then insert after; the new row is good.
-TEST_F(gaia_object_test, new_delete_insert)
+TEST_F(edc_object_test, new_delete_insert)
 {
     begin_transaction();
     auto e = create_employee("Hector");
@@ -254,14 +254,14 @@ TEST_F(gaia_object_test, new_delete_insert)
 // ====================
 
 // Attempt to create a row outside of a transaction
-TEST_F(gaia_object_test, no_txn)
+TEST_F(edc_object_test, no_txn)
 {
     EXPECT_THROW(create_employee("Harold"), no_open_transaction);
     // NOTE: the employee_t object is leaked here
 }
 
 // Scan beyond the end of the iterator.
-TEST_F(gaia_object_test, scan_past_end)
+TEST_F(edc_object_test, scan_past_end)
 {
     auto_transaction_t txn;
     create_employee("Hvitserk");
@@ -280,7 +280,7 @@ TEST_F(gaia_object_test, scan_past_end)
 }
 
 // Test pre/post increment of iterator.
-TEST_F(gaia_object_test, pre_post_iterator)
+TEST_F(edc_object_test, pre_post_iterator)
 {
     auto_transaction_t txn;
     create_employee("Hvitserk");
@@ -299,7 +299,7 @@ TEST_F(gaia_object_test, pre_post_iterator)
 }
 
 // Create row, try getting row from wrong type
-TEST_F(gaia_object_test, read_wrong_type)
+TEST_F(edc_object_test, read_wrong_type)
 {
     begin_transaction();
     gaia_id_t eid = create_employee("Howard").gaia_id();
@@ -319,7 +319,7 @@ TEST_F(gaia_object_test, read_wrong_type)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, delete_wrong_type)
+TEST_F(edc_object_test, delete_wrong_type)
 {
     begin_transaction();
     gaia_id_t eid = create_employee("Howard").gaia_id();
@@ -331,7 +331,7 @@ TEST_F(gaia_object_test, delete_wrong_type)
 }
 
 // Create, write two rows, read back by ID and verify
-TEST_F(gaia_object_test, read_back_id)
+TEST_F(edc_object_test, read_back_id)
 {
     auto_transaction_t txn;
     auto eid = create_employee("Howard").gaia_id();
@@ -361,7 +361,7 @@ TEST_F(gaia_object_test, read_back_id)
     EXPECT_THROW(e.name_first(), invalid_node_id);
 }
 
-TEST_F(gaia_object_test, new_del_field_ref)
+TEST_F(edc_object_test, new_del_field_ref)
 {
     // create GAIA-64 scenario
     begin_transaction();
@@ -378,7 +378,7 @@ TEST_F(gaia_object_test, new_del_field_ref)
 }
 
 // Delete a found object then update
-TEST_F(gaia_object_test, new_del_update)
+TEST_F(edc_object_test, new_del_update)
 {
     begin_transaction();
     auto e = create_employee("Hector");
@@ -388,7 +388,7 @@ TEST_F(gaia_object_test, new_del_update)
 }
 
 // Delete a found object then insert after, it's good again.
-TEST_F(gaia_object_test, found_del_ins)
+TEST_F(edc_object_test, found_del_ins)
 {
     begin_transaction();
 
@@ -408,7 +408,7 @@ TEST_F(gaia_object_test, found_del_ins)
 }
 
 // Delete a found object then update
-TEST_F(gaia_object_test, found_del_update)
+TEST_F(edc_object_test, found_del_update)
 {
     begin_transaction();
     gaia_id_t eid = create_employee("Hector").gaia_id();
@@ -439,7 +439,7 @@ TEST_F(gaia_object_test, found_del_update)
 // only takes a writer object.
 
 // Delete a row twice
-TEST_F(gaia_object_test, new_del_del)
+TEST_F(edc_object_test, new_del_del)
 {
     begin_transaction();
     auto e = create_employee("Hugo");
@@ -450,7 +450,7 @@ TEST_F(gaia_object_test, new_del_del)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, auto_txn_begin)
+TEST_F(edc_object_test, auto_txn_begin)
 {
 
     // Default constructor enables auto_begin semantics
@@ -472,7 +472,7 @@ TEST_F(gaia_object_test, auto_txn_begin)
     EXPECT_STREQ(e.name_last(), "Clinton");
 }
 
-TEST_F(gaia_object_test, auto_txn)
+TEST_F(edc_object_test, auto_txn)
 {
     // Specify auto_begin = false
     auto_transaction_t txn(false);
@@ -493,7 +493,7 @@ TEST_F(gaia_object_test, auto_txn)
     txn.commit();
 }
 
-TEST_F(gaia_object_test, auto_txn_rollback)
+TEST_F(edc_object_test, auto_txn_rollback)
 {
     gaia_id_t id;
     {
@@ -508,7 +508,7 @@ TEST_F(gaia_object_test, auto_txn_rollback)
     EXPECT_FALSE(e);
 }
 
-TEST_F(gaia_object_test, writer_value_ref)
+TEST_F(edc_object_test, writer_value_ref)
 {
     begin_transaction();
     employee_writer w1 = employee_writer();
@@ -575,7 +575,7 @@ void delete_thread(gaia_id_t id)
     end_session();
 }
 
-TEST_F(gaia_object_test, thread_insert)
+TEST_F(edc_object_test, thread_insert)
 {
     // Insert a record in another thread and verify
     // we can see it here.
@@ -589,7 +589,7 @@ TEST_F(gaia_object_test, thread_insert)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, thread_update)
+TEST_F(edc_object_test, thread_update)
 {
     // Update a record in another thread and verify
     // we can see it here.
@@ -615,7 +615,7 @@ TEST_F(gaia_object_test, thread_update)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, thread_update_conflict)
+TEST_F(edc_object_test, thread_update_conflict)
 {
     insert_thread(false);
 
@@ -640,7 +640,7 @@ TEST_F(gaia_object_test, thread_update_conflict)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, thread_update_other_row)
+TEST_F(edc_object_test, thread_update_other_row)
 {
     gaia_id_t row1_id = 0;
     gaia_id_t row2_id = 0;
@@ -674,7 +674,7 @@ TEST_F(gaia_object_test, thread_update_other_row)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, thread_delete)
+TEST_F(edc_object_test, thread_delete)
 {
     // update a record in another thread and verify
     // we can see it
@@ -699,7 +699,7 @@ TEST_F(gaia_object_test, thread_delete)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, thread_insert_update_delete)
+TEST_F(edc_object_test, thread_insert_update_delete)
 {
     // Do three concurrent operations and make sure we see are isolated from them
     // and then do see them in a subsequent transaction.
@@ -739,7 +739,7 @@ TEST_F(gaia_object_test, thread_insert_update_delete)
     commit_transaction();
 };
 
-TEST_F(gaia_object_test, thread_delete_conflict)
+TEST_F(edc_object_test, thread_delete_conflict)
 {
     // Have two threads delete the same row.
     insert_thread(false);
@@ -793,7 +793,7 @@ void employee_func_val(employee_t e, const char* first_name)
     commit_transaction();
 }
 
-TEST_F(gaia_object_test, default_construction)
+TEST_F(edc_object_test, default_construction)
 {
     // Valid use case to create an unbacked object that
     // you can't do anything with.  However, now you can
@@ -829,8 +829,8 @@ TEST_F(gaia_object_test, default_construction)
     commit_transaction();
 }
 
-// Testing the arrow dereference operator->() in gaia_iterator_t.
-TEST_F(gaia_object_test, iter_arrow_deref)
+// Testing the arrow dereference operator->() in edc_iterator_t.
+TEST_F(edc_object_test, iter_arrow_deref)
 {
     const char* emp_name = "Phillip";
     auto_transaction_t txn;
@@ -838,7 +838,7 @@ TEST_F(gaia_object_test, iter_arrow_deref)
     create_employee(emp_name);
     txn.commit();
 
-    gaia_iterator_t<employee_t> emp_iter = employee_t::list().begin();
+    edc_iterator_t<employee_t> emp_iter = employee_t::list().begin();
     EXPECT_STREQ(emp_iter->name_first(), emp_name);
 }
 
@@ -858,7 +858,7 @@ int count_names(size_t name_length)
     return count;
 }
 
-TEST_F(gaia_object_test, list_filter)
+TEST_F(edc_object_test, list_filter)
 {
     auto_transaction_t txn;
 

--- a/production/direct_access/tests/test_iterators.cpp
+++ b/production/direct_access/tests/test_iterators.cpp
@@ -51,22 +51,22 @@ public:
 
     // Use operator overloading to call the right begin and end methods.  Ignore
     // the parameter, however.
-    T_iterator get_begin(gaia_iterator_t<address_t>&)
+    T_iterator get_begin(edc_iterator_t<address_t>&)
     {
         return address_t::list().begin();
     }
 
-    T_iterator get_begin(gaia_set_iterator_t<address_t>&)
+    T_iterator get_begin(edc_set_iterator_t<address_t>&)
     {
         return m_employee.addressee_address_list().begin();
     }
 
-    T_iterator get_end(gaia_iterator_t<address_t>&)
+    T_iterator get_end(edc_iterator_t<address_t>&)
     {
         return address_t::list().end();
     }
 
-    T_iterator get_end(gaia_set_iterator_t<address_t>&)
+    T_iterator get_end(edc_set_iterator_t<address_t>&)
     {
         return m_employee.addressee_address_list().end();
     }
@@ -77,7 +77,7 @@ private:
 
 // Set up the test suite to test the gaia_iterator and gaia_set_iterator types.
 using iterator_types
-    = ::testing::Types<gaia_iterator_t<address_t>, gaia_set_iterator_t<address_t>>;
+    = ::testing::Types<edc_iterator_t<address_t>, edc_set_iterator_t<address_t>>;
 TYPED_TEST_SUITE(iterator_conformance_t, iterator_types);
 
 // Tests for LegacyIterator conformance
@@ -109,7 +109,7 @@ TYPED_TEST(iterator_conformance_t, swappable)
     EXPECT_TRUE(is_swappable<TypeParam>::value) << "The iterator is not Swappable as an lvalue.";
 }
 
-// Does iterator_traits<gaia_iterator_t<edc*>> have member typedefs
+// Does iterator_traits<edc_iterator_t<edc*>> have member typedefs
 // value_type, difference_type, reference, pointer, and iterator_category?
 TYPED_TEST(iterator_conformance_t, iterator_traits)
 {

--- a/production/direct_access/tests/test_references.cpp
+++ b/production/direct_access/tests/test_references.cpp
@@ -764,7 +764,7 @@ TEST_F(gaia_references_test, thread_inserts)
     EXPECT_EQ(count, 3);
 }
 
-// Testing the arrow dereference operator->() in gaia_set_iterator_t.
+// Testing the arrow dereference operator->() in edc_set_iterator_t.
 TEST_F(gaia_references_test, set_iter_arrow_deref)
 {
     const char* emp_name = "Phillip";

--- a/production/inc/gaia/direct_access/edc_base.hpp
+++ b/production/inc/gaia/direct_access/edc_base.hpp
@@ -49,31 +49,31 @@ protected:
  */
 
 /**
- * The gaia_base_t struct is a tag to mark extended data class objects as well as provide
+ * The edc_base_t struct is a tag to mark extended data class objects as well as provide
  * non-template functionality.
  */
-struct gaia_base_t : edc_db_t
+struct edc_base_t : edc_db_t
 {
     /**
-     * The gaia_base_t and gaia_object_t shouldn't be instantiated directly. The
-     * gaia_object_t is created to be subclassed by a "typed" class that is identified
+     * The edc_base_t and edc_object_t shouldn't be instantiated directly. The
+     * edc_object_t is created to be subclassed by a "typed" class that is identified
      * with a flatbuffer table. This method returns the name of that type.
      */
-    gaia_base_t() = delete;
-    explicit gaia_base_t(const char* gaia_typename);
-    gaia_base_t(const char* gaia_typename, common::gaia_id_t id);
+    edc_base_t() = delete;
+    explicit edc_base_t(const char* gaia_typename);
+    edc_base_t(const char* gaia_typename, common::gaia_id_t id);
 
     const char* gaia_typename()
     {
         return m_typename;
     }
     virtual common::gaia_type_t gaia_type() = 0;
-    virtual ~gaia_base_t() = default;
+    virtual ~edc_base_t() = default;
 
 protected:
     common::gaia_id_t id() const;
     bool exists() const;
-    bool equals(const gaia_base_t& other) const;
+    bool equals(const edc_base_t& other) const;
     const char* data() const;
     common::gaia_id_t find_next();
 

--- a/production/inc/gaia/direct_access/edc_iterators.hpp
+++ b/production/inc/gaia/direct_access/edc_iterators.hpp
@@ -29,12 +29,12 @@ namespace direct_access
 
 // C++17 compliant way when std::iterator is deprecated.
 //
-// A gaia_iterator_t contains the methods that satisfy an iterator interface.
-// Only used from gaia_container_t template, which defines the begin(), where() and end().
+// A edc_iterator_t contains the methods that satisfy an iterator interface.
+// Only used from edc_container_t template, which defines the begin(), where() and end().
 //
 // @tparam T_class the Extended Data Class
 template <typename T_class>
-class gaia_iterator_t
+class edc_iterator_t
 {
     T_class m_obj;
     std::function<bool(const T_class&)> m_filter_fn;
@@ -46,53 +46,53 @@ public:
     using reference = T_class&;
     using iterator_category = std::forward_iterator_tag;
 
-    explicit gaia_iterator_t(gaia::common::gaia_id_t id);
-    explicit gaia_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_class&)> filter_function);
-    gaia_iterator_t() = default;
+    explicit edc_iterator_t(gaia::common::gaia_id_t id);
+    explicit edc_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_class&)> filter_function);
+    edc_iterator_t() = default;
 
-    gaia_iterator_t<T_class>& operator++();
+    edc_iterator_t<T_class>& operator++();
 
-    gaia_iterator_t<T_class> operator++(int);
+    edc_iterator_t<T_class> operator++(int);
 
-    bool operator==(const gaia_iterator_t& rhs) const;
+    bool operator==(const edc_iterator_t& rhs) const;
 
-    bool operator!=(const gaia_iterator_t& rhs) const;
+    bool operator!=(const edc_iterator_t& rhs) const;
 
     reference operator*();
 
     pointer operator->();
 };
 
-// A gaia_container_t is all objects of the same Extended Data Class in the database.
+// A edc_container_t is all objects of the same Extended Data Class in the database.
 //
 // @tparam T_container the type identifier of Extended Data Class
 // @tparam T_class the class of the Extended Data Class
 template <gaia::common::gaia_type_t T_container, typename T_class>
-struct gaia_container_t : edc_db_t
+struct edc_container_t : edc_db_t
 {
     // This constructor will be used by the where() method to create a filtered container.
-    gaia_container_t(std::function<bool(const T_class&)> filter_function)
+    edc_container_t(std::function<bool(const T_class&)> filter_function)
         : m_filter_fn(filter_function)
     {
     }
-    gaia_container_t() = default;
+    edc_container_t() = default;
 
-    gaia_iterator_t<T_class> begin() const;
-    static gaia_container_t<T_container, T_class> where(std::function<bool(const T_class&)>);
-    gaia_iterator_t<T_class> end() const;
+    edc_iterator_t<T_class> begin() const;
+    static edc_container_t<T_container, T_class> where(std::function<bool(const T_class&)>);
+    edc_iterator_t<T_class> end() const;
 
 private:
     std::function<bool(const T_class&)> m_filter_fn;
 };
 
-// A gaia_set_iterator_t is only used from reference_chain_container_t. It
+// A edc_set_iterator_t is only used from reference_chain_container_t. It
 // contains the methods that implement an iterator for scanning through the
 // linked list forming a "set" between a parent and multiple child instances of
 // a class.
 //
 // @tparam T_child the Extended Data Class that is in the child position in the set
 template <typename T_child>
-class gaia_set_iterator_t
+class edc_set_iterator_t
 {
     T_child m_child_obj;
     std::function<bool(const T_child&)> m_filter_fn;
@@ -105,21 +105,21 @@ public:
     using reference = T_child&;
     using iterator_category = std::forward_iterator_tag;
 
-    explicit gaia_set_iterator_t(gaia::common::gaia_id_t id, size_t next_offset);
-    explicit gaia_set_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_child&)> filter_function, size_t next_offset);
-    gaia_set_iterator_t() = default;
+    explicit edc_set_iterator_t(gaia::common::gaia_id_t id, size_t next_offset);
+    explicit edc_set_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_child&)> filter_function, size_t next_offset);
+    edc_set_iterator_t() = default;
 
     reference operator*();
 
     pointer operator->();
 
-    gaia_set_iterator_t<T_child>& operator++();
+    edc_set_iterator_t<T_child>& operator++();
 
-    gaia_set_iterator_t<T_child> operator++(int);
+    edc_set_iterator_t<T_child> operator++(int);
 
-    bool operator==(const gaia_set_iterator_t& rhs) const;
+    bool operator==(const edc_set_iterator_t& rhs) const;
 
-    bool operator!=(const gaia_set_iterator_t& rhs) const;
+    bool operator!=(const edc_set_iterator_t& rhs) const;
 };
 
 // A reference_chain_container_t is defined within each EDC that is a parent in
@@ -161,17 +161,17 @@ public:
     reference_chain_container_t(const reference_chain_container_t&) = default;
     reference_chain_container_t& operator=(const reference_chain_container_t&) = default;
 
-    gaia_set_iterator_t<T_child> begin() const;
+    edc_set_iterator_t<T_child> begin() const;
 
     reference_chain_container_t<T_child> where(std::function<bool(const T_child&)>) const;
 
-    gaia_set_iterator_t<T_child> end() const;
+    edc_set_iterator_t<T_child> end() const;
 
     void insert(gaia::common::gaia_id_t child_id);
 
     void insert(T_child& child_edc);
 
-    gaia_set_iterator_t<T_child> erase(gaia_set_iterator_t<T_child> position);
+    edc_set_iterator_t<T_child> erase(edc_set_iterator_t<T_child> position);
 
     void remove(gaia::common::gaia_id_t child_id);
 

--- a/production/inc/gaia/direct_access/edc_iterators.inc
+++ b/production/inc/gaia/direct_access/edc_iterators.inc
@@ -9,23 +9,23 @@ namespace direct_access
 {
 
 //
-// Implementation for gaia_iterator_t.
+// Implementation for edc_iterator_t.
 //
 template <typename T_class>
-gaia_iterator_t<T_class>::gaia_iterator_t(gaia::common::gaia_id_t id)
+edc_iterator_t<T_class>::edc_iterator_t(gaia::common::gaia_id_t id)
 {
     m_obj = T_class::get(id);
 }
 
 template <typename T_class>
-gaia_iterator_t<T_class>::gaia_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_class&)> filter_function)
+edc_iterator_t<T_class>::edc_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_class&)> filter_function)
     : m_filter_fn(filter_function)
 {
     m_obj = T_class::get(id);
 }
 
 template <typename T_class>
-gaia_iterator_t<T_class>& gaia_iterator_t<T_class>::operator++()
+edc_iterator_t<T_class>& edc_iterator_t<T_class>::operator++()
 {
     if (!m_obj)
     {
@@ -54,53 +54,53 @@ gaia_iterator_t<T_class>& gaia_iterator_t<T_class>::operator++()
 }
 
 template <typename T_class>
-gaia_iterator_t<T_class> gaia_iterator_t<T_class>::operator++(int)
+edc_iterator_t<T_class> edc_iterator_t<T_class>::operator++(int)
 {
-    gaia_iterator_t<T_class> old = *this;
+    edc_iterator_t<T_class> old = *this;
     operator++();
     return old;
 }
 
 template <typename T_class>
-bool gaia_iterator_t<T_class>::operator==(const gaia_iterator_t& rhs) const
+bool edc_iterator_t<T_class>::operator==(const edc_iterator_t& rhs) const
 {
     return m_obj == rhs.m_obj;
 }
 
 template <typename T_class>
-bool gaia_iterator_t<T_class>::operator!=(const gaia_iterator_t& rhs) const
+bool edc_iterator_t<T_class>::operator!=(const edc_iterator_t& rhs) const
 {
     return !(m_obj == rhs.m_obj);
 }
 
 template <typename T_class>
-typename gaia_iterator_t<T_class>::reference gaia_iterator_t<T_class>::operator*()
+typename edc_iterator_t<T_class>::reference edc_iterator_t<T_class>::operator*()
 {
     return m_obj;
 }
 
 template <typename T_class>
-typename gaia_iterator_t<T_class>::pointer gaia_iterator_t<T_class>::operator->()
+typename edc_iterator_t<T_class>::pointer edc_iterator_t<T_class>::operator->()
 {
     return &m_obj;
 }
 
 //
-// Implementation for gaia_container_t
+// Implementation for edc_container_t
 //
 
 // The begin() method returns either the first element, or the first element that satisfies m_filter_fn.
 template <gaia::common::gaia_type_t T_container, typename T_class>
-gaia_iterator_t<T_class> gaia_container_t<T_container, T_class>::begin() const
+edc_iterator_t<T_class> edc_container_t<T_container, T_class>::begin() const
 {
-    gaia::common::gaia_id_t id = gaia_base_t::find_first(T_container);
+    gaia::common::gaia_id_t id = edc_base_t::find_first(T_container);
     while (id != common::c_invalid_gaia_id)
     {
         if (m_filter_fn)
         {
             if (m_filter_fn(T_class::get(id)))
             {
-                return gaia_iterator_t<T_class>(id, m_filter_fn);
+                return edc_iterator_t<T_class>(id, m_filter_fn);
             }
         }
         else
@@ -110,34 +110,34 @@ gaia_iterator_t<T_class> gaia_container_t<T_container, T_class>::begin() const
 
         id = edc_db_t::find_next(id);
     }
-    return gaia_iterator_t<T_class>(id);
+    return edc_iterator_t<T_class>(id);
 }
 
-// The where() method constructs a gaia_container_t with a std::function to be used for filtering.
+// The where() method constructs a edc_container_t with a std::function to be used for filtering.
 template <gaia::common::gaia_type_t T_container, typename T_class>
-gaia_container_t<T_container, T_class> gaia_container_t<T_container, T_class>::where(std::function<bool(const T_class&)> filter_function)
+edc_container_t<T_container, T_class> edc_container_t<T_container, T_class>::where(std::function<bool(const T_class&)> filter_function)
 {
-    return gaia_container_t<T_container, T_class>(filter_function);
+    return edc_container_t<T_container, T_class>(filter_function);
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class>
-gaia_iterator_t<T_class> gaia_container_t<T_container, T_class>::end() const
+edc_iterator_t<T_class> edc_container_t<T_container, T_class>::end() const
 {
-    return gaia_iterator_t<T_class>(0);
+    return edc_iterator_t<T_class>(0);
 }
 
 //
-// Implementation for gaia_set_iterator_t.
+// Implementation for edc_set_iterator_t.
 //
 template <typename T_child>
-gaia_set_iterator_t<T_child>::gaia_set_iterator_t(gaia::common::gaia_id_t id, size_t next_offset)
+edc_set_iterator_t<T_child>::edc_set_iterator_t(gaia::common::gaia_id_t id, size_t next_offset)
     : m_next_offset(next_offset)
 {
     m_child_obj = T_child::get(id);
 }
 
 template <typename T_child>
-gaia_set_iterator_t<T_child>::gaia_set_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_child&)> filter_function, size_t next_offset)
+edc_set_iterator_t<T_child>::edc_set_iterator_t(gaia::common::gaia_id_t id, std::function<bool(const T_child&)> filter_function, size_t next_offset)
     : m_filter_fn(filter_function)
     , m_next_offset(next_offset)
 {
@@ -145,19 +145,19 @@ gaia_set_iterator_t<T_child>::gaia_set_iterator_t(gaia::common::gaia_id_t id, st
 }
 
 template <typename T_child>
-typename gaia_set_iterator_t<T_child>::reference gaia_set_iterator_t<T_child>::operator*()
+typename edc_set_iterator_t<T_child>::reference edc_set_iterator_t<T_child>::operator*()
 {
     return m_child_obj;
 }
 
 template <typename T_child>
-typename gaia_set_iterator_t<T_child>::pointer gaia_set_iterator_t<T_child>::operator->()
+typename edc_set_iterator_t<T_child>::pointer edc_set_iterator_t<T_child>::operator->()
 {
     return &m_child_obj;
 }
 
 template <typename T_child>
-gaia_set_iterator_t<T_child>& gaia_set_iterator_t<T_child>::operator++()
+edc_set_iterator_t<T_child>& edc_set_iterator_t<T_child>::operator++()
 {
     if (!m_child_obj)
     {
@@ -188,21 +188,21 @@ gaia_set_iterator_t<T_child>& gaia_set_iterator_t<T_child>::operator++()
 }
 
 template <typename T_child>
-gaia_set_iterator_t<T_child> gaia_set_iterator_t<T_child>::operator++(int)
+edc_set_iterator_t<T_child> edc_set_iterator_t<T_child>::operator++(int)
 {
-    gaia_set_iterator_t<T_child> old = *this;
+    edc_set_iterator_t<T_child> old = *this;
     operator++();
     return old;
 }
 
 template <typename T_child>
-bool gaia_set_iterator_t<T_child>::operator==(const gaia_set_iterator_t& rhs) const
+bool edc_set_iterator_t<T_child>::operator==(const edc_set_iterator_t& rhs) const
 {
     return m_child_obj == rhs.m_child_obj;
 }
 
 template <typename T_child>
-bool gaia_set_iterator_t<T_child>::operator!=(const gaia_set_iterator_t& rhs) const
+bool edc_set_iterator_t<T_child>::operator!=(const edc_set_iterator_t& rhs) const
 {
     return !(m_child_obj == rhs.m_child_obj);
 }
@@ -211,13 +211,13 @@ bool gaia_set_iterator_t<T_child>::operator!=(const gaia_set_iterator_t& rhs) co
 // Implementation for reference_chain_container_t.
 //
 template <typename T_child>
-gaia_set_iterator_t<T_child> reference_chain_container_t<T_child>::begin() const
+edc_set_iterator_t<T_child> reference_chain_container_t<T_child>::begin() const
 {
     gaia::common::gaia_id_t id = 0;
 
     if (m_parent_id)
     {
-        id = gaia_base_t::get_reference(m_parent_id, m_child_offset);
+        id = edc_base_t::get_reference(m_parent_id, m_child_offset);
         while (id)
         {
             if (m_filter_fn)
@@ -226,7 +226,7 @@ gaia_set_iterator_t<T_child> reference_chain_container_t<T_child>::begin() const
                 {
                     break;
                 }
-                id = gaia_base_t::get_reference(id, m_next_offset);
+                id = edc_base_t::get_reference(id, m_next_offset);
             }
             else
             {
@@ -234,7 +234,7 @@ gaia_set_iterator_t<T_child> reference_chain_container_t<T_child>::begin() const
             }
         }
     }
-    return gaia_set_iterator_t<T_child>(id, m_filter_fn, m_next_offset);
+    return edc_set_iterator_t<T_child>(id, m_filter_fn, m_next_offset);
 }
 
 // The where() method saves the address of the std::function, to be called for each candidate return value.
@@ -246,9 +246,9 @@ reference_chain_container_t<T_child>::where(std::function<bool(const T_child&)> 
 }
 
 template <typename T_child>
-gaia_set_iterator_t<T_child> reference_chain_container_t<T_child>::end() const
+edc_set_iterator_t<T_child> reference_chain_container_t<T_child>::end() const
 {
-    return gaia_set_iterator_t<T_child>(0, 0);
+    return edc_set_iterator_t<T_child>(0, 0);
 }
 
 template <typename T_child>
@@ -261,7 +261,7 @@ void reference_chain_container_t<T_child>::insert(gaia::common::gaia_id_t child_
         throw edc_invalid_state(m_parent_id, child_id, received.gaia_typename());
     }
 
-    gaia_base_t::insert_child_reference(m_parent_id, child_id, m_child_offset);
+    edc_base_t::insert_child_reference(m_parent_id, child_id, m_child_offset);
 }
 
 template <typename T_child>
@@ -273,7 +273,7 @@ void reference_chain_container_t<T_child>::insert(T_child& child_edc)
 template <typename T_child>
 void reference_chain_container_t<T_child>::remove(gaia::common::gaia_id_t child_id)
 {
-    gaia_base_t::remove_child_reference(m_parent_id, child_id, m_child_offset);
+    edc_base_t::remove_child_reference(m_parent_id, child_id, m_child_offset);
 }
 
 template <typename T_child>
@@ -283,7 +283,7 @@ void reference_chain_container_t<T_child>::remove(T_child& child_edc)
 }
 
 template <typename T_child>
-gaia_set_iterator_t<T_child> reference_chain_container_t<T_child>::erase(gaia_set_iterator_t<T_child> position)
+edc_set_iterator_t<T_child> reference_chain_container_t<T_child>::erase(edc_set_iterator_t<T_child> position)
 {
     auto current = *position;
     position++;

--- a/production/inc/gaia/direct_access/edc_object.hpp
+++ b/production/inc/gaia/direct_access/edc_object.hpp
@@ -37,10 +37,10 @@ namespace direct_access
  */
 
 template <gaia::common::gaia_type_t T_gaia_type, typename T_gaia, typename T_fb, typename T_obj>
-struct gaia_writer_t;
+struct edc_writer_t;
 
 /**
- * The gaia_object_t that must be specialized to operate on a flatbuffer type.
+ * The edc_object_t that must be specialized to operate on a flatbuffer type.
  *
  * @tparam T_gaia_type an integer (gaia_type_t) uniquely identifying the flatbuffer table type
  * @tparam T_gaia the subclass type derived from this template
@@ -48,15 +48,15 @@ struct gaia_writer_t;
  * @tparam T_obj the mutable flatbuffer type to be implemented
  */
 template <gaia::common::gaia_type_t T_gaia_type, typename T_gaia, typename T_fb, typename T_obj>
-struct gaia_object_t : gaia_base_t
+struct edc_object_t : edc_base_t
 {
 public:
-    explicit gaia_object_t(const char* gaia_typename);
+    explicit edc_object_t(const char* gaia_typename);
 
     /**
      * Return a reference that is pre-populated with values from the row
      */
-    gaia_writer_t<T_gaia_type, T_gaia, T_fb, T_obj> writer();
+    edc_writer_t<T_gaia_type, T_gaia, T_fb, T_obj> writer();
 
     /**
      * This can be used for subscribing to rules when you don't
@@ -65,7 +65,7 @@ public:
     static gaia::common::gaia_type_t s_gaia_type;
 
     /**
-     * This can be used when you are passed a gaia_base_t
+     * This can be used when you are passed a edc_base_t
      * object and want to know the type at runtime.
      */
     gaia::common::gaia_type_t gaia_type() override
@@ -123,14 +123,14 @@ public:
      * Returns true if the gaia locator these objects represent
      * is the same.
      */
-    bool operator==(const gaia_object_t& other) const;
+    bool operator==(const edc_object_t& other) const;
 
 protected:
     /**
      * This constructor supports creating new objects from existing
      * nodes in the database.  It is called by our get_object below.
      */
-    gaia_object_t(gaia::common::gaia_id_t id, const char* gaia_typename);
+    edc_object_t(gaia::common::gaia_id_t id, const char* gaia_typename);
 
     /**
      * Insert a mutable flatbuffer into a newly created database object. This will be
@@ -154,9 +154,9 @@ protected:
 };
 
 template <gaia::common::gaia_type_t T_gaia_type, typename T_gaia, typename T_fb, typename T_obj>
-struct gaia_writer_t : public T_obj, edc_db_t
+struct edc_writer_t : public T_obj, edc_db_t
 {
-    gaia_writer_t() = default;
+    edc_writer_t() = default;
 
     /**
      * Insert the values in this new object into a newly created database object.
@@ -177,7 +177,7 @@ private:
         gaia::common::gaia_id_t id;
     } m_gaia;
 
-    friend gaia_object_t<T_gaia_type, T_gaia, T_fb, T_obj>;
+    friend edc_object_t<T_gaia_type, T_gaia, T_fb, T_obj>;
 };
 
 /*@}*/

--- a/production/inc/gaia/direct_access/edc_object.inc
+++ b/production/inc/gaia/direct_access/edc_object.inc
@@ -4,7 +4,7 @@
 /////////////////////////////////////////////
 
 // NOTE: This is included included by edc_object.hpp as this is a template
-// implementation file.  Because the template specializations of gaia_object_t are
+// implementation file.  Because the template specializations of edc_object_t are
 // created by user-defined schema, we don't know what they will be a priori.
 namespace gaia
 {
@@ -12,110 +12,110 @@ namespace direct_access
 {
 
 //
-// The gaia_object_t implementation.
+// The edc_object_t implementation.
 //
 
-// Macros for strongly-typed field accessors used by gaia_object_t objects below.
+// Macros for strongly-typed field accessors used by edc_object_t objects below.
 #define GET(field) (row()->field())
 #define GET_STR(field) (row()->field() ? row()->field()->c_str() : nullptr)
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::gaia_object_t(
+edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::edc_object_t(
     const char* gaia_typename)
-    : gaia_base_t(gaia_typename)
+    : edc_base_t(gaia_typename)
 {
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::gaia_object_t(
+edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::edc_object_t(
     gaia::common::gaia_id_t id, const char* gaia_typename)
-    : gaia_base_t(gaia_typename, id)
+    : edc_base_t(gaia_typename, id)
 {
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::gaia_id() const
+gaia::common::gaia_id_t edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::gaia_id() const
 {
-    return gaia_base_t::id();
+    return edc_base_t::id();
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-const T_flatbuffer* gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::row() const
+const T_flatbuffer* edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::row() const
 {
-    if (!gaia_base_t::exists())
+    if (!edc_base_t::exists())
     {
         throw gaia::db::invalid_node_id(0);
     }
-    return flatbuffers::GetRoot<T_flatbuffer>(gaia_base_t::data());
+    return flatbuffers::GetRoot<T_flatbuffer>(edc_base_t::data());
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::operator bool() const
+edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::operator bool() const
 {
-    return gaia_base_t::exists();
+    return edc_base_t::exists();
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-bool gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::operator==(
-    const gaia_object_t& other) const
+bool edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::operator==(
+    const edc_object_t& other) const
 {
-    return gaia_base_t::equals(other);
+    return edc_base_t::equals(other);
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t* gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::references() const
+gaia::common::gaia_id_t* edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::references() const
 {
-    if (!gaia_base_t::exists())
+    if (!edc_base_t::exists())
     {
         throw gaia::db::invalid_node_id(0);
     }
-    return gaia_base_t::references();
+    return edc_base_t::references();
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>
-gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::writer()
+edc_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>
+edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::writer()
 {
-    if (!gaia_base_t::exists())
+    if (!edc_base_t::exists())
     {
         throw gaia::db::invalid_node_id(0);
     }
 
-    auto writer = gaia_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>();
+    auto writer = edc_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>();
     writer.m_gaia.id = id();
     row()->UnPackTo(&writer);
     return writer;
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-T_class gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get_first()
+T_class edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get_first()
 {
-    gaia::common::gaia_id_t id = gaia_base_t::find_first(T_container);
+    gaia::common::gaia_id_t id = edc_base_t::find_first(T_container);
     return T_class(id);
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-T_class gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get_next()
+T_class edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get_next()
 {
-    if (!gaia_base_t::exists())
+    if (!edc_base_t::exists())
     {
         throw gaia::db::invalid_node_id(0);
     }
-    gaia::common::gaia_id_t id = gaia_base_t::find_next();
+    gaia::common::gaia_id_t id = edc_base_t::find_next();
     return T_class(id);
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-T_class gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get(gaia::common::gaia_id_t id)
+T_class edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::get(gaia::common::gaia_id_t id)
 {
     return T_class(verify_type(id));
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::verify_type(gaia::common::gaia_id_t id)
+gaia::common::gaia_id_t edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::verify_type(gaia::common::gaia_id_t id)
 {
     gaia::common::gaia_type_t target_type = gaia::common::c_invalid_gaia_type;
-    if (!gaia_base_t::get_type(id, target_type))
+    if (!edc_base_t::get_type(id, target_type))
     {
         return gaia::common::c_invalid_gaia_id;
     }
@@ -131,16 +131,16 @@ gaia::common::gaia_id_t gaia_object_t<T_container, T_class, T_flatbuffer, T_flat
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row(
+gaia::common::gaia_id_t edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row(
     flatbuffers::FlatBufferBuilder& fbb)
 {
-    return gaia_base_t::insert(T_container, fbb.GetSize(), fbb.GetBufferPointer());
+    return edc_base_t::insert(T_container, fbb.GetSize(), fbb.GetBufferPointer());
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-void gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::delete_row()
+void edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::delete_row()
 {
-    if (!gaia_base_t::exists())
+    if (!edc_base_t::exists())
     {
         throw gaia::db::invalid_node_id(0);
     }
@@ -149,20 +149,20 @@ void gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::del
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-void gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::delete_row(gaia::common::gaia_id_t id)
+void edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::delete_row(gaia::common::gaia_id_t id)
 {
-    gaia_base_t::delete_row(verify_type(id));
+    edc_base_t::delete_row(verify_type(id));
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_type_t gaia_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::s_gaia_type
+gaia::common::gaia_type_t edc_object_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::s_gaia_type
     = T_container;
 
 //
-// The gaia_writer_t implementation.
+// The edc_writer_t implementation.
 //
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t gaia_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row()
+gaia::common::gaia_id_t edc_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row()
 {
     auto u = T_flatbuffer::Pack(m_builder, this);
     m_builder.Finish(u);
@@ -172,7 +172,7 @@ gaia::common::gaia_id_t gaia_writer_t<T_container, T_class, T_flatbuffer, T_flat
 }
 
 template <gaia::common::gaia_type_t T_container, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-void gaia_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::update_row()
+void edc_writer_t<T_container, T_class, T_flatbuffer, T_flatbuffer_object>::update_row()
 {
     auto u = T_flatbuffer::Pack(m_builder, this);
     m_builder.Finish(u);

--- a/production/inc/gaia_internal/catalog/gaia_catalog.h
+++ b/production/inc/gaia_internal/catalog/gaia_catalog.h
@@ -67,51 +67,51 @@ struct gaia_field_t;
 struct gaia_table_t;
 struct gaia_database_t;
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT> gaia_database_writer;
-struct gaia_database_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT> {
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT> gaia_database_writer;
+struct gaia_database_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT> {
     typedef gaia::direct_access::reference_chain_container_t<gaia_table_t> gaia_table_list_t;
-    gaia_database_t() : gaia_object_t("gaia_database_t") {}
+    gaia_database_t() : edc_object_t("gaia_database_t") {}
     const char* name() const {return GET_STR(name);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_databaseDirect(b, name));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_database, gaia_database_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_database, gaia_database_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_database, gaia_database_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_database, gaia_database_t> list;
         return list;
     }
     gaia_table_list_t gaia_table_list() const {
         return gaia_table_list_t(gaia_id(), c_first_gaia_database_gaia_table, c_next_gaia_database_gaia_table);
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT>;
-    explicit gaia_database_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_database_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT>;
+    explicit gaia_database_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_database_t") {}
 };
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT> gaia_table_writer;
-struct gaia_table_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT> {
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT> gaia_table_writer;
+struct gaia_table_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT> {
     typedef gaia::direct_access::reference_chain_container_t<gaia_field_t> gaia_field_list_t;
     typedef gaia::direct_access::reference_chain_container_t<gaia_relationship_t> parent_gaia_relationship_list_t;
     typedef gaia::direct_access::reference_chain_container_t<gaia_relationship_t> child_gaia_relationship_list_t;
-    gaia_table_t() : gaia_object_t("gaia_table_t") {}
+    gaia_table_t() : edc_object_t("gaia_table_t") {}
     const char* name() const {return GET_STR(name);}
     uint32_t type() const {return GET(type);}
     bool is_system() const {return GET(is_system);}
     const char* binary_schema() const {return GET_STR(binary_schema);}
     const char* serialization_template() const {return GET_STR(serialization_template);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name, uint32_t type, bool is_system, const char* binary_schema, const char* serialization_template) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_tableDirect(b, name, type, is_system, binary_schema, serialization_template));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
     gaia_database_t gaia_database() const {
         return gaia_database_t::get(this->references()[c_parent_gaia_database_gaia_table]);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_table, gaia_table_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_table, gaia_table_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_table, gaia_table_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_table, gaia_table_t> list;
         return list;
     }
     gaia_field_list_t gaia_field_list() const {
@@ -124,40 +124,40 @@ struct gaia_table_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia
         return child_gaia_relationship_list_t(gaia_id(), c_first_child_gaia_relationship, c_next_child_gaia_relationship);
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT>;
-    explicit gaia_table_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_table_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT>;
+    explicit gaia_table_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_table_t") {}
 };
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT> gaia_field_writer;
-struct gaia_field_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT> {
-    gaia_field_t() : gaia_object_t("gaia_field_t") {}
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT> gaia_field_writer;
+struct gaia_field_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT> {
+    gaia_field_t() : edc_object_t("gaia_field_t") {}
     const char* name() const {return GET_STR(name);}
     uint8_t type() const {return GET(type);}
     uint16_t repeated_count() const {return GET(repeated_count);}
     uint16_t position() const {return GET(position);}
     bool deprecated() const {return GET(deprecated);}
     bool active() const {return GET(active);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_fieldDirect(b, name, type, repeated_count, position, deprecated, active));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
     gaia_table_t gaia_table() const {
         return gaia_table_t::get(this->references()[c_parent_gaia_table_gaia_field]);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_field, gaia_field_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_field, gaia_field_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_field, gaia_field_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_field, gaia_field_t> list;
         return list;
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT>;
-    explicit gaia_field_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_field_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_field, gaia_field_t, internal::gaia_field, internal::gaia_fieldT>;
+    explicit gaia_field_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_field_t") {}
 };
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT> gaia_relationship_writer;
-struct gaia_relationship_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT> {
-    gaia_relationship_t() : gaia_object_t("gaia_relationship_t") {}
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT> gaia_relationship_writer;
+struct gaia_relationship_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT> {
+    gaia_relationship_t() : edc_object_t("gaia_relationship_t") {}
     const char* name() const {return GET_STR(name);}
     uint8_t cardinality() const {return GET(cardinality);}
     bool parent_required() const {return GET(parent_required);}
@@ -165,11 +165,11 @@ struct gaia_relationship_t : public gaia::direct_access::gaia_object_t<c_gaia_ty
     uint16_t first_child_offset() const {return GET(first_child_offset);}
     uint16_t next_child_offset() const {return GET(next_child_offset);}
     uint16_t parent_offset() const {return GET(parent_offset);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t parent_offset) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_relationshipDirect(b, name, cardinality, parent_required, deprecated, first_child_offset, next_child_offset, parent_offset));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
     gaia_table_t parent_gaia_table() const {
         return gaia_table_t::get(this->references()[c_parent_parent_gaia_relationship]);
@@ -177,62 +177,62 @@ struct gaia_relationship_t : public gaia::direct_access::gaia_object_t<c_gaia_ty
     gaia_table_t child_gaia_table() const {
         return gaia_table_t::get(this->references()[c_parent_child_gaia_relationship]);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> list;
         return list;
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT>;
-    explicit gaia_relationship_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_relationship_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_relationship, gaia_relationship_t, internal::gaia_relationship, internal::gaia_relationshipT>;
+    explicit gaia_relationship_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_relationship_t") {}
 };
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT> gaia_ruleset_writer;
-struct gaia_ruleset_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT> {
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT> gaia_ruleset_writer;
+struct gaia_ruleset_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT> {
     typedef gaia::direct_access::reference_chain_container_t<gaia_rule_t> gaia_rule_list_t;
-    gaia_ruleset_t() : gaia_object_t("gaia_ruleset_t") {}
+    gaia_ruleset_t() : edc_object_t("gaia_ruleset_t") {}
     const char* name() const {return GET_STR(name);}
     bool active_on_startup() const {return GET(active_on_startup);}
     const char* table_ids() const {return GET_STR(table_ids);}
     const char* source_location() const {return GET_STR(source_location);}
     const char* serial_stream() const {return GET_STR(serial_stream);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name, bool active_on_startup, const char* table_ids, const char* source_location, const char* serial_stream) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_rulesetDirect(b, name, active_on_startup, table_ids, source_location, serial_stream));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t> list;
         return list;
     }
     gaia_rule_list_t gaia_rule_list() const {
         return gaia_rule_list_t(gaia_id(), c_first_gaia_ruleset_gaia_rule, c_next_gaia_ruleset_gaia_rule);
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT>;
-    explicit gaia_ruleset_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_ruleset_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT>;
+    explicit gaia_ruleset_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_ruleset_t") {}
 };
 
-typedef gaia::direct_access::gaia_writer_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT> gaia_rule_writer;
-struct gaia_rule_t : public gaia::direct_access::gaia_object_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT> {
-    gaia_rule_t() : gaia_object_t("gaia_rule_t") {}
+typedef gaia::direct_access::edc_writer_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT> gaia_rule_writer;
+struct gaia_rule_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT> {
+    gaia_rule_t() : edc_object_t("gaia_rule_t") {}
     const char* name() const {return GET_STR(name);}
-    using gaia_object_t::insert_row;
+    using edc_object_t::insert_row;
     static gaia::common::gaia_id_t insert_row(const char* name) {
         flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
         b.Finish(internal::Creategaia_ruleDirect(b, name));
-        return gaia_object_t::insert_row(b);
+        return edc_object_t::insert_row(b);
     }
     gaia_ruleset_t gaia_ruleset() const {
         return gaia_ruleset_t::get(this->references()[c_parent_gaia_ruleset_gaia_rule]);
     }
-    static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_rule, gaia_rule_t>& list() {
-        static gaia::direct_access::gaia_container_t<c_gaia_type_gaia_rule, gaia_rule_t> list;
+    static gaia::direct_access::edc_container_t<c_gaia_type_gaia_rule, gaia_rule_t>& list() {
+        static gaia::direct_access::edc_container_t<c_gaia_type_gaia_rule, gaia_rule_t> list;
         return list;
     }
 private:
-    friend struct gaia_object_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT>;
-    explicit gaia_rule_t(gaia::common::gaia_id_t id) : gaia_object_t(id, "gaia_rule_t") {}
+    friend struct edc_object_t<c_gaia_type_gaia_rule, gaia_rule_t, internal::gaia_rule, internal::gaia_ruleT>;
+    explicit gaia_rule_t(gaia::common::gaia_id_t id) : edc_object_t(id, "gaia_rule_t") {}
 };
 
 }  // namespace catalog

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -131,7 +131,7 @@ rule_context_checker_t g_context_checker;
  * Our test object that will serve as the
  * row context sent to table events.
  */
-class test_gaia_t : public gaia_base_t
+class test_gaia_t : public edc_base_t
 {
 public:
     test_gaia_t()
@@ -140,7 +140,7 @@ public:
     }
 
     explicit test_gaia_t(gaia_id_t record)
-        : gaia_base_t("test_gaia_t"), m_id(record)
+        : edc_base_t("test_gaia_t"), m_id(record)
     {
     }
 
@@ -162,7 +162,7 @@ typedef unique_ptr<test_gaia_t> test_gaia_ptr_t;
 
 // Only to test gaia type filters on the
 // list_subscribed_rules api.
-class test_gaia_other_t : public gaia_base_t
+class test_gaia_other_t : public edc_base_t
 {
 public:
     test_gaia_other_t()
@@ -171,7 +171,7 @@ public:
     }
 
     explicit test_gaia_other_t(gaia_id_t record)
-        : gaia_base_t("test_gaia_other_t"), m_id(record)
+        : edc_base_t("test_gaia_other_t"), m_id(record)
     {
     }
 

--- a/third_party/production/flatbuffers/include/flatbuffers/idl.h
+++ b/third_party/production/flatbuffers/include/flatbuffers/idl.h
@@ -566,8 +566,6 @@ struct IDLOptions {
   std::string proto_namespace_suffix;
   std::string filename_suffix;
   std::string filename_extension;
-  bool generate_events;
-  bool generate_setters;
   uint64_t gaia_type_initial_value;
 
   // Possible options for the more general generator below.
@@ -655,8 +653,6 @@ struct IDLOptions {
         cs_gen_json_serializer(false),
         filename_suffix("_generated"),
         filename_extension(),
-        generate_events(false),
-        generate_setters(false),
         gaia_type_initial_value(1),
         lang(IDLOptions::kJava),
         mini_reflect(IDLOptions::kNone),

--- a/third_party/production/flatbuffers/src/flatc.cpp
+++ b/third_party/production/flatbuffers/src/flatc.cpp
@@ -127,8 +127,6 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                             * 'c++0x' - generate code compatible with old compilers;\n"
     "                             * 'c++11' - use C++11 code generator (default);\n"
     "                             * 'c++17' - use C++17 features in generated code (experimental).\n"
-    "  --gen-events             Generate code in Gaia Wrapper to invoke event triggers.\n"
-    "  --gen-setters            Generate code in Gaia Wrapper to generate setters for class data.\n"
     "  --gaia-type-initial-value sets an initial value while generating Gaia type.\n"
     "  --object-prefix          Customise class prefix for C++ object-based API.\n"
     "  --object-suffix          Customise class suffix for C++ object-based API.\n"
@@ -371,10 +369,6 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cs_gen_json_serializer = true;
       } else if (arg == "--flexbuffers") {
         opts.use_flexbuffers = true;
-      } else if (arg == "--gen-events") {
-        opts.generate_events = true;
-      } else if (arg == "--gen-setters") {
-        opts.generate_setters = true;
       } else if (arg == "--cpp-std") {
         if (++argi >= argc)
           Error("missing C++ standard specification" + arg, true);


### PR DESCRIPTION
This renames the gaia EDC objects to match their filenames.  I also removed some obsolete code in our changes to flatc.   The following classes were renamed:
| old | new |
|---|---|
|gaia_base_t|edc_base_t|
|gaia_object_t|edc_object_t|
|gaia_writer_t|edc_writer_t|
|gaia_iterator_t|edc_iterator_t|
|gaia_container_t|edc_container_t|
|gaia_set_iterator_t|edc_set_iterator_t|

**Note** I did not change any code under _scratch_. If you have checked in generated headers you will need to regenerate them.  I also didn't change any syntax under Q1 demos.  My thinking there was that they should match the code as it was in Q1.  I don't know if we have a requirement that code written for Q1 demos is compatible with current code.