### PR TITLE
Update field_diff logic to handle array field types

### DIFF
--- a/production/db/core/src/payload_diff.cpp
+++ b/production/db/core/src/payload_diff.cpp
@@ -44,12 +44,9 @@ void compute_payload_diff(
     for (auto field_view : catalog_core_t::list_fields(type_record_id))
     {
         field_position_t field_position = field_view.position();
-        payload_types::data_holder_t data_holder1 = payload_types::get_field_value(
-            type_id, payload1, schema.data(), schema.size(), field_position);
-        payload_types::data_holder_t data_holder2 = payload_types::get_field_value(
-            type_id, payload2, schema.data(), schema.size(), field_position);
 
-        if (data_holder1.compare(data_holder2) != 0)
+        if (!payload_types::are_field_values_equal(
+                type_id, payload1, payload2, schema.data(), schema.size(), field_position))
         {
             changed_fields->push_back(field_position);
         }

--- a/production/db/inc/payload_types/field_access.hpp
+++ b/production/db/inc/payload_types/field_access.hpp
@@ -11,6 +11,7 @@
 #include "flatbuffers/reflection.h"
 
 #include "gaia/exception.hpp"
+
 #include "data_holder.hpp"
 #include "type_cache.hpp"
 
@@ -100,6 +101,16 @@ bool verify_data_schema(
     size_t serialized_data_size,
     const uint8_t* binary_schema);
 
+// Returns true if the field values are equal and false if they are different.
+// This function handles both scalar fields and array fields.
+bool are_field_values_equal(
+    gaia::common::gaia_type_t type_id,
+    const uint8_t* first_serialized_data,
+    const uint8_t* second_serialized_data,
+    const uint8_t* binary_schema,
+    size_t binary_schema_size,
+    gaia::common::field_position_t field_position);
+
 // Get the field value of a table record payload.
 data_holder_t get_field_value(
     gaia::common::gaia_type_t type_id,
@@ -110,7 +121,7 @@ data_holder_t get_field_value(
 
 // Set the scalar field value of a table record payload.
 //
-// This function only works for scalar fields (integers and floating point numbers).
+// This function only works for scalar fields of numeric types (integers and floating point numbers).
 bool set_field_value(
     gaia::common::gaia_type_t type_id,
     uint8_t* serialized_data,
@@ -185,7 +196,7 @@ data_holder_t get_field_array_element(
 //
 // An exception will be thrown if the index is out of bounds.
 //
-// This function only works for scalar fields (integers and floating point numbers).
+// This function only works for scalar fields of numeric types (integers and floating point numbers).
 void set_field_array_element(
     gaia::common::gaia_type_t type_id,
     uint8_t* serialized_data,

--- a/production/db/payload_types/tests/test_field_access.cpp
+++ b/production/db/payload_types/tests/test_field_access.cpp
@@ -284,6 +284,31 @@ void get_fields_data(
             ASSERT_TRUE(credit_amount.hold.float_value <= c_last_yearly_top_credit_amounts[i] + 1);
         }
     }
+
+    // A few quick equality checks.
+    ASSERT_TRUE(are_field_values_equal(
+        c_type_id,
+        data_loader.get_data(),
+        data_loader.get_data(),
+        pass_schema ? schema_loader.get_data() : nullptr,
+        pass_schema ? schema_loader.get_data_length() : 0,
+        field::last_name));
+
+    ASSERT_TRUE(are_field_values_equal(
+        c_type_id,
+        data_loader.get_data(),
+        data_loader.get_data(),
+        pass_schema ? schema_loader.get_data() : nullptr,
+        pass_schema ? schema_loader.get_data_length() : 0,
+        field::age));
+
+    ASSERT_TRUE(are_field_values_equal(
+        c_type_id,
+        data_loader.get_data(),
+        data_loader.get_data(),
+        pass_schema ? schema_loader.get_data() : nullptr,
+        pass_schema ? schema_loader.get_data_length() : 0,
+        field::known_aliases));
 }
 
 void process_flatbuffers_data(bool access_fields = false)
@@ -537,6 +562,23 @@ void update_flatbuffers_data()
         schema_loader.get_data_length(),
         field::last_yearly_top_credit_amounts,
         c_new_count_credit_amounts);
+
+    // A couple of quick (in)equality checks.
+    ASSERT_FALSE(are_field_values_equal(
+        c_type_id,
+        data_loader.get_data(),
+        serialization.data(),
+        schema_loader.get_data(),
+        schema_loader.get_data_length(),
+        field::last_name));
+
+    ASSERT_FALSE(are_field_values_equal(
+        c_type_id,
+        data_loader.get_data(),
+        serialization.data(),
+        schema_loader.get_data(),
+        schema_loader.get_data_length(),
+        field::known_aliases));
 
     // Write out the final serialization.
     ofstream file;


### PR DESCRIPTION
This change adds a new helper function for checking whether two field values are equal. This enables the `compute_payload_diff` method to determine changes in fields of array type, once such fields are supported.

Changes include:

- addition of new helper.
- update of `compute_payload_diff` to use new helper.
- update of unit tests to exercise new helper.