### PR TITLE
Fix build issues for gcc 11

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "gaia/db/db.hpp"
 
 #include "gaia_internal/common/mmap_helpers.hpp"

--- a/production/db/payload_types/src/type_cache.cpp
+++ b/production/db/payload_types/src/type_cache.cpp
@@ -5,6 +5,8 @@
 
 #include "type_cache.hpp"
 
+#include <mutex>
+
 #include "gaia_internal/common/retail_assert.hpp"
 
 using namespace std;

--- a/production/inc/gaia_internal/common/queue.hpp
+++ b/production/inc/gaia_internal/common/queue.hpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 
 #include "gaia_internal/common/retail_assert.hpp"


### PR DESCRIPTION
After upgrading to gcc 11, I need to make the following fixes. It seem latest libstdc++ is more strict about STL headers. 