### PR TITLE
Corrected a couple of assert statements

### DIFF
--- a/third_party/production/TranslationEngineLLVM/clang/lib/Parse/ParseGaia.cpp
+++ b/third_party/production/TranslationEngineLLVM/clang/lib/Parse/ParseGaia.cpp
@@ -343,7 +343,7 @@ bool Parser::ParseGaiaAttributes(ParsedAttributesWithRange &attrs, GaiaAttribute
 bool Parser::ParseRulesetSerialStream(ParsedAttributesWithRange &attrs,
     SourceLocation *endLoc)
 {
-    assert(Tok.getIdentifierInfo()->getName().equals("SerialStream") && "Not a ruleset table!");
+    assert(Tok.getIdentifierInfo()->getName().equals("SerialStream") && "Not a SerialStream attribute!");
 
     ArgsVector argExprs;
 
@@ -389,7 +389,7 @@ bool Parser::ParseRulesetSerialStream(ParsedAttributesWithRange &attrs,
 bool Parser::ParseRulesetTable(ParsedAttributesWithRange &attrs,
     SourceLocation *endLoc)
 {
-    assert(!Tok.getIdentifierInfo()->getName().equals("Table") && "Not a ruleset table!");
+    assert(Tok.getIdentifierInfo()->getName().equals("Table") && "Not a ruleset table!");
 
     ArgsVector argExprs;
 


### PR DESCRIPTION
Found during gaiat testing. Then the Table attribute is added to a ruleset, there was an assert failure. It turns out that the assertion was inverted because of a change in the representation of the comparison in the assert. This was only noticed when gaiat was compiled in Debug mode.

A second assert message was corrected.