### PR TITLE
Rename client/server classes to client_t/server_t

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
     gaia_log::initialize({});
 
     int res = EXIT_SUCCESS;
-    db_server_t server;
+    server_t server;
     string output_path;
     string db_name;
     string ddl_filename;

--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -24,7 +24,7 @@ namespace gaia
 namespace db
 {
 
-class db_client_t
+class client_t
 {
     friend class gaia_ptr_t;
 

--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -5,28 +5,28 @@
 
 #pragma once
 
-inline bool db_client_t::is_transaction_active()
+inline bool client_t::is_transaction_active()
 {
     return (s_private_locators.is_set());
 }
 
-inline void db_client_t::set_commit_trigger(triggers::commit_trigger_fn trigger_fn)
+inline void client_t::set_commit_trigger(triggers::commit_trigger_fn trigger_fn)
 {
     s_txn_commit_trigger = trigger_fn;
 }
 
-inline gaia_txn_id_t db_client_t::get_txn_id()
+inline gaia_txn_id_t client_t::get_txn_id()
 {
     return s_txn_id;
 }
 
-inline bool db_client_t::is_valid_event(common::gaia_type_t type)
+inline bool client_t::is_valid_event(common::gaia_type_t type)
 {
     constexpr const common::gaia_type_t* c_end = c_trigger_excluded_types + std::size(c_trigger_excluded_types);
     return (s_txn_commit_trigger && (std::find(c_trigger_excluded_types, c_end, type) == c_end));
 }
 
-inline void db_client_t::verify_txn_active()
+inline void client_t::verify_txn_active()
 {
     if (!is_transaction_active())
     {
@@ -34,7 +34,7 @@ inline void db_client_t::verify_txn_active()
     }
 }
 
-inline void db_client_t::verify_no_txn()
+inline void client_t::verify_no_txn()
 {
     if (is_transaction_active())
     {
@@ -42,7 +42,7 @@ inline void db_client_t::verify_no_txn()
     }
 }
 
-inline void db_client_t::verify_session_active()
+inline void client_t::verify_session_active()
 {
     if (s_session_socket == -1)
     {
@@ -50,7 +50,7 @@ inline void db_client_t::verify_session_active()
     }
 }
 
-inline void db_client_t::verify_no_session()
+inline void client_t::verify_no_session()
 {
     if (s_session_socket != -1)
     {
@@ -58,7 +58,7 @@ inline void db_client_t::verify_no_session()
     }
 }
 
-inline void db_client_t::txn_log(
+inline void client_t::txn_log(
     gaia_locator_t locator,
     gaia_offset_t old_offset,
     gaia_offset_t new_offset,

--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -39,7 +39,7 @@ public:
     }
 };
 
-class db_server_t
+class server_t
 {
     friend gaia::db::locators_t* gaia::db::get_locators();
     friend gaia::db::counters_t* gaia::db::get_counters();

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -75,7 +75,7 @@ static constexpr char c_message_validating_txn_should_have_been_validated[]
 static constexpr char c_message_preceding_txn_should_have_been_validated[]
     = "A transaction with commit timestamp preceding this transaction's begin timestamp is undecided!";
 
-db_server_t::safe_fd_from_ts_t::safe_fd_from_ts_t(gaia_txn_id_t commit_ts, bool auto_close_fd)
+server_t::safe_fd_from_ts_t::safe_fd_from_ts_t(gaia_txn_id_t commit_ts, bool auto_close_fd)
     : m_auto_close_fd(auto_close_fd)
 {
     common::retail_assert(is_commit_ts(commit_ts), "You must initialize safe_fd_from_ts_t from a valid commit_ts!");
@@ -135,7 +135,7 @@ db_server_t::safe_fd_from_ts_t::safe_fd_from_ts_t(gaia_txn_id_t commit_ts, bool 
     }
 }
 
-db_server_t::safe_fd_from_ts_t::~safe_fd_from_ts_t()
+server_t::safe_fd_from_ts_t::~safe_fd_from_ts_t()
 {
     // Ensure we close the dup log fd. If the original log fd was closed
     // already (indicated by get_txn_log_fd() returning -1), this will free
@@ -148,12 +148,12 @@ db_server_t::safe_fd_from_ts_t::~safe_fd_from_ts_t()
     }
 }
 
-int db_server_t::safe_fd_from_ts_t::get_fd() const
+int server_t::safe_fd_from_ts_t::get_fd() const
 {
     return m_local_log_fd;
 }
 
-address_offset_t db_server_t::allocate_from_memory_manager(
+address_offset_t server_t::allocate_from_memory_manager(
     size_t memory_request_size_bytes)
 {
     retail_assert(
@@ -171,12 +171,12 @@ address_offset_t db_server_t::allocate_from_memory_manager(
 }
 
 // This assignment is non-atomic since there seems to be no reason to expect concurrent invocations.
-void db_server_t::register_object_deallocator(std::function<void(gaia_offset_t)> deallocator_fn)
+void server_t::register_object_deallocator(std::function<void(gaia_offset_t)> deallocator_fn)
 {
     s_object_deallocator_fn = deallocator_fn;
 }
 
-void db_server_t::handle_connect(
+void server_t::handle_connect(
     int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(event == session_event_t::CONNECT, c_message_unexpected_event_received);
@@ -194,7 +194,7 @@ void db_server_t::handle_connect(
     send_msg_with_fds(s_session_socket, send_fds, std::size(send_fds), builder.GetBufferPointer(), builder.GetSize());
 }
 
-void db_server_t::handle_begin_txn(
+void server_t::handle_begin_txn(
     int*, size_t, session_event_t event, const void* event_data, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(event == session_event_t::BEGIN_TXN, c_message_unexpected_event_received);
@@ -257,7 +257,7 @@ void db_server_t::handle_begin_txn(
     }
 }
 
-void db_server_t::get_txn_log_fds_for_snapshot(gaia_txn_id_t begin_ts, std::vector<int>& txn_log_fds)
+void server_t::get_txn_log_fds_for_snapshot(gaia_txn_id_t begin_ts, std::vector<int>& txn_log_fds)
 {
     // Take a snapshot of the post-apply watermark and scan backward from
     // begin_ts, stopping either just before the saved watermark or at the first
@@ -305,7 +305,7 @@ void db_server_t::get_txn_log_fds_for_snapshot(gaia_txn_id_t begin_ts, std::vect
     std::reverse(std::begin(txn_log_fds), std::end(txn_log_fds));
 }
 
-void db_server_t::handle_rollback_txn(
+void server_t::handle_rollback_txn(
     int* fds, size_t fd_count, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(event == session_event_t::ROLLBACK_TXN, c_message_unexpected_event_received);
@@ -329,7 +329,7 @@ void db_server_t::handle_rollback_txn(
     txn_rollback();
 }
 
-void db_server_t::handle_commit_txn(
+void server_t::handle_commit_txn(
     int* fds, size_t fd_count, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(event == session_event_t::COMMIT_TXN, c_message_unexpected_event_received);
@@ -384,7 +384,7 @@ void db_server_t::handle_commit_txn(
     apply_transition(decision, nullptr, nullptr, 0);
 }
 
-void db_server_t::handle_request_memory(
+void server_t::handle_request_memory(
     int*, size_t, session_event_t event, const void* event_data, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(
@@ -414,7 +414,7 @@ void db_server_t::handle_request_memory(
     send_msg_with_fds(s_session_socket, nullptr, 0, builder.GetBufferPointer(), builder.GetSize());
 }
 
-void db_server_t::handle_decide_txn(
+void server_t::handle_decide_txn(
     int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(
@@ -448,7 +448,7 @@ void db_server_t::handle_decide_txn(
     perform_maintenance();
 }
 
-void db_server_t::handle_client_shutdown(
+void server_t::handle_client_shutdown(
     int*, size_t, session_event_t event, const void*, session_state_t, session_state_t new_state)
 {
     retail_assert(
@@ -475,7 +475,7 @@ void db_server_t::handle_client_shutdown(
     }
 }
 
-void db_server_t::handle_server_shutdown(
+void server_t::handle_server_shutdown(
     int*, size_t, session_event_t event, const void*, session_state_t, session_state_t new_state)
 {
     retail_assert(
@@ -493,7 +493,7 @@ void db_server_t::handle_server_shutdown(
     s_session_shutdown = true;
 }
 
-std::pair<int, int> db_server_t::get_stream_socket_pair()
+std::pair<int, int> server_t::get_stream_socket_pair()
 {
     // Create a connected pair of datagram sockets, one of which we will keep
     // and the other we will send to the client.
@@ -521,7 +521,7 @@ std::pair<int, int> db_server_t::get_stream_socket_pair()
     return std::pair{client_socket, server_socket};
 }
 
-void db_server_t::handle_request_stream(
+void server_t::handle_request_stream(
     int*, size_t, session_event_t event, const void* event_data, session_state_t old_state, session_state_t new_state)
 {
     retail_assert(
@@ -576,7 +576,7 @@ void db_server_t::handle_request_stream(
     send_msg_with_fds(s_session_socket, &client_socket, 1, builder.GetBufferPointer(), builder.GetSize());
 }
 
-void db_server_t::apply_transition(session_event_t event, const void* event_data, int* fds, size_t fd_count)
+void server_t::apply_transition(session_event_t event, const void* event_data, int* fds, size_t fd_count)
 {
     if (event == session_event_t::NOP)
     {
@@ -619,7 +619,7 @@ void db_server_t::apply_transition(session_event_t event, const void* event_data
         + "'.");
 }
 
-void db_server_t::build_server_reply(
+void server_t::build_server_reply(
     FlatBufferBuilder& builder,
     session_event_t event,
     session_state_t old_state,
@@ -645,7 +645,7 @@ void db_server_t::build_server_reply(
     builder.Finish(message);
 }
 
-void db_server_t::clear_shared_memory()
+void server_t::clear_shared_memory()
 {
     s_shared_locators.close();
     s_shared_counters.close();
@@ -655,7 +655,7 @@ void db_server_t::clear_shared_memory()
 
 // To avoid synchronization, we assume that this method is only called when
 // no sessions exist and the server is not accepting any new connections.
-void db_server_t::init_shared_memory()
+void server_t::init_shared_memory()
 {
     // The listening socket must not be open.
     retail_assert(s_listening_socket == -1, "Listening socket should not be open!");
@@ -693,7 +693,7 @@ void db_server_t::init_shared_memory()
     cleanup_memory.dismiss();
 }
 
-void db_server_t::init_memory_manager()
+void server_t::init_memory_manager()
 {
     s_memory_manager.reset();
     s_memory_manager = make_unique<memory_manager_t>();
@@ -705,7 +705,7 @@ void db_server_t::init_memory_manager()
     register_object_deallocator(deallocate_object_fn);
 }
 
-address_offset_t db_server_t::allocate_object(
+address_offset_t server_t::allocate_object(
     gaia_locator_t locator,
     size_t size)
 {
@@ -779,7 +779,7 @@ address_offset_t db_server_t::allocate_object(
 // advancing the watermark on termination of the oldest active txn, which is
 // delegated to that txn's session thread.
 
-void db_server_t::init_txn_info()
+void server_t::init_txn_info()
 {
     // We reserve 2^45 bytes = 32TB of virtual address space. YOLO.
     constexpr size_t c_size_in_bytes = (1ULL << c_txn_ts_bits) * sizeof(*s_txn_info);
@@ -802,7 +802,7 @@ void db_server_t::init_txn_info()
         0);
 }
 
-void db_server_t::recover_db()
+void server_t::recover_db()
 {
     // If persistence is disabled, then this is a no-op.
     if (!(s_persistence_mode == persistence_mode_t::e_disabled))
@@ -829,7 +829,7 @@ void db_server_t::recover_db()
     }
 }
 
-sigset_t db_server_t::mask_signals()
+sigset_t server_t::mask_signals()
 {
     sigset_t sigset;
     ::sigemptyset(&sigset);
@@ -848,7 +848,7 @@ sigset_t db_server_t::mask_signals()
     return sigset;
 }
 
-void db_server_t::signal_handler(sigset_t sigset, int& signum)
+void server_t::signal_handler(sigset_t sigset, int& signum)
 {
     // Wait until a signal is delivered.
     // REVIEW: do we have any use for sigwaitinfo()?
@@ -859,7 +859,7 @@ void db_server_t::signal_handler(sigset_t sigset, int& signum)
     signal_eventfd(s_server_shutdown_eventfd);
 }
 
-void db_server_t::init_listening_socket()
+void server_t::init_listening_socket()
 {
     // Launch a connection-based listening Unix socket on a well-known address.
     // We use SOCK_SEQPACKET to get connection-oriented *and* datagram semantics.
@@ -905,7 +905,7 @@ void db_server_t::init_listening_socket()
     s_listening_socket = listening_socket;
 }
 
-bool db_server_t::authenticate_client_socket(int socket)
+bool server_t::authenticate_client_socket(int socket)
 {
     struct ucred cred;
     socklen_t cred_len = sizeof(cred);
@@ -986,7 +986,7 @@ static void reap_exited_threads(std::vector<std::thread>& threads)
     }
 }
 
-void db_server_t::client_dispatch_handler()
+void server_t::client_dispatch_handler()
 {
     // Register session cleanup handler first, so we can execute it last.
     auto session_cleanup = make_scope_guard([]() {
@@ -1110,7 +1110,7 @@ void db_server_t::client_dispatch_handler()
     }
 }
 
-void db_server_t::session_handler(int session_socket)
+void server_t::session_handler(int session_socket)
 {
     // Set up session socket.
     s_session_shutdown = false;
@@ -1297,7 +1297,7 @@ void db_server_t::session_handler(int session_socket)
 }
 
 template <typename T_element_type>
-void db_server_t::stream_producer_handler(
+void server_t::stream_producer_handler(
     int stream_socket, int cancel_eventfd, std::function<std::optional<T_element_type>()> generator_fn)
 {
     // We only support fixed-width integer types for now to avoid framing.
@@ -1483,7 +1483,7 @@ void db_server_t::stream_producer_handler(
 }
 
 template <typename T_element_type>
-void db_server_t::start_stream_producer(int stream_socket, std::function<std::optional<T_element_type>()> generator_fn)
+void server_t::start_stream_producer(int stream_socket, std::function<std::optional<T_element_type>()> generator_fn)
 {
     // First reap any owned threads that have terminated (to avoid memory and
     // system resource leaks).
@@ -1494,7 +1494,7 @@ void db_server_t::start_stream_producer(int stream_socket, std::function<std::op
         stream_producer_handler<T_element_type>, stream_socket, s_session_shutdown_eventfd, generator_fn);
 }
 
-std::function<std::optional<gaia_id_t>()> db_server_t::get_id_generator_for_type(gaia_type_t type)
+std::function<std::optional<gaia_id_t>()> server_t::get_id_generator_for_type(gaia_type_t type)
 {
     gaia_locator_t locator = 0;
 
@@ -1529,7 +1529,7 @@ std::function<std::optional<gaia_id_t>()> db_server_t::get_id_generator_for_type
     };
 }
 
-void db_server_t::validate_txns_in_range(gaia_txn_id_t start_ts, gaia_txn_id_t end_ts)
+void server_t::validate_txns_in_range(gaia_txn_id_t start_ts, gaia_txn_id_t end_ts)
 {
     // Scan txn table entries from start_ts to end_ts.
     // Invalidate any unknown entries and validate any undecided txns.
@@ -1551,7 +1551,7 @@ void db_server_t::validate_txns_in_range(gaia_txn_id_t start_ts, gaia_txn_id_t e
     }
 }
 
-const char* db_server_t::status_to_str(ts_entry_t ts_entry)
+const char* server_t::status_to_str(ts_entry_t ts_entry)
 {
     retail_assert(
         (ts_entry != c_txn_entry_unknown) && (ts_entry != c_txn_entry_invalid),
@@ -1578,7 +1578,7 @@ const char* db_server_t::status_to_str(ts_entry_t ts_entry)
     return nullptr;
 }
 
-void db_server_t::dump_ts_entry(gaia_txn_id_t ts)
+void server_t::dump_ts_entry(gaia_txn_id_t ts)
 {
     // NB: We generally cannot use the is_*_ts() functions since the entry could
     // change while we're reading it!
@@ -1635,7 +1635,7 @@ void db_server_t::dump_ts_entry(gaia_txn_id_t ts)
 // that timestamp, it simply allocates another timestamp and retries. This is
 // possible because we never publish a newly allocated timestamp until we know
 // that its entry has been successfully initialized.
-inline bool db_server_t::invalidate_unknown_ts(gaia_txn_id_t ts)
+inline bool server_t::invalidate_unknown_ts(gaia_txn_id_t ts)
 {
     // If the entry is not unknown, we can't invalidate it.
     if (!is_unknown_ts(ts))
@@ -1660,133 +1660,133 @@ inline bool db_server_t::invalidate_unknown_ts(gaia_txn_id_t ts)
     return has_invalidated_entry;
 }
 
-inline bool db_server_t::is_unknown_ts(gaia_txn_id_t ts)
+inline bool server_t::is_unknown_ts(gaia_txn_id_t ts)
 {
     return s_txn_info[ts] == c_txn_entry_unknown;
 }
 
-inline bool db_server_t::is_invalid_ts(gaia_txn_id_t ts)
+inline bool server_t::is_invalid_ts(gaia_txn_id_t ts)
 {
     return s_txn_info[ts] == c_txn_entry_invalid;
 }
 
-inline bool db_server_t::is_txn_entry_begin_ts(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_begin_ts(ts_entry_t ts_entry)
 {
     // The "unknown" value has the commit bit unset, so we need to check it as well.
     return ((ts_entry != c_txn_entry_unknown) && ((ts_entry & c_txn_status_commit_mask) == 0));
 }
 
-inline bool db_server_t::is_begin_ts(gaia_txn_id_t ts)
+inline bool server_t::is_begin_ts(gaia_txn_id_t ts)
 {
     ts_entry_t ts_entry = s_txn_info[ts];
     return is_txn_entry_begin_ts(ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_commit_ts(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_commit_ts(ts_entry_t ts_entry)
 {
     // The "invalid" value has the commit bit set, so we need to check it as well.
     return ((ts_entry != c_txn_entry_invalid) && ((ts_entry & c_txn_status_commit_mask) == c_txn_status_commit_mask));
 }
 
-inline bool db_server_t::is_commit_ts(gaia_txn_id_t ts)
+inline bool server_t::is_commit_ts(gaia_txn_id_t ts)
 {
     ts_entry_t ts_entry = s_txn_info[ts];
     return is_txn_entry_commit_ts(ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_submitted(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_submitted(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_submitted);
 }
 
-inline bool db_server_t::is_txn_submitted(gaia_txn_id_t begin_ts)
+inline bool server_t::is_txn_submitted(gaia_txn_id_t begin_ts)
 {
     retail_assert(is_begin_ts(begin_ts), c_message_not_a_begin_timestamp);
     ts_entry_t begin_ts_entry = s_txn_info[begin_ts];
     return is_txn_entry_submitted(begin_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_validating(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_validating(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_validating);
 }
 
-inline bool db_server_t::is_txn_validating(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_validating(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     return is_txn_entry_validating(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_decided(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_decided(ts_entry_t ts_entry)
 {
     constexpr uint64_t c_decided_mask = c_txn_status_decided << c_txn_status_flags_shift;
     return ((ts_entry & c_decided_mask) == c_decided_mask);
 }
 
-inline bool db_server_t::is_txn_decided(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_decided(gaia_txn_id_t commit_ts)
 {
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     retail_assert(is_txn_entry_commit_ts(commit_ts_entry), c_message_not_a_commit_timestamp);
     return is_txn_entry_decided(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_committed(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_committed(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_committed);
 }
 
-inline bool db_server_t::is_txn_committed(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_committed(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     return is_txn_entry_committed(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_aborted(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_aborted(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_aborted);
 }
 
-inline bool db_server_t::is_txn_aborted(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_aborted(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     return is_txn_entry_aborted(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_gc_complete(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_gc_complete(ts_entry_t ts_entry)
 {
     uint64_t gc_flags = (ts_entry & c_txn_gc_flags_mask) >> c_txn_gc_flags_shift;
     return (gc_flags == c_txn_gc_complete);
 }
 
-inline bool db_server_t::is_txn_gc_complete(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_gc_complete(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), "Not a commit timestamp!");
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     return is_txn_entry_gc_complete(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_durable(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_durable(ts_entry_t ts_entry)
 {
     uint64_t persistence_flags = (ts_entry & c_txn_persistence_flags_mask) >> c_txn_persistence_flags_shift;
     return (persistence_flags == c_txn_persistence_complete);
 }
 
-inline bool db_server_t::is_txn_durable(gaia_txn_id_t commit_ts)
+inline bool server_t::is_txn_durable(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), "Not a commit timestamp!");
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
     return is_txn_entry_durable(commit_ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_active(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_active(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_active);
 }
 
-inline bool db_server_t::is_txn_active(gaia_txn_id_t begin_ts)
+inline bool server_t::is_txn_active(gaia_txn_id_t begin_ts)
 {
     retail_assert(begin_ts != c_txn_entry_unknown, c_message_unknown_timestamp);
     retail_assert(is_begin_ts(begin_ts), c_message_not_a_begin_timestamp);
@@ -1794,12 +1794,12 @@ inline bool db_server_t::is_txn_active(gaia_txn_id_t begin_ts)
     return is_txn_entry_active(ts_entry);
 }
 
-inline bool db_server_t::is_txn_entry_terminated(ts_entry_t ts_entry)
+inline bool server_t::is_txn_entry_terminated(ts_entry_t ts_entry)
 {
     return (get_status_from_entry(ts_entry) == c_txn_status_terminated);
 }
 
-inline bool db_server_t::is_txn_terminated(gaia_txn_id_t begin_ts)
+inline bool server_t::is_txn_terminated(gaia_txn_id_t begin_ts)
 {
     retail_assert(begin_ts != c_txn_entry_unknown, c_message_unknown_timestamp);
     retail_assert(is_begin_ts(begin_ts), c_message_not_a_begin_timestamp);
@@ -1807,7 +1807,7 @@ inline bool db_server_t::is_txn_terminated(gaia_txn_id_t begin_ts)
     return is_txn_entry_terminated(ts_entry);
 }
 
-inline uint64_t db_server_t::get_status(gaia_txn_id_t ts)
+inline uint64_t server_t::get_status(gaia_txn_id_t ts)
 {
     retail_assert(
         !is_unknown_ts(ts) && !is_invalid_ts(ts),
@@ -1816,12 +1816,12 @@ inline uint64_t db_server_t::get_status(gaia_txn_id_t ts)
     return get_status_from_entry(ts_entry);
 }
 
-inline uint64_t db_server_t::get_status_from_entry(ts_entry_t ts_entry)
+inline uint64_t server_t::get_status_from_entry(ts_entry_t ts_entry)
 {
     return ((ts_entry & c_txn_status_flags_mask) >> c_txn_status_flags_shift);
 }
 
-inline gaia_txn_id_t db_server_t::get_begin_ts(gaia_txn_id_t commit_ts)
+inline gaia_txn_id_t server_t::get_begin_ts(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     ts_entry_t commit_ts_entry = s_txn_info[commit_ts];
@@ -1831,7 +1831,7 @@ inline gaia_txn_id_t db_server_t::get_begin_ts(gaia_txn_id_t commit_ts)
     return begin_ts;
 }
 
-inline gaia_txn_id_t db_server_t::get_commit_ts(gaia_txn_id_t begin_ts)
+inline gaia_txn_id_t server_t::get_commit_ts(gaia_txn_id_t begin_ts)
 {
     retail_assert(is_begin_ts(begin_ts), c_message_not_a_begin_timestamp);
     retail_assert(is_txn_submitted(begin_ts), "begin_ts must be submitted!");
@@ -1845,13 +1845,13 @@ inline gaia_txn_id_t db_server_t::get_commit_ts(gaia_txn_id_t begin_ts)
     return commit_ts;
 }
 
-inline int db_server_t::get_txn_log_fd(gaia_txn_id_t commit_ts)
+inline int server_t::get_txn_log_fd(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     return get_txn_log_fd_from_entry(s_txn_info[commit_ts]);
 }
 
-inline int db_server_t::get_txn_log_fd_from_entry(ts_entry_t commit_ts_entry)
+inline int server_t::get_txn_log_fd_from_entry(ts_entry_t commit_ts_entry)
 {
     // The txn log fd is the 16 bits of the ts entry after the 3 status bits.
     uint16_t fd = (commit_ts_entry & c_txn_log_fd_mask) >> c_txn_log_fd_shift;
@@ -1859,7 +1859,7 @@ inline int db_server_t::get_txn_log_fd_from_entry(ts_entry_t commit_ts_entry)
     return (fd != c_invalid_txn_log_fd_bits) ? static_cast<int>(fd) : -1;
 }
 
-inline bool db_server_t::invalidate_txn_log_fd(gaia_txn_id_t commit_ts)
+inline bool server_t::invalidate_txn_log_fd(gaia_txn_id_t commit_ts)
 {
     retail_assert(is_commit_ts(commit_ts), c_message_not_a_commit_timestamp);
     retail_assert(is_txn_decided(commit_ts), "Cannot invalidate an undecided txn!");
@@ -1892,7 +1892,7 @@ inline bool db_server_t::invalidate_txn_log_fd(gaia_txn_id_t commit_ts)
 }
 
 // Sets the begin_ts entry's status to TXN_SUBMITTED.
-inline void db_server_t::set_active_txn_submitted(gaia_txn_id_t begin_ts, gaia_txn_id_t commit_ts)
+inline void server_t::set_active_txn_submitted(gaia_txn_id_t begin_ts, gaia_txn_id_t commit_ts)
 {
     // Only an active txn can be submitted.
     retail_assert(is_txn_active(begin_ts), "Not an active transaction!");
@@ -1909,7 +1909,7 @@ inline void db_server_t::set_active_txn_submitted(gaia_txn_id_t begin_ts, gaia_t
 }
 
 // Sets the begin_ts entry's status to TXN_TERMINATED.
-inline void db_server_t::set_active_txn_terminated(gaia_txn_id_t begin_ts)
+inline void server_t::set_active_txn_terminated(gaia_txn_id_t begin_ts)
 {
     // Only an active txn can be terminated.
     retail_assert(is_txn_active(begin_ts), "Not an active transaction!");
@@ -1924,7 +1924,7 @@ inline void db_server_t::set_active_txn_terminated(gaia_txn_id_t begin_ts)
     s_txn_info[begin_ts] = new_entry;
 }
 
-inline gaia_txn_id_t db_server_t::register_commit_ts(gaia_txn_id_t begin_ts, int log_fd)
+inline gaia_txn_id_t server_t::register_commit_ts(gaia_txn_id_t begin_ts, int log_fd)
 {
     // We construct the commit_ts entry by concatenating status flags (3 bits),
     // txn log fd (16 bits), reserved bits (3 bits), and begin_ts (42 bits).
@@ -1952,7 +1952,7 @@ inline gaia_txn_id_t db_server_t::register_commit_ts(gaia_txn_id_t begin_ts, int
     return commit_ts;
 }
 
-gaia_txn_id_t db_server_t::submit_txn(gaia_txn_id_t begin_ts, int log_fd)
+gaia_txn_id_t server_t::submit_txn(gaia_txn_id_t begin_ts, int log_fd)
 {
     // The begin_ts entry must fit in 42 bits.
     retail_assert(begin_ts < (1ULL << c_txn_ts_bits), "begin_ts must fit in 42 bits!");
@@ -1974,7 +1974,7 @@ gaia_txn_id_t db_server_t::submit_txn(gaia_txn_id_t begin_ts, int log_fd)
     return commit_ts;
 }
 
-void db_server_t::update_txn_decision(gaia_txn_id_t commit_ts, bool committed)
+void server_t::update_txn_decision(gaia_txn_id_t commit_ts, bool committed)
 {
     // The commit_ts entry must be in state TXN_VALIDATING or TXN_DECIDED.
     // We allow the latter to enable idempotent concurrent validation.
@@ -2025,7 +2025,7 @@ void db_server_t::update_txn_decision(gaia_txn_id_t commit_ts, bool committed)
 // first common element is found), so we write our own simple merge intersection
 // code. If we ever need to return the IDs of all conflicting objects to clients
 // (or just log them for diagnostics), we could use std::set_intersection.
-bool db_server_t::txn_logs_conflict(int log_fd1, int log_fd2)
+bool server_t::txn_logs_conflict(int log_fd1, int log_fd2)
 {
     // First map the two fds.
     mapped_log_t log1;
@@ -2055,7 +2055,7 @@ bool db_server_t::txn_logs_conflict(int log_fd1, int log_fd2)
     return false;
 }
 
-bool db_server_t::validate_txn(gaia_txn_id_t commit_ts)
+bool server_t::validate_txn(gaia_txn_id_t commit_ts)
 {
     // Validation algorithm:
 
@@ -2315,7 +2315,7 @@ bool db_server_t::validate_txn(gaia_txn_id_t commit_ts)
 // NB: we use compare_exchange_weak() for the global update since we need to
 // retry anyway on concurrent updates, so tolerating spurious failures
 // requires no additional logic.
-bool db_server_t::advance_watermark(std::atomic<gaia_txn_id_t>& watermark, gaia_txn_id_t ts)
+bool server_t::advance_watermark(std::atomic<gaia_txn_id_t>& watermark, gaia_txn_id_t ts)
 {
     gaia_txn_id_t last_watermark_ts = watermark;
     do
@@ -2332,7 +2332,7 @@ bool db_server_t::advance_watermark(std::atomic<gaia_txn_id_t>& watermark, gaia_
     return true;
 }
 
-void db_server_t::apply_txn_log_from_ts(gaia_txn_id_t commit_ts)
+void server_t::apply_txn_log_from_ts(gaia_txn_id_t commit_ts)
 {
     retail_assert(
         is_commit_ts(commit_ts) && is_txn_committed(commit_ts),
@@ -2377,7 +2377,7 @@ void db_server_t::apply_txn_log_from_ts(gaia_txn_id_t commit_ts)
         "Committed txn applied to shared locators view out of order!");
 }
 
-bool db_server_t::set_txn_gc_complete(gaia_txn_id_t commit_ts)
+bool server_t::set_txn_gc_complete(gaia_txn_id_t commit_ts)
 {
     ts_entry_t expected_entry = s_txn_info[commit_ts];
     // Set GC status to TXN_GC_COMPLETE.
@@ -2385,7 +2385,7 @@ bool db_server_t::set_txn_gc_complete(gaia_txn_id_t commit_ts)
     return s_txn_info[commit_ts].compare_exchange_strong(expected_entry, commit_ts_entry);
 }
 
-void db_server_t::gc_txn_log_from_fd(int log_fd, bool committed)
+void server_t::gc_txn_log_from_fd(int log_fd, bool committed)
 {
     mapped_log_t txn_log;
     txn_log.open(log_fd);
@@ -2395,7 +2395,7 @@ void db_server_t::gc_txn_log_from_fd(int log_fd, bool committed)
     deallocate_txn_log(txn_log.data(), deallocate_new_offsets);
 }
 
-void db_server_t::deallocate_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets)
+void server_t::deallocate_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets)
 {
     retail_assert(txn_log, "txn_log must be a valid mapped address!");
 
@@ -2517,7 +2517,7 @@ void db_server_t::deallocate_txn_log(txn_log_t* txn_log, bool deallocate_new_off
 // very fast sequence of operations, retries should be infrequent, so livelock
 // shouldn't be an issue.)
 
-void db_server_t::perform_maintenance()
+void server_t::perform_maintenance()
 {
     // Attempt to apply all txn logs to the shared view, from the last value of
     // the post-apply watermark to the latest committed txn.
@@ -2533,7 +2533,7 @@ void db_server_t::perform_maintenance()
     update_txn_table_safe_truncation_point();
 }
 
-void db_server_t::apply_txn_logs_to_shared_view()
+void server_t::apply_txn_logs_to_shared_view()
 {
     // First get a snapshot of the timestamp counter for an upper bound on
     // the scan (we don't know yet if this is a begin_ts or commit_ts).
@@ -2659,7 +2659,7 @@ void db_server_t::apply_txn_logs_to_shared_view()
     }
 }
 
-void db_server_t::gc_applied_txn_logs()
+void server_t::gc_applied_txn_logs()
 {
     // First get a snapshot of the post-apply watermark, for an upper bound on the scan.
     gaia_txn_id_t last_freed_commit_ts_lower_bound = s_last_freed_commit_ts_lower_bound;
@@ -2740,7 +2740,7 @@ void db_server_t::gc_applied_txn_logs()
     }
 }
 
-void db_server_t::update_txn_table_safe_truncation_point()
+void server_t::update_txn_table_safe_truncation_point()
 {
     // First get a snapshot of the post-apply watermark, for an upper bound on the scan.
     gaia_txn_id_t last_applied_commit_ts_lower_bound = s_last_applied_commit_ts_lower_bound;
@@ -2792,7 +2792,7 @@ void db_server_t::update_txn_table_safe_truncation_point()
 
 // This method allocates a new begin_ts and initializes its entry in the txn
 // table.
-gaia_txn_id_t db_server_t::txn_begin()
+gaia_txn_id_t server_t::txn_begin()
 {
     // The newly allocated begin timestamp for the new txn.
     gaia_txn_id_t begin_ts;
@@ -2827,7 +2827,7 @@ gaia_txn_id_t db_server_t::txn_begin()
     return begin_ts;
 }
 
-void db_server_t::txn_rollback()
+void server_t::txn_rollback()
 {
     retail_assert(
         s_txn_id != c_invalid_gaia_txn_id,
@@ -2857,7 +2857,7 @@ void db_server_t::txn_rollback()
 // Before this method is called, we have already received the log fd from the client
 // and mmapped it.
 // This method returns true for a commit decision and false for an abort decision.
-bool db_server_t::txn_commit()
+bool server_t::txn_commit()
 {
     retail_assert(s_fd_log != -1, c_message_uninitialized_fd_log);
 
@@ -2901,7 +2901,7 @@ bool db_server_t::txn_commit()
 
 // this must be run on main thread
 // see https://thomastrapp.com/blog/signal-handler-for-multithreaded-c++/
-void db_server_t::run(persistence_mode_t persistence_mode)
+void server_t::run(persistence_mode_t persistence_mode)
 {
     // There can only be one thread running at this point, so this doesn't need synchronization.
     s_persistence_mode = persistence_mode;

--- a/production/db/core/src/db_server_exec.cpp
+++ b/production/db/core/src/db_server_exec.cpp
@@ -22,11 +22,11 @@ static void usage()
     std::cerr
         << "\nCopyright (c) Gaia Platform LLC\n\n"
         << "Usage: gaia_db_server ["
-        << gaia::db::db_server_t::c_disable_persistence_flag
+        << gaia::db::server_t::c_disable_persistence_flag
         << " | "
-        << gaia::db::db_server_t::c_disable_persistence_after_recovery_flag
+        << gaia::db::server_t::c_disable_persistence_after_recovery_flag
         << " | "
-        << gaia::db::db_server_t::c_reinitialize_persistent_store_flag
+        << gaia::db::server_t::c_reinitialize_persistent_store_flag
         << "] \n"
         << "                      ["
         << gaia::db::persistent_store_manager::c_data_dir_command_flag
@@ -61,28 +61,28 @@ static void expand_user_path(std::string& path)
     path = home + path.substr(1);
 }
 
-static db_server_t::persistence_mode_t process_command_line(int argc, char* argv[])
+static server_t::persistence_mode_t process_command_line(int argc, char* argv[])
 {
     std::set<std::string> used_flags;
     bool found_data_dir = false;
     const char* conf_file_path = nullptr;
 
-    db_server_t::persistence_mode_t persistence_mode{db_server_t::persistence_mode_t::e_default};
+    server_t::persistence_mode_t persistence_mode{server_t::persistence_mode_t::e_default};
 
     for (int i = 1; i < argc; ++i)
     {
         used_flags.insert(argv[i]);
-        if (strcmp(argv[i], gaia::db::db_server_t::c_disable_persistence_flag) == 0)
+        if (strcmp(argv[i], gaia::db::server_t::c_disable_persistence_flag) == 0)
         {
-            persistence_mode = db_server_t::persistence_mode_t::e_disabled;
+            persistence_mode = server_t::persistence_mode_t::e_disabled;
         }
-        else if (strcmp(argv[i], gaia::db::db_server_t::c_disable_persistence_after_recovery_flag) == 0)
+        else if (strcmp(argv[i], gaia::db::server_t::c_disable_persistence_after_recovery_flag) == 0)
         {
-            persistence_mode = db_server_t::persistence_mode_t::e_disabled_after_recovery;
+            persistence_mode = server_t::persistence_mode_t::e_disabled_after_recovery;
         }
-        else if (strcmp(argv[i], gaia::db::db_server_t::c_reinitialize_persistent_store_flag) == 0)
+        else if (strcmp(argv[i], gaia::db::server_t::c_reinitialize_persistent_store_flag) == 0)
         {
-            persistence_mode = db_server_t::persistence_mode_t::e_reinitialized_on_startup;
+            persistence_mode = server_t::persistence_mode_t::e_reinitialized_on_startup;
         }
         else if ((strcmp(argv[i], gaia::db::persistent_store_manager::c_data_dir_command_flag) == 0) && (i + 1 < argc))
         {
@@ -105,7 +105,7 @@ static db_server_t::persistence_mode_t process_command_line(int argc, char* argv
     }
 
     std::string gaia_configuration_file;
-    if (!found_data_dir && (persistence_mode != db_server_t::persistence_mode_t::e_disabled))
+    if (!found_data_dir && (persistence_mode != server_t::persistence_mode_t::e_disabled))
     {
         // Since there is no --data-dir parameter, locate it from the configuration.
         gaia_configuration_file = gaia::common::get_conf_file_path(conf_file_path, c_default_conf_file_name);
@@ -129,22 +129,22 @@ static db_server_t::persistence_mode_t process_command_line(int argc, char* argv
     }
 
     // In case anyone can see this...
-    if (persistence_mode == db_server_t::persistence_mode_t::e_disabled)
+    if (persistence_mode == server_t::persistence_mode_t::e_disabled)
     {
         std::cerr
             << "Persistence is disabled." << std::endl;
     }
-    if (persistence_mode == db_server_t::persistence_mode_t::e_disabled_after_recovery)
+    if (persistence_mode == server_t::persistence_mode_t::e_disabled_after_recovery)
     {
         std::cerr
             << "Persistence is disabled after recovery." << std::endl;
     }
-    if (persistence_mode == db_server_t::persistence_mode_t::e_reinitialized_on_startup)
+    if (persistence_mode == server_t::persistence_mode_t::e_reinitialized_on_startup)
     {
         std::cerr
             << "Persistence is reinitialized on startup." << std::endl;
     }
-    if (persistence_mode != db_server_t::persistence_mode_t::e_disabled)
+    if (persistence_mode != server_t::persistence_mode_t::e_disabled)
     {
         if (!found_data_dir)
         {
@@ -189,11 +189,11 @@ static db_server_t::persistence_mode_t process_command_line(int argc, char* argv
 
     for (const auto& flag_pair : std::initializer_list<std::pair<std::string, std::string>>{
              // Disable persistence flag is mutually exclusive with specifying data directory for persistence.
-             {gaia::db::db_server_t::c_disable_persistence_flag, gaia::db::persistent_store_manager::c_data_dir_command_flag},
+             {gaia::db::server_t::c_disable_persistence_flag, gaia::db::persistent_store_manager::c_data_dir_command_flag},
              // The three persistence flags that are mutually exclusive with each other.
-             {gaia::db::db_server_t::c_disable_persistence_flag, gaia::db::db_server_t::c_disable_persistence_after_recovery_flag},
-             {gaia::db::db_server_t::c_disable_persistence_flag, gaia::db::db_server_t::c_reinitialize_persistent_store_flag},
-             {gaia::db::db_server_t::c_disable_persistence_after_recovery_flag, gaia::db::db_server_t::c_reinitialize_persistent_store_flag}})
+             {gaia::db::server_t::c_disable_persistence_flag, gaia::db::server_t::c_disable_persistence_after_recovery_flag},
+             {gaia::db::server_t::c_disable_persistence_flag, gaia::db::server_t::c_reinitialize_persistent_store_flag},
+             {gaia::db::server_t::c_disable_persistence_after_recovery_flag, gaia::db::server_t::c_reinitialize_persistent_store_flag}})
     {
         if ((used_flags.find(flag_pair.first) != used_flags.end()) && (used_flags.find(flag_pair.second) != used_flags.end()))
         {
@@ -215,5 +215,5 @@ int main(int argc, char* argv[])
 {
     auto persistence_mode = process_command_line(argc, argv);
 
-    gaia::db::db_server_t::run(persistence_mode);
+    gaia::db::server_t::run(persistence_mode);
 }

--- a/production/db/core/src/db_shared_data_client.cpp
+++ b/production/db/core/src/db_shared_data_client.cpp
@@ -8,7 +8,7 @@
 
 gaia::db::locators_t* gaia::db::get_locators()
 {
-    if (!gaia::db::db_client_t::s_private_locators.is_set())
+    if (!gaia::db::client_t::s_private_locators.is_set())
     {
         throw no_open_transaction();
     }
@@ -21,7 +21,7 @@ gaia::db::locators_t* gaia::db::get_locators()
     // observing a null locators pointer should always be the result of a
     // programming error, i.e., calling a transactional operation outside a
     // transaction) before adding an assert here.
-    return gaia::db::db_client_t::s_private_locators.data();
+    return gaia::db::client_t::s_private_locators.data();
 }
 
 gaia::db::counters_t* gaia::db::get_counters()
@@ -30,12 +30,12 @@ gaia::db::counters_t* gaia::db::get_counters()
     // it is always non-null (since callers should never be able to observe it
     // in its null state, i.e., with the counters segment unmapped).
 
-    if (!gaia::db::db_client_t::s_shared_counters.is_set())
+    if (!gaia::db::client_t::s_shared_counters.is_set())
     {
         throw no_active_session();
     }
 
-    return gaia::db::db_client_t::s_shared_counters.data();
+    return gaia::db::client_t::s_shared_counters.data();
 }
 
 gaia::db::data_t* gaia::db::get_data()
@@ -44,12 +44,12 @@ gaia::db::data_t* gaia::db::get_data()
     // it is always non-null (since callers should never be able to observe it
     // in its null state, i.e., with the data segment unmapped).
 
-    if (!gaia::db::db_client_t::s_shared_data.is_set())
+    if (!gaia::db::client_t::s_shared_data.is_set())
     {
         throw no_active_session();
     }
 
-    return gaia::db::db_client_t::s_shared_data.data();
+    return gaia::db::client_t::s_shared_data.data();
 }
 
 gaia::db::id_index_t* gaia::db::get_id_index()
@@ -58,17 +58,17 @@ gaia::db::id_index_t* gaia::db::get_id_index()
     // it is always non-null (since callers should never be able to observe it
     // in its null state, i.e., with the id_index segment unmapped).
 
-    if (!gaia::db::db_client_t::s_shared_id_index.is_set())
+    if (!gaia::db::client_t::s_shared_id_index.is_set())
     {
         throw no_active_session();
     }
 
-    return gaia::db::db_client_t::s_shared_id_index.data();
+    return gaia::db::client_t::s_shared_id_index.data();
 }
 
 gaia::db::memory_manager::address_offset_t gaia::db::allocate_object(
     gaia_locator_t locator,
     size_t size)
 {
-    return gaia::db::db_client_t::allocate_object(locator, size);
+    return gaia::db::client_t::allocate_object(locator, size);
 }

--- a/production/db/core/src/db_shared_data_server.cpp
+++ b/production/db/core/src/db_shared_data_server.cpp
@@ -10,8 +10,8 @@ gaia::db::locators_t* gaia::db::get_locators()
 {
     // The server's locator segment should always be mapped whenever any callers
     // of this method are able to observe it.
-    common::retail_assert(gaia::db::db_server_t::s_shared_locators.is_set(), "Server locators segment is unmapped!");
-    return gaia::db::db_server_t::s_shared_locators.data();
+    common::retail_assert(gaia::db::server_t::s_shared_locators.is_set(), "Server locators segment is unmapped!");
+    return gaia::db::server_t::s_shared_locators.data();
 }
 
 gaia::db::counters_t* gaia::db::get_counters()
@@ -19,8 +19,8 @@ gaia::db::counters_t* gaia::db::get_counters()
     // Since we don't use this accessor in the server itself, we can assert that
     // it is always non-null (since callers should never be able to see it in
     // its null state, i.e., with the counters segment unmapped).
-    common::retail_assert(gaia::db::db_server_t::s_shared_counters.is_set(), "Server counters segment is unmapped!");
-    return gaia::db::db_server_t::s_shared_counters.data();
+    common::retail_assert(gaia::db::server_t::s_shared_counters.is_set(), "Server counters segment is unmapped!");
+    return gaia::db::server_t::s_shared_counters.data();
 }
 
 gaia::db::data_t* gaia::db::get_data()
@@ -28,8 +28,8 @@ gaia::db::data_t* gaia::db::get_data()
     // Since we don't use this accessor in the server itself, we can assert that
     // it is always non-null (since callers should never be able to see it in
     // its null state, i.e., with the data segment unmapped).
-    common::retail_assert(gaia::db::db_server_t::s_shared_data.is_set(), "Server data segment is unmapped!");
-    return gaia::db::db_server_t::s_shared_data.data();
+    common::retail_assert(gaia::db::server_t::s_shared_data.is_set(), "Server data segment is unmapped!");
+    return gaia::db::server_t::s_shared_data.data();
 }
 
 gaia::db::id_index_t* gaia::db::get_id_index()
@@ -37,13 +37,13 @@ gaia::db::id_index_t* gaia::db::get_id_index()
     // Since we don't use this accessor in the server itself, we can assert that
     // it is always non-null (since callers should never be able to see it in
     // its null state, i.e., with the id_index segment unmapped).
-    common::retail_assert(gaia::db::db_server_t::s_shared_id_index.is_set(), "Server id_index segment is unmapped!");
-    return gaia::db::db_server_t::s_shared_id_index.data();
+    common::retail_assert(gaia::db::server_t::s_shared_id_index.is_set(), "Server id_index segment is unmapped!");
+    return gaia::db::server_t::s_shared_id_index.data();
 }
 
 gaia::db::memory_manager::address_offset_t gaia::db::allocate_object(
     gaia_locator_t locator,
     size_t size)
 {
-    return gaia::db::db_server_t::allocate_object(locator, size);
+    return gaia::db::server_t::allocate_object(locator, size);
 }

--- a/production/db/core/src/gaia_db.cpp
+++ b/production/db/core/src/gaia_db.cpp
@@ -12,47 +12,47 @@
 
 bool gaia::db::is_transaction_active()
 {
-    return gaia::db::db_client_t::is_transaction_active();
+    return gaia::db::client_t::is_transaction_active();
 }
 
 void gaia::db::begin_session()
 {
-    gaia::db::db_client_t::begin_session();
+    gaia::db::client_t::begin_session();
 }
 
 void gaia::db::end_session()
 {
-    gaia::db::db_client_t::end_session();
+    gaia::db::client_t::end_session();
 }
 
 void gaia::db::begin_transaction()
 {
-    gaia::db::db_client_t::begin_transaction();
+    gaia::db::client_t::begin_transaction();
 }
 
 void gaia::db::rollback_transaction()
 {
-    gaia::db::db_client_t::rollback_transaction();
+    gaia::db::client_t::rollback_transaction();
 }
 
 void gaia::db::commit_transaction()
 {
-    gaia::db::db_client_t::commit_transaction();
+    gaia::db::client_t::commit_transaction();
 }
 
 void gaia::db::set_commit_trigger(gaia::db::triggers::commit_trigger_fn trigger_fn)
 {
-    gaia::db::db_client_t::set_commit_trigger(trigger_fn);
+    gaia::db::client_t::set_commit_trigger(trigger_fn);
 }
 
 void gaia::db::clear_shared_memory()
 {
-    gaia::db::db_client_t::clear_shared_memory();
+    gaia::db::client_t::clear_shared_memory();
 }
 
 gaia::db::gaia_txn_id_t gaia::db::get_txn_id()
 {
-    return gaia::db::db_client_t::get_txn_id();
+    return gaia::db::client_t::get_txn_id();
 }
 
 // Implements Murmur3 64-bit finalizer
@@ -77,7 +77,7 @@ static inline uint64_t mix_bits(uint64_t x)
 // Returns uint64_t since gaia_txn_id_t isn't a public type.
 uint64_t gaia::db::transaction_id()
 {
-    auto txn_id = static_cast<uint64_t>(gaia::db::db_client_t::get_txn_id());
+    auto txn_id = static_cast<uint64_t>(gaia::db::client_t::get_txn_id());
     uint64_t obfuscated_txn_id = mix_bits(txn_id);
     // We require that mix_bits() maps 0 to 0, and that its inverse does as well.
     common::retail_assert(

--- a/production/db/core/src/gaia_ptr.cpp
+++ b/production/db/core/src/gaia_ptr.cpp
@@ -61,7 +61,7 @@ gaia_ptr_t gaia_ptr_t::create(gaia_id_t id, gaia_type_t type, size_t num_referen
     hash_node_t* hash_node = db_hash_map::insert(id);
     size_t object_size = total_payload_size + sizeof(db_object_t);
     hash_node->locator = allocate_locator();
-    address_offset_t offset = db_client_t::allocate_object(hash_node->locator, object_size);
+    address_offset_t offset = client_t::allocate_object(hash_node->locator, object_size);
     gaia_ptr_t obj(hash_node->locator, offset);
     db_object_t* obj_ptr = obj.to_ptr();
     obj_ptr->id = id;
@@ -107,7 +107,7 @@ void gaia_ptr_t::clone_no_txn()
 {
     db_object_t* old_this = to_ptr();
     size_t new_size = sizeof(db_object_t) + old_this->payload_size;
-    db_client_t::allocate_object(m_locator, new_size);
+    client_t::allocate_object(m_locator, new_size);
     db_object_t* new_this = to_ptr();
     memcpy(new_this, old_this, new_size);
 }
@@ -117,12 +117,12 @@ gaia_ptr_t& gaia_ptr_t::clone()
     gaia_offset_t old_offset = to_offset();
     clone_no_txn();
 
-    db_client_t::txn_log(m_locator, old_offset, to_offset(), gaia_operation_t::clone);
+    client_t::txn_log(m_locator, old_offset, to_offset(), gaia_operation_t::clone);
 
     db_object_t* new_this = to_ptr();
-    if (db_client_t::is_valid_event(new_this->type))
+    if (client_t::is_valid_event(new_this->type))
     {
-        db_client_t::s_events.emplace_back(event_type_t::row_insert, new_this->type, new_this->id, empty_position_list);
+        client_t::s_events.emplace_back(event_type_t::row_insert, new_this->type, new_this->id, empty_position_list);
     }
 
     return *this;
@@ -141,7 +141,7 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
     }
 
     // Updates m_locator to point to the new object.
-    db_client_t::allocate_object(m_locator, sizeof(db_object_t) + total_payload_size);
+    client_t::allocate_object(m_locator, sizeof(db_object_t) + total_payload_size);
 
     db_object_t* new_this = to_ptr();
 
@@ -154,9 +154,9 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
     new_this->num_references = old_this->num_references;
     memcpy(new_this->payload + references_size, data, data_size);
 
-    db_client_t::txn_log(m_locator, old_offset, to_offset(), gaia_operation_t::update);
+    client_t::txn_log(m_locator, old_offset, to_offset(), gaia_operation_t::update);
 
-    if (db_client_t::is_valid_event(new_this->type))
+    if (client_t::is_valid_event(new_this->type))
     {
         auto new_data = reinterpret_cast<const uint8_t*>(data);
         auto old_data = reinterpret_cast<const uint8_t*>(old_this->payload);
@@ -165,7 +165,7 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
         // Compute field difference.
         field_position_list_t position_list;
         compute_payload_diff(new_this->type, old_data_payload, new_data, &position_list);
-        db_client_t::s_events.emplace_back(event_type_t::row_update, new_this->type, new_this->id, position_list);
+        client_t::s_events.emplace_back(event_type_t::row_update, new_this->type, new_this->id, position_list);
     }
 
     return *this;
@@ -173,9 +173,9 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
 
 void gaia_ptr_t::create_insert_trigger(gaia_type_t type, gaia_id_t id)
 {
-    if (db_client_t::is_valid_event(type))
+    if (client_t::is_valid_event(type))
     {
-        db_client_t::s_events.emplace_back(event_type_t::row_insert, type, id, empty_position_list);
+        client_t::s_events.emplace_back(event_type_t::row_insert, type, id, empty_position_list);
     }
 }
 
@@ -187,18 +187,18 @@ gaia_ptr_t::gaia_ptr_t(gaia_id_t id)
 gaia_ptr_t::gaia_ptr_t(gaia_locator_t locator, address_offset_t offset)
 {
     m_locator = locator;
-    db_client_t::txn_log(m_locator, 0, get_gaia_offset(offset), gaia_operation_t::create);
+    client_t::txn_log(m_locator, 0, get_gaia_offset(offset), gaia_operation_t::create);
 }
 
 db_object_t* gaia_ptr_t::to_ptr() const
 {
-    db_client_t::verify_txn_active();
+    client_t::verify_txn_active();
     return locator_to_ptr(m_locator);
 }
 
 gaia_offset_t gaia_ptr_t::to_offset() const
 {
-    db_client_t::verify_txn_active();
+    client_t::verify_txn_active();
     return locator_to_offset(m_locator);
 }
 
@@ -224,21 +224,21 @@ void gaia_ptr_t::find_next(gaia_type_t type)
 void gaia_ptr_t::reset()
 {
     gaia::db::locators_t* locators = gaia::db::get_locators();
-    db_client_t::txn_log(m_locator, to_offset(), 0, gaia_operation_t::remove, to_ptr()->id);
+    client_t::txn_log(m_locator, to_offset(), 0, gaia_operation_t::remove, to_ptr()->id);
 
-    if (db_client_t::is_valid_event(to_ptr()->type))
+    if (client_t::is_valid_event(to_ptr()->type))
     {
-        db_client_t::s_events.emplace_back(event_type_t::row_delete, to_ptr()->type, to_ptr()->id, empty_position_list);
+        client_t::s_events.emplace_back(event_type_t::row_delete, to_ptr()->type, to_ptr()->id, empty_position_list);
     }
     (*locators)[m_locator] = c_invalid_gaia_offset;
     m_locator = c_invalid_gaia_locator;
 }
 
-// This trivial implementation is necessary to avoid calling into db_client_t code from the header file.
+// This trivial implementation is necessary to avoid calling into client_t code from the header file.
 std::function<std::optional<gaia_id_t>()>
 gaia_ptr_t::get_id_generator_for_type(gaia_type_t type)
 {
-    return db_client_t::get_id_generator_for_type(type);
+    return client_t::get_id_generator_for_type(type);
 }
 
 void gaia_ptr_t::add_child_reference(gaia_id_t child_id, reference_offset_t first_child_offset)
@@ -308,8 +308,8 @@ void gaia_ptr_t::add_child_reference(gaia_id_t child_id, reference_offset_t firs
     references()[first_child_offset] = child_ptr.id();
     child_ptr.references()[relationship->parent_offset] = id();
 
-    db_client_t::txn_log(m_locator, old_parent_offset, to_offset(), gaia_operation_t::update);
-    db_client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset(), gaia_operation_t::update);
+    client_t::txn_log(m_locator, old_parent_offset, to_offset(), gaia_operation_t::update);
+    client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset(), gaia_operation_t::update);
 }
 
 void gaia_ptr_t::add_parent_reference(gaia_id_t parent_id, reference_offset_t parent_offset)
@@ -409,8 +409,8 @@ void gaia_ptr_t::remove_child_reference(gaia_id_t child_id, reference_offset_t f
         curr_ptr.references()[relationship->next_child_offset] = c_invalid_gaia_id;
     }
 
-    db_client_t::txn_log(m_locator, old_parent_offset, to_offset(), gaia_operation_t::update);
-    db_client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset(), gaia_operation_t::update);
+    client_t::txn_log(m_locator, old_parent_offset, to_offset(), gaia_operation_t::update);
+    client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset(), gaia_operation_t::update);
 }
 
 void gaia_ptr_t::remove_parent_reference(gaia_id_t parent_id, reference_offset_t parent_offset)

--- a/production/inc/gaia_internal/db/db_test_helpers.hpp
+++ b/production/inc/gaia_internal/db/db_test_helpers.hpp
@@ -102,15 +102,15 @@ inline void reset_server()
     wait_for_server_init();
 }
 
-class db_server_t
+class server_t
 {
 public:
-    db_server_t()
+    server_t()
     {
         set_path(nullptr);
     }
 
-    explicit db_server_t(
+    explicit server_t(
         const char* db_server_path,
         bool disable_persistence = false)
         : m_disable_persistence(disable_persistence)

--- a/production/system/tests/test_recovery.cpp
+++ b/production/system/tests/test_recovery.cpp
@@ -44,7 +44,7 @@ class recovery_test : public ::testing::Test
 {
 public:
     // Empty server path, enable persistence.
-    static inline db_server_t s_server{nullptr, false};
+    static inline server_t s_server{nullptr, false};
 
     static void set_server_path(const char* server_path)
     {


### PR DESCRIPTION
Also renamed `safe_fd_from_ts` to `safe_fd_from_ts_t`.

Let me know if you know of any other database classes that would need similar renaming.