### PR TITLE
Support drop ... if exists

### DIFF
--- a/production/catalog/parser/src/parser.yy
+++ b/production/catalog/parser/src/parser.yy
@@ -84,6 +84,7 @@
 %type <std::unique_ptr<gaia::catalog::ddl::drop_statement_t>> drop_statement
 
 %type <int> opt_array
+%type <bool> opt_if_exists
 %type <bool> opt_if_not_exists
 %type <data_type_t> scalar_type
 %type <std::unique_ptr<gaia::catalog::ddl::base_field_def_t>> field_def
@@ -127,6 +128,8 @@ statement_list:
   }
 ;
 
+opt_if_exists: IF EXISTS { $$ = true; } | { $$ = false; };
+
 opt_if_not_exists: IF NOT EXISTS { $$ = true; } | { $$ = false; };
 
 statement:
@@ -156,12 +159,14 @@ create_statement:
 ;
 
 drop_statement:
-  DROP TABLE composite_name {
-      $$ = std::make_unique<drop_statement_t>(drop_type_t::drop_table, $3.second);
-      $$->database = std::move($3.first);
+  DROP TABLE opt_if_exists composite_name {
+      $$ = std::make_unique<drop_statement_t>(drop_type_t::drop_table, $4.second);
+      $$->database = std::move($4.first);
+      $$->if_exists = $3;
   }
-| DROP DATABASE IDENTIFIER {
-      $$ = std::make_unique<drop_statement_t>(drop_type_t::drop_database, $3);
+| DROP DATABASE opt_if_exists IDENTIFIER {
+      $$ = std::make_unique<drop_statement_t>(drop_type_t::drop_database, $4);
+      $$->if_exists = $3;
   }
 ;
 

--- a/production/catalog/parser/tests/test_ddl_parser.cpp
+++ b/production/catalog/parser/tests/test_ddl_parser.cpp
@@ -88,6 +88,18 @@ TEST(catalog_ddl_parser_test, drop_table)
 
     EXPECT_EQ(drop_stmt->type, drop_type_t::drop_table);
     EXPECT_EQ(drop_stmt->name, "t");
+    EXPECT_FALSE(drop_stmt->if_exists);
+
+    ASSERT_EQ(EXIT_SUCCESS, parser.parse_line("DROP TABLE IF EXISTS t;"));
+
+    EXPECT_EQ(1, parser.statements.size());
+    EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
+
+    drop_stmt = dynamic_cast<drop_statement_t*>(parser.statements[0].get());
+
+    EXPECT_EQ(drop_stmt->type, drop_type_t::drop_table);
+    EXPECT_EQ(drop_stmt->name, "t");
+    EXPECT_TRUE(drop_stmt->if_exists);
 }
 
 TEST(catalog_ddl_parser_test, case_sensitivity)
@@ -191,6 +203,18 @@ TEST(catalog_ddl_parser_test, drop_database)
 
     EXPECT_EQ(drop_stmt->type, drop_type_t::drop_database);
     EXPECT_EQ(drop_stmt->name, "d");
+    EXPECT_FALSE(drop_stmt->if_exists);
+
+    ASSERT_EQ(EXIT_SUCCESS, parser.parse_line("DROP DATABASE IF EXISTS d;"));
+
+    EXPECT_EQ(1, parser.statements.size());
+    EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
+
+    drop_stmt = dynamic_cast<drop_statement_t*>(parser.statements[0].get());
+
+    EXPECT_EQ(drop_stmt->type, drop_type_t::drop_database);
+    EXPECT_EQ(drop_stmt->name, "d");
+    EXPECT_TRUE(drop_stmt->if_exists);
 }
 
 TEST(catalog_ddl_parser_test, illegal_characters)

--- a/production/catalog/src/catalog.cpp
+++ b/production/catalog/src/catalog.cpp
@@ -49,19 +49,19 @@ gaia_id_t create_relationship(
     return ddl_executor_t::get().create_relationship(name, link1, link2, throw_on_exists);
 }
 
-void drop_database(const string& name)
+void drop_database(const string& name, bool throw_unless_exists)
 {
-    return ddl_executor_t::get().drop_database(name);
+    return ddl_executor_t::get().drop_database(name, throw_unless_exists);
 }
 
