### PR TITLE
Add CMake options to disable ASan and backward-cpp

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -31,7 +31,7 @@ set(FLATBUFFERS "${GAIA_REPO}/third_party/production/flatbuffers")
 set(FLATBUFFERS_INC "${FLATBUFFERS}/include")
 
 # Enable AddressSanitizer in debug mode.
-if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address")
 endif()

--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -14,9 +14,9 @@ project(production VERSION 0.1.0)
 
 option(EXECUTE_FDW_TESTS "Execute FDW tests" OFF)
 
-option(DISABLE_ASAN "Disable ASan in debug builds" OFF)
+option(ENABLE_ASAN "Enable ASan in debug builds" ON)
 
-option(DISABLE_STACKTRACE "Disable stack traces in debug builds" OFF)
+option(ENABLE_STACKTRACE "Enable stack traces in debug builds" ON)
 
 option(BUILD_GAIA_RELEASE "Build Gaia Release packages and binaries" OFF)
 include(GNUInstallDirs)
@@ -56,7 +56,7 @@ else()
   set(GAIA_COMPILE_FLAGS "-c -Wall -Wextra -ggdb")
   set(GAIA_LINK_FLAGS "-ggdb -pthread")
 endif()
-if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address")
 endif()

--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -117,7 +117,7 @@ set(GAIA_DB_SERVER_SOURCES
   src/db_server_exec.cpp
 )
 
-if((NOT DISABLE_STACKTRACE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_STACKTRACE AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   list(APPEND GAIA_DB_SERVER_SOURCES src/backward.cpp)
 endif()
 
@@ -135,7 +135,7 @@ target_include_directories(gaia_db_server SYSTEM PRIVATE "${GEN_DIR}")
 set_target_properties(gaia_db_server PROPERTIES COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -Wno-missing-field-initializers")
 set_target_properties(gaia_db_server PROPERTIES LINK_FLAGS ${GAIA_LINK_FLAGS})
 target_link_libraries(gaia_db_server PRIVATE gaia_common Threads::Threads rocks_wrapper gaia_memory_manager ${LIB_EXPLAIN} ${LIB_CAP} dl)
-if((NOT DISABLE_STACKTRACE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_STACKTRACE AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   target_link_libraries(gaia_db_server PUBLIC backward)
 endif()
 install(TARGETS gaia_db_server DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -162,7 +162,7 @@ if(Python3_FOUND AND pybind11_FOUND)
   set_target_properties(gaia_db_pybind PROPERTIES COMPILE_FLAGS
     "${GAIA_COMPILE_FLAGS} -Wno-deprecated-register -Wno-unused-parameter -fsized-deallocation")
   set_target_properties(gaia_db_pybind PROPERTIES LINK_FLAGS ${GAIA_LINK_FLAGS})
-  if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+  if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
     target_link_options(gaia_db_pybind PRIVATE "-shared-libasan")
   endif()
 
@@ -192,7 +192,7 @@ if(JAVA_FOUND AND JNI_FOUND)
   set_target_properties(gaia_db_jni PROPERTIES COMPILE_FLAGS
     "${GAIA_COMPILE_FLAGS} -Wno-deprecated-register -Wno-unused-parameter")
   set_target_properties(gaia_db_jni PROPERTIES LINK_FLAGS "${GAIA_LINK_FLAGS}")
-  if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+  if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
     target_link_options(gaia_db_jni PRIVATE "-shared-libasan")
   endif()
 endif()

--- a/production/examples/incubator/CMakeLists.txt
+++ b/production/examples/incubator/CMakeLists.txt
@@ -13,7 +13,7 @@ set(GAIA_COMPILE_FLAGS "-c -Wall -Wextra -ggdb")
 set(GAIA_LINK_FLAGS "-ggdb -pthread")
 
 # Enable AddressSanitizer in debug mode.
-if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address")
 endif()

--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(gaia PRIVATE
   ${SDK_LINK_LIBRARIES}
 )
 
-if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   target_link_options(gaia PRIVATE "-shared-libasan")
 endif()
 

--- a/production/sql/src/CMakeLists.txt
+++ b/production/sql/src/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_options(gaia_fdw PRIVATE ${PGSQL_LDFLAGS})
 # We need to un-quote this variable for some reason as well.
 separate_arguments(GAIA_LINK_FLAGS UNIX_COMMAND "${GAIA_LINK_FLAGS}")
 target_link_options(gaia_fdw PRIVATE ${GAIA_LINK_FLAGS})
-if((NOT DISABLE_ASAN) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if(ENABLE_ASAN AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   target_link_options(gaia_fdw PRIVATE "-shared-libasan")
 endif()
 


### PR DESCRIPTION
I've needed to do this manually for my stress testing, because both ASan and `backward-cpp` apparently consume unbounded memory over time, and ASan also slows down tests by about 2x. (ASan also has a limit on the number of threads that can ever be created, but that won't be an issue once https://github.com/gaia-platform/GaiaPlatform/pull/535 is merged.)