### PR TITLE
Make sure gaiat uses the c++ standard.

### DIFF
--- a/production/tools/gaia_translate/CMakeLists.txt
+++ b/production/tools/gaia_translate/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_command(
       -I ${GAIA_INC}
       -I ${SPDLOG_INC}
       -I /usr/include/clang/10/include/
-      -std=c++17
+      -std=c++${CMAKE_CXX_STANDARD}
   COMMAND pkill -f -KILL gaia_db_server &
   # In some contexts, the next attempt to start gaia_db_server precedes this kill, leading
   # to a build failure. A short sleep is currently fixing that, but may not be the
@@ -98,6 +98,7 @@ add_custom_command(
     -I ${GAIA_GENERATED_SCHEMAS}
     -I ${FLATBUFFERS_INC}
     -I /usr/include/clang/10/include/
+    -std=c++${CMAKE_CXX_STANDARD}
   COMMAND pkill -f -KILL gaia_db_server &
   # In some contexts, the next attempt to start gaia_db_server precedes this kill, leading
   # to a build failure. A short sleep is currently fixing that, but may not be the


### PR DESCRIPTION
When `gaiat` is run, it needs the `-std=c++17` like in other compiles. This includes it in the commands that invoke `gaiat` in the build.

This change doesn't affect anything in the current `master`, but some of the EDC enhancements coming soon require it.