### PR TITLE
Fix txn log GC for rollbacks and aborts

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -112,7 +112,7 @@ private:
 
     static void txn_cleanup();
 
-    static void dedup_log();
+    static void sort_log();
 
     static void apply_txn_log(int log_fd);
 
@@ -187,13 +187,13 @@ private:
         }
 
         // We never allocate more than `c_max_log_records` records in the log.
-        if (s_log.data()->count == c_max_log_records)
+        if (s_log.data()->record_count == c_max_log_records)
         {
             throw transaction_object_limit_exceeded();
         }
 
         // Initialize the new record and increment the record count.
-        txn_log_t::log_record_t* lr = s_log.data()->log_records + s_log.data()->count++;
+        txn_log_t::log_record_t* lr = s_log.data()->log_records + s_log.data()->record_count++;
         lr->locator = locator;
         lr->old_offset = old_offset;
         lr->new_offset = new_offset;

--- a/production/db/core/inc/db_internal_types.hpp
+++ b/production/db/core/inc/db_internal_types.hpp
@@ -92,7 +92,7 @@ struct hash_node_t
 struct txn_log_t
 {
     gaia_txn_id_t begin_ts;
-    size_t count;
+    size_t record_count;
 
     struct log_record_t
     {
@@ -123,18 +123,19 @@ struct txn_log_t
 
     friend std::ostream& operator<<(std::ostream& os, const txn_log_t& l)
     {
-        os << "count: " << l.count << std::endl;
+        os << "record_count: " << l.record_count << std::endl;
         const log_record_t* const lr_start = static_cast<const log_record_t*>(l.log_records);
-        for (const log_record_t* lr = lr_start; lr < lr_start + l.count; ++lr)
+        for (const log_record_t* lr = lr_start; lr < lr_start + l.record_count; ++lr)
         {
-            os << *lr << std::endl;
+            os << *lr;
         }
+        os << std::endl;
         return os;
     }
 
     inline size_t size()
     {
-        return sizeof(txn_log_t) + (sizeof(txn_log_t::log_record_t) * count);
+        return sizeof(txn_log_t) + (sizeof(txn_log_t::log_record_t) * record_count);
     }
 };
 

--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -426,7 +426,7 @@ private:
 
     static void apply_txn_redo_log_from_ts(gaia_txn_id_t commit_ts);
 
-    static void gc_txn_undo_log(int log_fd, bool deallocate_new_offsets = false);
+    static void gc_txn_log(int log_fd, bool committed = true);
 
     static void deallocate_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets = false);
 

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -180,21 +180,6 @@ void server::handle_begin_txn(
     send_msg_with_fds(s_session_socket, &client_socket, 1, builder.GetBufferPointer(), builder.GetSize());
 }
 
