### PR TITLE
Fix build failure in test_relationships.cpp

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -224,7 +224,7 @@ add_gtest(test_db_references tests/test_db_references.cpp "${GAIA_DB_CORE_TEST_I
 
 add_gtest(test_relationships
   tests/test_relationships.cpp
-  "${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC}"
+  "${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC};${FLATBUFFERS_INC}"
   "gaia_common;gaia_db_client;gaia_catalog")
 
 add_gtest(test_catalog_core


### PR DESCRIPTION
I think this has been recently introduced. The error I get is:

```
In file included from /home/simone/repos/GaiaPlatform/production/db/core/tests/test_relationships.cpp:9:
In file included from /home/simone/repos/GaiaPlatform/production/inc/gaia_internal/catalog/gaia_catalog.h:14:
/home/simone/repos/GaiaPlatform/production/inc/gaia/direct_access/edc_object.hpp:13:10: fatal error: 'flatbuffers/flatbuffers.h' file not found
#include "flatbuffers/flatbuffers.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```