### PR TITLE
Txn durability followup: clean up comments and bitwise logic

### DIFF
--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -2318,8 +2318,6 @@ bool server_t::txn_commit()
         // This is effectively asynchronous with validation, because if it takes
         // too long, then another thread may recursively validate this txn,
         // before the committing thread has a chance to do so.
-        // NB: We only mark the txn as durable after validation, to simplify
-        // reasoning about txn state transitions.
         rdb->prepare_wal_for_write(s_log, txn_name);
     }
 
@@ -2332,16 +2330,14 @@ bool server_t::txn_commit()
     txn_metadata_t::update_txn_decision(commit_ts, is_committed);
 
     // Persist the commit decision.
-    // Eventually, we will return a decision to the client asynchronously with
-    // the decision being persisted (because the decision can be reconstructed
-    // from the durable log itself, without the decision record).
+    // REVIEW: We can return a decision to the client asynchronously with the
+    // decision being persisted (because the decision can be reconstructed from
+    // the durable log itself, without the decision record).
     if (rdb)
     {
         // Mark txn as durable in metadata so we can GC the txn log.
-        // The txn may be considered durable even if it hasn't yet been
-        // validated, since the decision can be reconstructed from the durable
-        // log, but we only mark it durable after validation to simplify the
-        // state transitions: we only allow
+        // We only mark it durable after validation to simplify the
+        // state transitions:
         // TXN_VALIDATING -> TXN_DECIDED -> TXN_DURABLE.
         txn_metadata_t::set_txn_durable(commit_ts);
 

--- a/production/db/core/src/txn_metadata.cpp
+++ b/production/db/core/src/txn_metadata.cpp
@@ -226,11 +226,11 @@ void txn_metadata_t::update_txn_decision(gaia_txn_id_t commit_ts, bool is_commit
 
     txn_metadata_t decided_commit_ts_metadata = commit_ts_metadata;
 
-    // This masks out just the commit_ts flag bits.
-    constexpr uint64_t c_commit_flags_mask = ~(~c_txn_status_commit_ts << c_txn_status_flags_shift);
+    // This masks out all bits except the commit_ts flag bits.
+    constexpr uint64_t c_commit_flags_mask = ~c_txn_status_commit_ts << c_txn_status_flags_shift;
 
     // Turn off all commit flag bits before turning on the bits for this decision.
-    decided_commit_ts_metadata.m_value &= c_commit_flags_mask;
+    decided_commit_ts_metadata.m_value &= ~c_commit_flags_mask;
 
     // Now set the decision flags.
     decided_commit_ts_metadata.m_value |= (decided_status_flags << c_txn_status_flags_shift);


### PR DESCRIPTION
This just addresses some post-merge feedback from https://github.com/gaia-platform/GaiaPlatform/pull/590.