### PR TITLE
Update comments in field_access files

### DIFF
--- a/production/db/inc/payload_types/field_access.hpp
+++ b/production/db/inc/payload_types/field_access.hpp
@@ -101,8 +101,9 @@ bool verify_data_schema(
     size_t serialized_data_size,
     const uint8_t* binary_schema);
 
-// Returns true if the field values are equal and false if they are different.
-// This function handles both scalar fields and array fields.
+// Return true if the field values are equal and false if they are different.
+//
+// This function handles numeric-type fields and numeric-type-array fields.
 bool are_field_values_equal(
     gaia::common::gaia_type_t type_id,
     const uint8_t* first_serialized_data,
@@ -111,7 +112,9 @@ bool are_field_values_equal(
     size_t binary_schema_size,
     gaia::common::field_position_t field_position);
 
-// Get the field value of a table record payload.
+// Get the value of a field.
+//
+// This function handles both numeric-type fields and string-type fields.
 data_holder_t get_field_value(
     gaia::common::gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -119,9 +122,7 @@ data_holder_t get_field_value(
     size_t binary_schema_size,
     gaia::common::field_position_t field_position);
 
-// Set the scalar field value of a table record payload.
-//
-// This function only works for scalar fields of numeric types (integers and floating point numbers).
+// Set the value of a numeric-type field.
 bool set_field_value(
     gaia::common::gaia_type_t type_id,
     uint8_t* serialized_data,
@@ -130,9 +131,7 @@ bool set_field_value(
     gaia::common::field_position_t field_position,
     const data_holder_t& value);
 
-// Set the string field value of a table record payload.
-//
-// This function only works for string fields.
+// Set the value of a string-type field.
 void set_field_value(
     gaia::common::gaia_type_t type_id,
     std::vector<uint8_t>& serialized_data,
@@ -141,8 +140,7 @@ void set_field_value(
     gaia::common::field_position_t field_position,
     const data_holder_t& value);
 
-// Alternative method for setting string fields,
-// when the serialization is not already available in a vector.
+// Set the value of a string-type field.
 std::vector<uint8_t> set_field_value(
     gaia::common::gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -152,7 +150,7 @@ std::vector<uint8_t> set_field_value(
     gaia::common::field_position_t field_position,
     const data_holder_t& value);
 
-// Get the size of a field of array type.
+// Get the size of an array-type field.
 size_t get_field_array_size(
     gaia::common::gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -160,7 +158,8 @@ size_t get_field_array_size(
     size_t binary_schema_size,
     gaia::common::field_position_t field_position);
 
-// Set the size of a field of array type.
+// Set the size of an array-type field.
+//
 // If the array is expanded, new entries will be set to 0.
 void set_field_array_size(
     gaia::common::gaia_type_t type_id,
@@ -170,7 +169,8 @@ void set_field_array_size(
     gaia::common::field_position_t field_position,
     size_t new_size);
 
-// Set the size of a field of array type.
+// Set the size of an array-type field.
+//
 // If the array is expanded, new entries will be set to 0.
 std::vector<uint8_t> set_field_array_size(
     gaia::common::gaia_type_t type_id,
@@ -181,7 +181,9 @@ std::vector<uint8_t> set_field_array_size(
     gaia::common::field_position_t field_position,
     size_t new_size);
 
-// Get a specific element of a field of array type.
+// Get a specific element of an array-type field.
+//
+// This function handles both numeric-type elements and string-type elements.
 //
 // An exception will be thrown if the index is out of bounds.
 data_holder_t get_field_array_element(
@@ -192,11 +194,9 @@ data_holder_t get_field_array_element(
     gaia::common::field_position_t field_position,
     size_t array_index);
 
-// Set a specific element of a scalar field of array type.
+// Set a specific numeric-type element of an array-type field .
 //
 // An exception will be thrown if the index is out of bounds.
-//
-// This function only works for scalar fields of numeric types (integers and floating point numbers).
 void set_field_array_element(
     gaia::common::gaia_type_t type_id,
     uint8_t* serialized_data,
@@ -206,11 +206,9 @@ void set_field_array_element(
     size_t array_index,
     const data_holder_t& value);
 
-// Set a specific element of a string field of array type.
+// Set a specific string-type element of an array-type field.
 //
 // An exception will be thrown if the index is out of bounds.
-//
-// This function only works for string fields.
 void set_field_array_element(
     gaia::common::gaia_type_t type_id,
     std::vector<uint8_t>& serialized_data,
@@ -220,11 +218,9 @@ void set_field_array_element(
     size_t array_index,
     const data_holder_t& value);
 
-// Set a specific element of a string field of array type.
+// Set a specific string-type element of an array-type field.
 //
 // An exception will be thrown if the index is out of bounds.
-//
-// This function only works for string fields.
 std::vector<uint8_t> set_field_array_element(
     gaia::common::gaia_type_t type_id,
     const uint8_t* serialized_data,

--- a/production/db/payload_types/src/field_access.cpp
+++ b/production/db/payload_types/src/field_access.cpp
@@ -127,13 +127,10 @@ bool verify_data_schema(
 
 // This is an internal helper for the field access methods.
 // It parses the flatbuffers serialization to get the root table
-// and then it retrieves the reflection::Field information
-// from the type's binary schema,
-// which is either loaded from the global type_cache
-// or parsed from the passed-in buffer.
+// and then it retrieves the reflection::Field information from the type's binary schema,
+// which is either loaded from the global type_cache or is parsed from the passed-in buffer.
 //
-// The caller is responsible for allocating the variables
-// that will hold the type_information information.
+// The caller is responsible for allocating the variables that will hold the type_information data.
 void get_table_field_information(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -175,7 +172,7 @@ void get_table_field_information(
     }
 }
 
-// Another helper for the methods that access field arrays.
+// Another helper for the methods that access array-type fields.
 // This helper also retrieves a VectorOfAny pointer
 // that allows operating on the array.
 void get_table_field_array_information(
@@ -282,7 +279,6 @@ bool are_field_values_equal(
     }
 }
 
-// The access method for scalar fields and strings.
 data_holder_t get_field_value(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -326,7 +322,6 @@ data_holder_t get_field_value(
     return result;
 }
 
-// The setter method for scalar fields.
 bool set_field_value(
     gaia_type_t type_id,
     uint8_t* serialized_data,
@@ -367,7 +362,6 @@ bool set_field_value(
     }
 }
 
-// The setter method for string fields.
 void set_field_value(
     gaia_type_t type_id,
     vector<uint8_t>& serialized_data,
@@ -416,7 +410,6 @@ void set_field_value(
         &serialized_data);
 }
 
-// Alternative setter method for string fields.
 vector<uint8_t> set_field_value(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -439,7 +432,6 @@ vector<uint8_t> set_field_value(
     return updatable_serialized_data;
 }
 
-// The access method for the size of a field of array type.
 size_t get_field_array_size(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -460,7 +452,6 @@ size_t get_field_array_size(
     return field_value->size();
 }
 
-// The setter method for the size of an array field.
 void set_field_array_size(
     gaia_type_t type_id,
     vector<uint8_t>& serialized_data,
@@ -510,7 +501,6 @@ void set_field_array_size(
         &serialized_data);
 }
 
-// Alternative setter method for the size of an array field.
 vector<uint8_t> set_field_array_size(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -533,7 +523,6 @@ vector<uint8_t> set_field_array_size(
     return updatable_serialized_data;
 }
 
-// The access method for an element of a field of array type.
 data_holder_t get_field_array_element(
     gaia_type_t type_id,
     const uint8_t* serialized_data,
@@ -573,7 +562,7 @@ data_holder_t get_field_array_element(
             = flatbuffers::GetAnyVectorElemPointer<const flatbuffers::String>(field_value, array_index);
         if (field_element_value == nullptr)
         {
-            // Unlike in the string scalar case, when we were calling GetFieldS(),
+            // Unlike in the string case, when we were calling GetFieldS(),
             // GetAnyVectorElemPointer() should not be able to return nullptr.
             throw invalid_serialized_data();
         }
@@ -588,7 +577,6 @@ data_holder_t get_field_array_element(
     return result;
 }
 
-// The setter method for a scalar element of a field of array type.
 void set_field_array_element(
     gaia_type_t type_id,
     uint8_t* serialized_data,
@@ -634,7 +622,6 @@ void set_field_array_element(
     }
 }
 
-// The setter method for a string element of a field of array type.
 void set_field_array_element(
     gaia_type_t type_id,
     vector<uint8_t>& serialized_data,
@@ -677,7 +664,7 @@ void set_field_array_element(
         = flatbuffers::GetAnyVectorElemPointer<const flatbuffers::String>(field_value, array_index);
     if (field_element_value == nullptr)
     {
-        // Unlike in the string scalar case, when we were calling GetFieldS(),
+        // Unlike in the string case, when we were calling GetFieldS(),
         // GetAnyVectorElemPointer() should not be able to return nullptr.
         throw invalid_serialized_data();
     }
@@ -689,7 +676,6 @@ void set_field_array_element(
         &serialized_data);
 }
 
-// Alternative setter method for a string element of a field of array type.
 std::vector<uint8_t> set_field_array_element(
     gaia_type_t type_id,
     const uint8_t* serialized_data,


### PR DESCRIPTION
Just updating comments in two files.

I removed most comments from the cpp file because they were redundant to those from the header file and thus were painful to maintain.