### PR TITLE
Fix gaia_translate unit test

### DIFF
--- a/production/tools/gaia_translate/tests/test_mixed_ruleset.cpp
+++ b/production/tools/gaia_translate/tests/test_mixed_ruleset.cpp
@@ -31,7 +31,7 @@ class test_mixed_code : public db_catalog_test_base_t
 {
 public:
     test_mixed_code()
-        : db_catalog_test_base_t("barn_storage.ddl"){};
+        : db_catalog_test_base_t("incubator.ddl"){};
 
 protected:
     void SetUp() override


### PR DESCRIPTION
Another test that required a full build with LLVM to detect.