### PR TITLE
Disable test_queries_code.new_registration

### DIFF
--- a/production/tools/gaia_translate/tests/test_queries.cpp
+++ b/production/tools/gaia_translate/tests/test_queries.cpp
@@ -268,7 +268,7 @@ TEST_F(test_queries_code, implicit_navigation_fork)
     EXPECT_EQ(g_onupdate_value, 7) << "Incorrect sum";
 }
 
-TEST_F(test_queries_code, new_registration)
+TEST_F(test_queries_code, DISABLED_new_registration)
 {
     const int num_inserts = 4;
 


### PR DESCRIPTION
This test is failing frequently enough that I am going to disable it while I'm investigating.