### PR TITLE
Fixes for GAIAPLAT-802 plus new constants to replace "magic numbers"

### DIFF
--- a/production/tools/tests/gaiat/integration_test_expected_duplicate_ruleset_name_error.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_duplicate_ruleset_name_error.ruleset
@@ -1,4 +1,4 @@
-// RUN: %gaiat %s -- 2>&1| FileCheck  %s
+// RUN: not %gaiat %s -- 2>&1| FileCheck  %s
 
 ruleset test
 {
@@ -15,4 +15,4 @@ ruleset test
 }
 
 // GAIAPLAT-802
-// CHECK: Rulesets must have unique names.
+// CHECK: Ruleset names must be unique - 'test' has been found multiple times.


### PR DESCRIPTION
Check the list of ruleset names that have been parsed. If any are repeated, a new error is issued:
```
Ruleset names must be unique - 'rulesetname' has been found multiple times.
```
Also satisfied a warning by adding constants to replace "magic numbers".

There is reformatting throughout main.cpp. I assume this is the work of `clang-format`.