### PR TITLE
Define a constant for the first locator value

### DIFF
--- a/production/db/core/src/catalog_core.cpp
+++ b/production/db/core/src/catalog_core.cpp
@@ -110,14 +110,14 @@ table_view_t catalog_core_t::get_table(gaia_id_t table_id)
 table_list_t catalog_core_t::list_tables()
 {
     counters_t* counters = gaia::db::get_counters();
-    auto gaia_table_generator = [counters, locator = c_invalid_gaia_locator]() mutable -> std::optional<table_view_t> {
+    auto gaia_table_generator = [counters, locator = c_first_gaia_locator]() mutable -> std::optional<table_view_t> {
         // We need an acquire barrier before reading `last_locator`. We can
         // change this full barrier to an acquire barrier when we change to proper
         // C++ atomic types.
         __sync_synchronize();
-        while (++locator && locator <= counters->last_locator)
+        while (locator <= counters->last_locator)
         {
-            auto ptr = locator_to_ptr(locator);
+            auto ptr = locator_to_ptr(locator++);
             if (ptr && ptr->type == static_cast<gaia_type_t>(catalog_table_type_t::gaia_table))
             {
                 return table_view_t(ptr);

--- a/production/db/core/src/gaia_ptr.cpp
+++ b/production/db/core/src/gaia_ptr.cpp
@@ -173,7 +173,7 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
 gaia_ptr_t gaia_ptr_t::find_first(common::gaia_type_t type)
 {
     gaia_ptr_t ptr;
-    ptr.m_locator = 1;
+    ptr.m_locator = c_first_gaia_locator;
 
     if (!ptr.is(type))
     {

--- a/production/inc/gaia_internal/db/db_types.hpp
+++ b/production/inc/gaia_internal/db/db_types.hpp
@@ -41,6 +41,11 @@ typedef uint64_t gaia_locator_t;
 constexpr gaia_locator_t c_invalid_gaia_locator = 0;
 
 /**
+ * The value of the first gaia_locator.
+ */
+constexpr gaia_locator_t c_first_gaia_locator = c_invalid_gaia_locator + 1;
+
+/**
  * The type of a Gaia data offset.
  *
  * This represents the offset of a gaia_se_object in the global data shared


### PR DESCRIPTION
There were places in our code where the first locator value was assumed to be 1 and to follow the invalid locator value, which was again assumed to be 0.

This change introduces a constant for the first locator value that makes these assumptions explicit.

I've changed two places to use this new constant. If you know of any other, let me know - I've tried a code search, but couldn't find anything else.