### PR TITLE
Fix undefined behavior identified by UBSan

### DIFF
--- a/production/db/core/inc/rdb_object_converter.hpp
+++ b/production/db/core/inc/rdb_object_converter.hpp
@@ -117,7 +117,8 @@ public:
     inline void read_uint64(uint64_t& out)
     {
         const char* value_ptr = read(sizeof(uint64_t));
-        uint64_t value = *(reinterpret_cast<const uint64_t*>(value_ptr));
+        uint64_t value;
+        memcpy(&value, value_ptr, sizeof(uint64_t));
         // Convert to host byte order.
         out = be64toh(value);
     }
@@ -125,7 +126,8 @@ public:
     inline void read_uint32(uint32_t& out)
     {
         const char* value_ptr = read(sizeof(uint32_t));
-        uint32_t value = *(reinterpret_cast<const uint32_t*>(value_ptr));
+        uint32_t value;
+        memcpy(&value, value_ptr, sizeof(uint32_t));
         // Convert to host byte order.
         out = be32toh(value);
     }
@@ -133,7 +135,8 @@ public:
     inline void read_uint16(uint16_t& out)
     {
         const char* value_ptr = read(sizeof(uint16_t));
-        uint16_t value = *(reinterpret_cast<const uint16_t*>(value_ptr));
+        uint16_t value;
+        memcpy(&value, value_ptr, sizeof(uint16_t));
         // Convert to host byte order.
         out = be16toh(value);
     }

--- a/production/db/memory_manager/tests/test_bitmap.cpp
+++ b/production/db/memory_manager/tests/test_bitmap.cpp
@@ -53,16 +53,17 @@ TEST(bitmap, find_first_unset_bit)
     bitmap[0] = bitmap[1] = bitmap[2] = 0;
     for (size_t i = 0; i < (c_bitmap_size - 1) * c_uint64_bit_count; ++i)
     {
-        if (i % c_uint64_bit_count != 0)
+        size_t bit_index_in_word = i % c_uint64_bit_count;
+        if (bit_index_in_word != 0)
         {
-            bitmap[i / c_uint64_bit_count] = (1ULL << i) - 1;
+            bitmap[i / c_uint64_bit_count] = (1ULL << bit_index_in_word) - 1;
         }
 
         ASSERT_EQ(i, find_first_unset_bit(bitmap, c_bitmap_size));
 
         // After we're done with a word, leave all bits set,
         // so the search will go into the next word.
-        if (i % c_uint64_bit_count == c_uint64_bit_count - 1)
+        if (bit_index_in_word == c_uint64_bit_count - 1)
         {
             bitmap[i / c_uint64_bit_count] = -1;
         }
@@ -124,14 +125,15 @@ TEST(bitmap, count_set_bits)
     bitmap[0] = bitmap[1] = bitmap[2] = 0;
     for (size_t i = 0; i < (c_bitmap_size - 1) * c_uint64_bit_count; ++i)
     {
-        if (i % c_uint64_bit_count != 0)
+        size_t bit_index_in_word = i % c_uint64_bit_count;
+        if (bit_index_in_word != 0)
         {
-            bitmap[i / c_uint64_bit_count] = (1ULL << i) - 1;
+            bitmap[i / c_uint64_bit_count] = (1ULL << bit_index_in_word) - 1;
         }
 
         ASSERT_EQ(i, count_set_bits(bitmap, c_bitmap_size));
 
-        if (i % c_uint64_bit_count == c_uint64_bit_count - 1)
+        if (bit_index_in_word == c_uint64_bit_count - 1)
         {
             bitmap[i / c_uint64_bit_count] = -1;
         }


### PR DESCRIPTION
This is the second of 3 PRs to enable UBSan in debug builds. The following types of undefined behavior were identified by UBSan and fixed in this PR:

1. A left or right shift greater than or equal to the word size (in bits) is undefined.
2. Casting an address to a pointer of a type for which that address is improperly aligned is undefined.