### PR TITLE
Force UBSan to terminate process on UB detection

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -67,8 +67,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(GAIA_COMPILE_FLAGS "-c -Wall -Wextra -O0 -g -fno-limit-debug-info")
 
   if(ENABLE_ASAN)
-    set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
-    set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address -fsanitize=undefined")
+    set(GAIA_COMPILE_FLAGS "${GAIA_COMPILE_FLAGS} -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer")
+    set(GAIA_LINK_FLAGS "${GAIA_LINK_FLAGS} -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all")
   endif()
 endif()
 


### PR DESCRIPTION
This should not be merged before https://github.com/gaia-platform/GaiaPlatform/pull/706, since without those fixes all tests containing undefined behavior will fail. The eager termination behavior (rather than logging issues and allowing the process to continue) will ensure that any undefined behavior in our tests will fail those tests, so issues can be identified and fixed immediately.