### PR TITLE
Fix unit test to use new DDL file name

### DIFF
--- a/production/direct_access/tests/test_incubator.cpp
+++ b/production/direct_access/tests/test_incubator.cpp
@@ -23,7 +23,7 @@ class gaia_incubator_test : public db_catalog_test_base_t
 {
 protected:
     gaia_incubator_test()
-        : db_catalog_test_base_t(std::string("barn_storage.ddl")){};
+        : db_catalog_test_base_t(std::string("incubator.ddl")){};
 
     gaia_id_t insert_incubator(const char* name, float min_temp, float max_temp)
     {


### PR DESCRIPTION
Fixes the recent unit test failure due to the rename of the DDL file.