### PR TITLE
Add namespace gaia::db to test_expressions.cpp

### DIFF
--- a/production/direct_access/tests/test_expressions.cpp
+++ b/production/direct_access/tests/test_expressions.cpp
@@ -21,6 +21,7 @@ using namespace gaia::addr_book;
 using namespace gaia::addr_book::employee_expr;
 using namespace gaia::addr_book::address_expr;
 using namespace gaia::common;
+using namespace gaia::db;
 using namespace gaia::direct_access;
 using namespace std;
 


### PR DESCRIPTION
This fixes a compile error in `test_expressions`. It looks like a merge of two PRs, where the changes of one should have also been applied to new files in the other.