-void server::free_uncommitted_allocations(session_event_t txn_status)
-{
-    bool deallocate_new_offsets = true;
-
-    // Deallocate transaction objects in case of an abort or rollback.
-    if (txn_status == session_event_t::ROLLBACK_TXN)
-    {
-        gc_txn_undo_log(s_fd_log, deallocate_new_offsets);
-    }
-    else if (txn_status == session_event_t::DECIDE_TXN_ABORT)
-    {
-        deallocate_txn_log(s_log, deallocate_new_offsets);
-    }
-}
-
 void server::handle_rollback_txn(
     int* fds, size_t fd_count, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
@@ -207,8 +192,8 @@ void server::handle_rollback_txn(
 
     retail_assert(s_fd_log == -1, "fd log should be uninitialized!");
 
-    // Get the log fd and mmap it if the client sends it.
-    // The client will not send the log segment to the server in case a read only txn was rolled back.
+    // Get the log fd and free it if the client sends it.
+    // The client will not send the txn log to the server if a read-only txn was rolled back.
     if (fds && fd_count == 1)
     {
         s_fd_log = *fds;
@@ -269,11 +254,6 @@ void server::handle_commit_txn(
     // thread advancing the watermark can clean up this txn's log fd.
     cleanup_log_fd.dismiss();
     session_event_t decision = success ? session_event_t::DECIDE_TXN_COMMIT : session_event_t::DECIDE_TXN_ABORT;
-
-    // If the txn aborts, then this frees all redo versions, and we ignore all
-    // undo versions when we invalidate the txn log fd, so there is nothing to
-    // do at that point except close the log fd.
-    free_uncommitted_allocations(decision);
 
     // Server-initiated state transition! (Any issues with reentrant handlers?)
     apply_transition(decision, nullptr, nullptr, 0);
@@ -2147,7 +2127,7 @@ bool server::txn_logs_conflict(int log_fd1, int log_fd2)
 
     // Now perform standard merge intersection and terminate on the first conflict found.
     size_t log1_idx = 0, log2_idx = 0;
-    while (log1_idx < log1.data()->count && log2_idx < log2.data()->count)
+    while (log1_idx < log1.data()->record_count && log2_idx < log2.data()->record_count)
     {
         txn_log_t::log_record_t* lr1 = log1.data()->log_records + log1_idx;
         txn_log_t::log_record_t* lr2 = log2.data()->log_records + log2_idx;
@@ -2465,7 +2445,7 @@ void server::apply_txn_redo_log_from_ts(gaia_txn_id_t commit_ts)
         txn_log.data()->begin_ts == get_begin_ts(commit_ts),
         "txn log begin_ts must match begin_ts reference in commit_ts entry!");
 
-    for (size_t i = 0; i < txn_log.data()->count; ++i)
+    for (size_t i = 0; i < txn_log.data()->record_count; ++i)
     {
         // Update the shared locator view with each redo version (i.e., the
         // version created or updated by the txn). This is safe as long as the
@@ -2479,39 +2459,40 @@ void server::apply_txn_redo_log_from_ts(gaia_txn_id_t commit_ts)
     }
 }
 
-void server::gc_txn_undo_log(int log_fd, bool deallocate_new_offsets)
+void server::gc_txn_log(int log_fd, bool committed)
 {
     mapped_log_t txn_log;
     txn_log.open(log_fd);
 
     retail_assert(txn_log.is_set(), "txn_log should be mapped when deallocating old offsets.");
+    bool deallocate_new_offsets = !committed;
     deallocate_txn_log(txn_log.data(), deallocate_new_offsets);
 }
 
 void server::deallocate_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets)
 {
-    for (size_t i = 0; i < txn_log->count; ++i)
+    for (size_t i = 0; i < txn_log->record_count; ++i)
     {
-        if (deallocate_new_offsets)
-        {
-            // Need to free the new offset for aborted and rollbacked transactions.
-            gaia_offset_t new_offset = txn_log->log_records[i].new_offset;
-            if (new_offset && s_object_deallocator_fn)
-            {
-                s_object_deallocator_fn(new_offset);
-            }
-        }
-        else
-        {
-            // Free each undo version (i.e., the version superseded by an update or
-            // delete operation), using the registered object deallocator (if it
-            // exists).
-            gaia_offset_t old_offset = txn_log->log_records[i].old_offset;
+        // For committed txns, free each undo version (i.e., the version
+        // superseded by an update or delete operation), using the registered
+        // object deallocator (if it exists), since the redo versions may still
+        // be visible but the undo versions cannot be. For aborted or
+        // rolled-back txns, free only the redo versions (since the undo
+        // versions may still be visible).
+        // NB: we can't safely free the redo versions and txn logs of aborted
+        // txns in the decide handler, because concurrently validating txns
+        // might be testing the aborted txn for conflicts while they still think
+        // it is undecided. The only safe place to free the redo versions and
+        // txn log of an aborted txn is after it falls behind the watermark,
+        // since at that point it cannot be in the conflict window of any
+        // committing txn.
+        gaia_offset_t offset_to_free = deallocate_new_offsets
+            ? txn_log->log_records[i].new_offset
+            : txn_log->log_records[i].old_offset;
 
-            if (old_offset && s_object_deallocator_fn)
-            {
-                s_object_deallocator_fn(old_offset);
-            }
+        if (offset_to_free && s_object_deallocator_fn)
+        {
+            s_object_deallocator_fn(offset_to_free);
         }
     }
 }
@@ -2642,17 +2623,12 @@ void server::update_apply_watermark(gaia_txn_id_t begin_ts)
             int log_fd = get_txn_log_fd(ts);
             retail_assert(log_fd != -1, "log fd cannot be invalidated if we advanced the watermark first!");
             retail_assert(is_fd_valid(log_fd), "log fd cannot be closed if we advanced the watermark first!");
-            // Invalidate the log fd, GC the undo versions in the log, and close the fd.
+            // Invalidate the log fd, GC the log, and close the fd.
             bool has_invalidated_fd = invalidate_txn_log_fd(ts);
-            retail_assert(has_invalidated_fd, "Invalidation must succeed if we were the first thread to advance the watermark to this commit_ts!");
-            // We only want to deallocate undo versions if this txn committed.
-            // Otherwise we do nothing since the undo versions are still visible
-            // and the redo versions were already freed in the txn abort
-            // handler.
-            if (is_txn_committed(ts))
-            {
-                gc_txn_undo_log(log_fd);
-            }
+            retail_assert(
+                has_invalidated_fd,
+                "Invalidation must succeed if we were the first thread to advance the watermark to this commit_ts!");
+            gc_txn_log(log_fd, is_txn_committed(ts));
             close_fd(log_fd);
         }
     }
@@ -2717,7 +2693,7 @@ void server::txn_rollback()
     if (s_fd_log != -1)
     {
         // Free any deallocated objects.
-        free_uncommitted_allocations(session_event_t::ROLLBACK_TXN);
+        gc_txn_log(s_fd_log, false);
     }
 }
 

