### PR TITLE
Add db_server_instance.wait_for_termination() to improve DB server kill wait time

### DIFF
--- a/production/db/core/src/db_server_instance.cpp
+++ b/production/db/core/src/db_server_instance.cpp
@@ -169,6 +169,8 @@ void server_instance_t::stop()
     }
     else if (return_pid == 0)
     {
+        // waitpid() returns zero only if WNOHANG option is specified.
+        // We don't use WNOHANG but leaving this branch to prevent regressions.
         throw common::system_error("The db server process should be killed!");
     }
 


### PR DESCRIPTION
The `server_instance_t::stop()` method used to wait 100ms for the server termination after sending `SIGKILL`. You can expect the server to be terminated much earlier. This PR introduces a method to wait for the process server termination in intervals of 5ms.