### PR TITLE
Add explicit checks to prevent copy of initialized record iterators

### DIFF
--- a/production/db/core/src/record_list.cpp
+++ b/production/db/core/src/record_list.cpp
@@ -147,6 +147,22 @@ record_iterator_t::~record_iterator_t()
     }
 }
 
+record_iterator_t::record_iterator_t(const record_iterator_t& other)
+{
+    ASSERT_PRECONDITION(other.current_range == nullptr, "An attempt was made to copy an initialized record_iterator!");
+    this->current_range = other.current_range;
+    this->current_index = other.current_index;
+}
+
+record_iterator_t& record_iterator_t::operator=(const record_iterator_t& other)
+{
+    ASSERT_PRECONDITION(this->current_range == nullptr, "An attempt was made to copy into an initialized record_iterator!");
+    ASSERT_PRECONDITION(other.current_range == nullptr, "An attempt was made to copy an initialized record_iterator!");
+    this->current_range = other.current_range;
+    this->current_index = other.current_index;
+    return *this;
+}
+
 record_list_t::record_list_t(size_t range_size)
 {
     clear();

--- a/production/db/inc/core/record_list.hpp
+++ b/production/db/inc/core/record_list.hpp
@@ -90,16 +90,21 @@ protected:
 // An iterator's destructor will release any locks held during iteration.
 struct record_iterator_t
 {
+    record_iterator_t();
+    ~record_iterator_t();
+
+    // These custom copy operations ensure that only uninitialized iterators can be copied,
+    // by asserting in any other situation.
+    record_iterator_t(const record_iterator_t&);
+    record_iterator_t& operator=(const record_iterator_t&);
+
+    // Tells whether the iterator position represents the end of the iteration.
+    inline bool at_end();
+
     // The position of the iterator is represented
     // by the current range and the current index in the range.
     record_range_t* current_range;
     size_t current_index;
-
-    record_iterator_t();
-    ~record_iterator_t();
-
-    // Tells whether the iterator position represents the end of the iteration.
-    inline bool at_end();
 };
 
 // The implementation of a record list.


### PR DESCRIPTION
Record iterators can acquire and release locks on the ranges they process, so that means that copying them is problematic because it can lead to double unlocking. The current use is safe because it avoids copies once iterations are in effect, but this change adds a custom copy constructor/operator to make it easier to spot changes in this situation (if initialized iterators get copied, then asserts would get triggered).

Once we move the record lists to shared memory, this entire implementation can go away.