### PR TITLE
Do not pull in internal retail assert header

### DIFF
--- a/production/inc/gaia/direct_access/edc_array.hpp
+++ b/production/inc/gaia/direct_access/edc_array.hpp
@@ -11,8 +11,6 @@
 
 #include "gaia/direct_access/edc_object.hpp"
 
-#include "gaia_internal/common/retail_assert.hpp"
-
 namespace gaia
 {
 
@@ -54,7 +52,6 @@ private:
         : m_vector(vector_ptr)
     {
         static_assert(std::is_arithmetic<T_type>::value, "edc_vector_t only supports basic types!");
-        common::retail_assert(vector_ptr != nullptr, "edc_vector_t does not support null-valued array pointers!");
     };
 
     const flatbuffers::Vector<T_type>* m_vector;


### PR DESCRIPTION
Looks like good intent caused the sdk to break.  Please do not pull in internal headers from public headers.

And yes, I really, really, need to get back to my SDK team city integration task.