### PR TITLE
Add C style code comment syntax to Gaia DDL

### DIFF
--- a/production/catalog/parser/src/lexer.ll
+++ b/production/catalog/parser/src/lexer.ll
@@ -26,6 +26,9 @@
     make_NUMBER (const std::string &s, const yy::parser::location_type& loc);
 %}
 
+/* The exclusive start condition for C style comments. */
+%x xcomment
+
 id    [a-zA-Z][a-zA-Z_0-9]*
 int   [0-9]+
 blank [ \t\r]
@@ -44,9 +47,18 @@ comment ("--".*)
     loc.step ();
 %}
 
+
+"/*"              BEGIN(xcomment);
+<xcomment>"*/"    BEGIN(INITIAL);
+<xcomment>[^*\n]+ { /* ignore anything that's not a '*' */ }
+<xcomment>"*"[^/] { /* ignore '*' not followed by a '/' */ }
+<xcomment>\n      loc.lines(yyleng);
+
+
 {blank}+     loc.step();
 {comment}    { /* ignore */ }
 \n+          loc.lines(yyleng); loc.step();
+
 
 "CREATE"     return yy::parser::make_CREATE(loc);
 "DROP"       return yy::parser::make_DROP(loc);

--- a/production/catalog/parser/tests/test_ddl_parser.cpp
+++ b/production/catalog/parser/tests/test_ddl_parser.cpp
@@ -248,3 +248,29 @@ TEST(catalog_ddl_parser_test, vector_of_strings)
     parser_t parser;
     ASSERT_EQ(EXIT_FAILURE, parser.parse_line("CREATE TABLE t (c STRING[]);"));
 }
+
+TEST(catalog_ddl_parser_test, code_comments)
+{
+    const string correct_ddl_text = R"(
+-------------------------------
+/*
+ * block comment
+ */
+-------------------------------
+CREATE TABLE t -- create table t
+( /**
+   **/ id int, -- column id
+  /* column c */ c STRING -- column c
+); -- end create table t
+-------------------------------
+)";
+
+    const string incorrect_ddl_text = R"(/*)";
+
+    parser_t parser;
+
+    ASSERT_EQ(EXIT_SUCCESS, parser.parse_line(correct_ddl_text));
+    EXPECT_EQ(1, parser.statements.size());
+
+    ASSERT_EQ(EXIT_FAILURE, parser.parse_line(incorrect_ddl_text));
+}


### PR DESCRIPTION
The C style `/* */` comments are also supported in SQL standard. Add support for this style of comments to our DDL as well.