### PR TITLE
Fix a build break

### DIFF
--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -37,7 +37,7 @@ set(SDK_TEST_INCLUDES
 
 configure_file("${GAIA_CONFIG}" "${PROJECT_BINARY_DIR}/gaia.conf")
 configure_file("${GAIA_LOG_CONFIG}" "${PROJECT_BINARY_DIR}/gaia_log.conf")
-add_gtest(test_sdk "tests/test_sdk.cpp" "${SDK_TEST_INCLUDES}" "rt;gaia" "generate_addr_book_headers")
+add_gtest(test_sdk "tests/test_sdk.cpp" "${SDK_TEST_INCLUDES}" "rt;gaia;gaia_common" "generate_addr_book_headers")
 add_gtest(test_sdk_no_init_rules "tests/test_sdk_no_init_rules.cpp" "${SDK_TEST_INCLUDES}" "rt;gaia" "generate_addr_book_headers")
 
 


### PR DESCRIPTION
I need to add the `gaia_common` dependency otherwise I get a build error in finding the logger header.