-void drop_table(const string& name)
+void drop_table(const string& name, bool throw_unless_exists)
 {
-    return ddl_executor_t::get().drop_table("", name);
+    return ddl_executor_t::get().drop_table("", name, throw_unless_exists);
 }
 
-void drop_table(const string& dbname, const string& name)
+void drop_table(const string& dbname, const string& name, bool throw_unless_exists)
 {
-    return ddl_executor_t::get().drop_table(dbname, name);
+    return ddl_executor_t::get().drop_table(dbname, name, throw_unless_exists);
 }
 
 gaia_id_t find_db_id(const string& dbname)

--- a/production/catalog/tests/test_ddl_executor.cpp
+++ b/production/catalog/tests/test_ddl_executor.cpp
@@ -211,6 +211,9 @@ TEST_F(ddl_executor_test, drop_table)
 TEST_F(ddl_executor_test, drop_table_not_exist)
 {
     string test_table_name{"a_not_existed_table"};
+
+    EXPECT_NO_THROW(drop_table(test_table_name, false));
+
     EXPECT_THROW(drop_table(test_table_name), table_not_exists);
 }
 

--- a/production/inc/gaia_internal/catalog/catalog.hpp
+++ b/production/inc/gaia_internal/catalog/catalog.hpp
@@ -242,6 +242,8 @@ struct drop_statement_t : statement_t
     std::string name;
 
     std::string database;
+
+    bool if_exists;
 };
 
 /*@}*/
@@ -440,9 +442,10 @@ gaia::common::gaia_id_t create_table(const std::string& name, const ddl::field_d
  *
  * @param name database name
  * @param name table name
+ * @param throw_unless_exists throw an execption unless the database exists
  * @throw table_not_exists
  */
-void drop_database(const std::string& name);
+void drop_database(const std::string& name, bool throw_unless_exists = true);
 
 /**
  * Delete a table in a given database.
@@ -453,9 +456,10 @@ void drop_database(const std::string& name);
  *
  * @param db_name database name
  * @param name table name
+ * @param throw_unless_exists throw an execption unless the database exists
  * @throw table_not_exists
  */
-void drop_table(const std::string& db_name, const std::string& name);
+void drop_table(const std::string& db_name, const std::string& name, bool throw_unless_exists = true);
 
 /**
  * Delete a table from the catalog's global database.
@@ -465,9 +469,10 @@ void drop_table(const std::string& db_name, const std::string& name);
  * which is not available to the catalog implementation.
  *
  * @param name table name
+ * @param throw_unless_exists throw an execption unless the database exists
  * @throw table_not_exists
  */
-void drop_table(const std::string& name);
+void drop_table(const std::string& name, bool throw_unless_exists = true);
 
 /**
  * List all data payload fields for a given table defined in the catalog.

--- a/production/inc/gaia_internal/catalog/ddl_execution.hpp
+++ b/production/inc/gaia_internal/catalog/ddl_execution.hpp
@@ -79,16 +79,16 @@ inline void execute(const std::string& db_name, std::vector<std::unique_ptr<ddl:
             {
                 if (!drop_stmt->database.empty())
                 {
-                    drop_table(drop_stmt->database, drop_stmt->name);
+                    drop_table(drop_stmt->database, drop_stmt->name, !drop_stmt->if_exists);
                 }
                 else
                 {
-                    drop_table(db_name, drop_stmt->name);
+                    drop_table(db_name, drop_stmt->name, !drop_stmt->if_exists);
                 }
             }
             else if (drop_stmt->type == ddl::drop_type_t::drop_database)
             {
-                drop_database(drop_stmt->name);
+                drop_database(drop_stmt->name, !drop_stmt->if_exists);
             }
         }
     }

--- a/production/inc/gaia_internal/catalog/ddl_executor.hpp
+++ b/production/inc/gaia_internal/catalog/ddl_executor.hpp
@@ -48,8 +48,8 @@ public:
         const ddl::link_def_t& link2,
         bool thrown_on_exists = true);
 
-    void drop_table(const std::string& db_name, const std::string& name);
-    void drop_database(const std::string& name);
+    void drop_table(const std::string& db_name, const std::string& name, bool throw_unless_exists);
+    void drop_database(const std::string& name, bool throw_unless_exists);
 
     gaia::common::gaia_id_t find_db_id(const std::string& dbname) const;
 


### PR DESCRIPTION
Add support for `drop ... if exists` syntax to the DDL. This helps with writing DDL scripts that can be idempotent.