### PR TITLE
Move relationship unit tests from catalog to db

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -220,8 +220,12 @@ add_gtest(test_record_list tests/test_record_list.cpp "${GAIA_DB_CORE_TEST_INCLU
 add_gtest(test_db_client tests/test_db_client.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_db_client;gaia_direct")
 add_gtest(test_db_internals tests/test_db_internals.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_storage;gaia_db_client")
 add_gtest(test_locator_allocator tests/test_locator_allocator.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_storage")
-add_gtest(test_relationships tests/test_relationships.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_db_client;gaia_direct;gaia_memory_manager")
 add_gtest(test_db_references tests/test_db_references.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_db_client;gaia_direct")
+
+add_gtest(test_relationships
+  tests/test_relationships.cpp
+  "${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC}"
+  "gaia_common;gaia_db_client;gaia_catalog")
 
 add_gtest(test_catalog_core
   tests/test_catalog_core.cpp


### PR DESCRIPTION
The two relationship unit tests should belong to the DB instead of catalog. Move them to the correct location.