### PR TITLE
[GAIAPLAT-601] Remove runtime checking of active fields in rule subscription

### DIFF
--- a/production/rules/event_manager/src/rule_checker.cpp
+++ b/production/rules/event_manager/src/rule_checker.cpp
@@ -130,12 +130,13 @@ void rule_checker_t::check_fields(gaia_id_t id, const field_position_list_t& fie
             gaia_field_t gaia_field = gaia_field_t::get(field_id);
             if (gaia_field.position() == requested_position)
             {
-                // If the field is deprecated then we should not be able to subscribe to it.
-                // TODO[GAIAPLAT-622] If we ever add a "strict" mode to the database
-                // then we should reinstate checking for active fields.
+                // If the field is deprecated, then we should not be able to subscribe to it.
+                // TODO[GAIAPLAT-622] If we ever add a "strict" mode to the database, then we
+                // should reinstate checking for active fields.
                 if (gaia_field.deprecated())
                 {
-                    throw invalid_subscription(id, gaia_table.name(), requested_position, gaia_field.name(), gaia_field.deprecated());
+                    throw invalid_subscription(
+                        id, gaia_table.name(), requested_position, gaia_field.name(), gaia_field.deprecated());
                 }
                 found_requested_field = true;
                 break;

--- a/production/rules/event_manager/tests/test_rule_checker.cpp
+++ b/production/rules/event_manager/tests/test_rule_checker.cpp
@@ -162,7 +162,7 @@ TEST_F(rule_checker_test, inactive_field)
     field_position_list_t fields;
     fields.emplace_back(g_field_positions["inactive"]);
 
-    // The following should not throw since we don't require the field
+    // The following should not throw because we don't require the field
     // to be marked as 'active' in the schema.  Note that this behavior may
     // change if a strict mode is enabled as described in GAIAPLAT-622.
     rule_checker.check_catalog(g_table_type, fields);
@@ -208,7 +208,7 @@ TEST_F(rule_checker_test, multiple_fields)
     fields.emplace_back(g_field_positions["active"]);
     fields.emplace_back(g_field_positions["inactive"]);
 
-    // The following should not throw since we don't require the field
+    // The following should not throw because we don't require the field
     // to be marked as 'active' in the schema.  Note that this behavior may
     // change if a strict mode is enabled as described in GAIAPLAT-622.
     rule_checker.check_catalog(g_table_type, fields);


### PR DESCRIPTION
This removes the runtime check that a field is marked as 'active' in the catalog when subscribing the rule. I added [GAIAPLAT-623](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-623) to remove the translation-time check in `gaiat`.