### PR TITLE
Improve dereferencing operator for generator_iterator

### DIFF
--- a/production/inc/gaia_internal/common/generator_iterator.hpp
+++ b/production/inc/gaia_internal/common/generator_iterator.hpp
@@ -56,7 +56,10 @@ public:
     // Returns current state.
     T_output operator*() const
     {
-        return *m_state;
+        // If we de-reference m_state via *m_state, we can run into undefined behavior
+        // if m_state does not contain a value, so we'll use the value() method instead,
+        // which throws an exception in that case.
+        return m_state.value();
     }
 
     // Advance to the next valid state.


### PR DESCRIPTION
This causes the tests to fail with the bad_optional_access exception when the generator_iterator is de-referenced without being checked first. So with this change we get a clearer failure regardless of whether ASAN is enabled or not. 