### PR TITLE
Revert linker from LLD to GNU ld

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -34,9 +34,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Ensure debug builds have the DEBUG flag defined.
 add_compile_options("$<$<CONFIG:DEBUG>:-DDEBUG>")
 
-# Use the LLVM linker rather than GNU ld (required for UBSan).
-add_link_options("-fuse-ld=lld")
-
 # Set some global variables.
 get_repo_root(${PROJECT_SOURCE_DIR} GAIA_REPO)
 
@@ -59,7 +56,6 @@ if(BUILD_GAIA_RELEASE OR BUILD_GAIA_LLVM_TESTS)
   set(LLVM_ENABLE_EH ON CACHE BOOL "")
   set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "")
   set(LLVM_ENABLE_RTTI ON CACHE BOOL "")
-  set(LLVM_USE_LINKER "lld" CACHE STRING "")
 endif()
 
 # Debug build-specific options.

--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -1,5 +1,4 @@
 [apt]
-lld
 clang-format
 clang-tidy
 {enable_if('GaiaRelease')}debhelper


### PR DESCRIPTION
It turned out that I was wrong and UBSan actually does work properly with GNU ld. I was unable to get lld working on the whole codebase anyway, so given that it doesn't seem necessary I'm reverting to the original linker.

I verified that the UB issues identified by UBSan are properly detected with GNU ld as the linker.