### PR TITLE
Make storage library static

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -60,7 +60,7 @@ endforeach(FBS_SOURCE)
 ###############################################
 # Our main target.
 ###############################################
-add_library(gaia_storage SHARED
+add_library(gaia_storage STATIC
   src/record_list.cpp
   src/record_list_manager.cpp)
 target_include_directories(gaia_storage PUBLIC ${GAIA_DB_CORE_PUBLIC_INCLUDES})


### PR DESCRIPTION
The storage library had remained declared as SHARED instead of STATIC, which leads to failures because it's not picked up by the gaia package.