### PR TITLE
Enable 'Debug' production gdev build.

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -52,19 +52,13 @@ echo "ASAN_OPTIONS = 'detect_leaks=0'" >> /etc/postgresql/12/main/environment
 mkdir -p /var/lib/gaia/db
 
 [run]
-{enable_if('Debug')}cmake \
+cmake \
     --log-level=VERBOSE -Wno-dev \
-    -DCMAKE_BUILD_TYPE=Debug \
-    {enable_if('Asan')}-DENABLE_ASAN=ON \
-    -DENABLE_STACKTRACE=ON \
-    -G "Unix Makefiles" \
-    {source_dir('production')}
-{enable_if_not('Debug')}cmake \
-    --log-level=VERBOSE -Wno-dev \
+    {enable_if('Debug')}-DCMAKE_BUILD_TYPE=Debug \
     {enable_if('GaiaRelease')}-DCMAKE_MODULE_PATH=/usr/local/lib/cmake/CPackDebHelper \
     {enable_if('GaiaLLVMTests')}-DBUILD_GAIA_LLVM_TESTS=ON \
     {enable_if_any('GaiaRelease','GaiaLLVMTests')}-DBUILD_GAIA_RELEASE=ON \
-    {enable_if_any('GaiaRelease','GaiaLLVMTests')}-G "Unix Makefiles" \
+    {enable_if_any('Debug', 'GaiaRelease','GaiaLLVMTests')}-G "Unix Makefiles" \
     {source_dir('production')}
 
 # LSAN will cause failures during docker build time since we cannot allow the


### PR DESCRIPTION
`gdev build --cfg-enables Debug` Now builds with debug. Additionally,
`gdev build --cfg-enables Debug Asan` will also build with Asan enabled.