--- a/production/db/core/src/persistent_store_manager.cpp
+++ b/production/db/core/src/persistent_store_manager.cpp
@@ -125,7 +125,7 @@ void persistent_store_manager::prepare_wal_for_write(gaia::db::txn_log_t* log, c
     size_t key_count = 0;
     // Obtain RocksDB transaction object.
     auto txn = m_rdb_internal->get_txn_by_name(txn_name);
-    for (size_t i = 0; i < log->count; i++)
+    for (size_t i = 0; i < log->record_count; i++)
     {
         auto lr = log->log_records + i;
         if (lr->operation == gaia_operation_t::remove)
@@ -156,7 +156,7 @@ void persistent_store_manager::prepare_wal_for_write(gaia::db::txn_log_t* log, c
         }
     }
     // Ensure that keys were inserted into the RocksDB transaction object.
-    retail_assert(key_count == log->count, "Count of inserted objects differs from log count!");
+    retail_assert(key_count == log->record_count, "Count of inserted objects differs from log count!");
     m_rdb_internal->prepare_wal_for_write(txn);
 }
 


### PR DESCRIPTION
This change does several related things: it eliminates the leak of intermediate object versions (i.e., versions which were overwritten in the txn itself) by removing the complex txn log deduplication logic, it fixes an assert during txn validation due to incorrect handling of aborted txn logs, and it fixes a bug where the client failed to notify the server of rolled-back txns with no writes (i.e., read-only txns), so it could properly update their server-side txn state.

With these changes, all submitted txns are only GC'ed behind the watermark, whether they are committed or aborted. This prevents committing txns from having a txn log fd invalidated in the decide handler while they are testing it for conflicts. The txn validation algorithm assumes that if a txn log being tested for conflicts has its fd concurrently invalidated, it must be because the committing txn being validated has been concurrently (i.e. recursively) validated by a different thread. The special-casing of aborted txns (eagerly GC'ing their txn logs in the decide handler) violated this assumption (and fortunately triggered an assert).

I was not aware of this special handling of aborted txn logs until now, or that we were not sending any control message to the server on read-only txn rollback. This suggests that these aspects of the system need more asserts and/or test coverage.