### PR TITLE
Fix test_queries_ruleset to check for correct result

### DIFF
--- a/production/tools/gaia_translate/tests/test_queries.cpp
+++ b/production/tools/gaia_translate/tests/test_queries.cpp
@@ -527,7 +527,7 @@ TEST_F(test_queries_code, while_stmt)
     EXPECT_TRUE(wait_for_rule(g_onupdate_called)) << "OnUpdate(student) not called";
     EXPECT_EQ(test_error_result_t::e_none, g_onupdate_result) << "OnUpdate failure";
 
-    EXPECT_EQ(g_string_value, "stu001reg002cou004 stu001reg002cou002 stu001reg001cou004 stu001reg001cou002 ") << "Incorrect result";
+    EXPECT_EQ(g_string_value, "stu001reg002cou004 stu001reg001cou002 ") << "Incorrect result";
 }
 
 TEST_F(test_queries_code, nomatch_stmt)

--- a/production/tools/tests/gaiat/integration_test.ruleset
+++ b/production/tools/tests/gaiat/integration_test.ruleset
@@ -160,9 +160,3 @@ ruleset test12
         }
     }
 }
-
-// GAIAPLAT-946
-// Leave this at the end of the file.
-#ifdef TEST_FAILURES
-ruleset gen_infinite_loop
-#endif

--- a/production/tools/tests/gaiat/integration_test_expected_invalid_rule.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_invalid_rule.ruleset
@@ -1,0 +1,7 @@
+// RUN: not %gaiat %s -- 2>&1| FileCheck %s
+
+// GAIAPLAT-946
+// Leave this at the end of the file.
+ruleset gen_infinite_loop
+
+// CHECK: expected '{'

--- a/production/tools/tests/gaiat/queries_tests.ruleset
+++ b/production/tools/tests/gaiat/queries_tests.ruleset
@@ -365,7 +365,6 @@ ruleset test36
 }
 
 // GAIAPLAT-945
-#ifdef TEST_FAILURES
 ruleset test37
 {
     OnUpdate(min_temp)
@@ -373,4 +372,3 @@ ruleset test37
         sensor.value += sensor.incubator->incubator.min_temp;
     }
 }
-#endif

--- a/production/tools/tests/gaiat/statements_tests.ruleset
+++ b/production/tools/tests/gaiat/statements_tests.ruleset
@@ -488,7 +488,7 @@ ruleset test31
     {
         const char* s = "just a string";
         int i = 0;
-        // Testing while/declarative-while/while/if nesting.$>%$<<$%<<%
+        // Testing while/declarative-while/while/if nesting.
         while (*s++) {
             while (/incubator.max_temp > 0) {
                 while(*s++) {


### PR DESCRIPTION
With the correction of translation of the declarative while statement, this test was found to be checking for an incorrect result. Now the result corresponds to the data in the database and the query used in the while statement.