### PR TITLE
Convert internal db scalar types to scoped enums

### DIFF
--- a/production/db/core/inc/db_internal_types.hpp
+++ b/production/db/core/inc/db_internal_types.hpp
@@ -114,11 +114,11 @@ struct txn_log_t
         friend std::ostream& operator<<(std::ostream& os, const log_record_t& lr)
         {
             os << "locator: "
-               << lr.locator
+               << to_integral(lr.locator)
                << "\told_offset: "
-               << lr.old_offset
+               << to_integral(lr.old_offset)
                << "\tnew_offset: "
-               << lr.new_offset
+               << to_integral(lr.new_offset)
                << "\tdeleted_id: "
                << lr.deleted_id
                << "\toperation: "
@@ -163,8 +163,8 @@ struct counters_t
     // segment, and the OS automatically zeroes new pages.
     common::gaia_id_t last_id;
     common::gaia_type_t last_type_id;
-    gaia_txn_id_t last_txn_id;
-    gaia_locator_t last_locator;
+    std::underlying_type_t<gaia_txn_id_t> last_txn_id;
+    std::underlying_type_t<gaia_locator_t> last_locator;
 };
 
 struct data_t

--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -222,7 +222,7 @@ private:
         messages::session_event_t event,
         messages::session_state_t old_state,
         messages::session_state_t new_state,
-        gaia_txn_id_t txn_id = 0,
+        gaia_txn_id_t txn_id = c_invalid_gaia_txn_id,
         size_t log_fd_count = 0);
 
     static void clear_shared_memory();

--- a/production/db/core/inc/txn_metadata.inc
+++ b/production/db/core/inc/txn_metadata.inc
@@ -171,7 +171,7 @@ bool txn_metadata_t::compare_exchange_weak(txn_metadata_t& expected_metadata, co
         expected_metadata.m_ts == desired_metadata.m_ts,
         "Metadata timestamps differ in call to compare_exchange_weak()!");
 
-    return s_txn_metadata_map[expected_metadata.m_ts].compare_exchange_weak(
+    return s_txn_metadata_map[to_integral(expected_metadata.m_ts)].compare_exchange_weak(
         expected_metadata.m_value, desired_metadata.m_value);
 }
 
@@ -181,13 +181,13 @@ bool txn_metadata_t::compare_exchange_strong(txn_metadata_t& expected_metadata, 
         expected_metadata.m_ts == desired_metadata.m_ts,
         "Metadata timestamps differ in call to compare_exchange_strong()!");
 
-    return s_txn_metadata_map[expected_metadata.m_ts].compare_exchange_strong(
+    return s_txn_metadata_map[to_integral(expected_metadata.m_ts)].compare_exchange_strong(
         expected_metadata.m_value, desired_metadata.m_value);
 }
 
 void txn_metadata_t::check_ts_size(gaia_txn_id_t ts)
 {
-    ASSERT_PRECONDITION(ts < (1ULL << c_txn_ts_bits), "Timestamp values must fit in 42 bits!");
+    ASSERT_PRECONDITION(to_integral(ts) < (1ULL << c_txn_ts_bits), "Timestamp values must fit in 42 bits!");
 }
 
 bool txn_metadata_t::is_uninitialized() const
@@ -268,7 +268,7 @@ uint64_t txn_metadata_t::get_status() const
 gaia_txn_id_t txn_metadata_t::get_timestamp() const
 {
     // The timestamp is in the low 42 bits of the txn metadata.
-    return (m_value & c_txn_ts_mask);
+    return gaia_txn_id_t{m_value & c_txn_ts_mask};
 }
 
 int txn_metadata_t::get_txn_log_fd() const

--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -434,7 +434,7 @@ void client_t::begin_transaction()
 
     // Extract the transaction id and cache it; it needs to be reset for the next transaction.
     const transaction_info_t* txn_info = client_messenger.server_reply()->data_as_transaction_info();
-    s_txn_id = txn_info->transaction_id();
+    s_txn_id = gaia_txn_id_t{txn_info->transaction_id()};
     ASSERT_INVARIANT(
         s_txn_id != c_invalid_gaia_txn_id,
         "Begin timestamp should not be invalid!");
@@ -479,7 +479,7 @@ void client_t::apply_txn_log(int log_fd)
     for (size_t i = 0; i < txn_log.data()->record_count; ++i)
     {
         const auto& lr = txn_log.data()->log_records[i];
-        (*s_private_locators.data())[lr.locator] = lr.new_offset;
+        (*s_private_locators.data())[to_integral(lr.locator)] = lr.new_offset;
     }
 }
 
@@ -565,7 +565,7 @@ void client_t::commit_transaction()
         c_message_unexpected_event_received);
 
     const transaction_info_t* txn_info = client_messenger.server_reply()->data_as_transaction_info();
-    ASSERT_INVARIANT(txn_info->transaction_id() == s_txn_id, "Unexpected transaction id!");
+    ASSERT_INVARIANT(txn_info->transaction_id() == to_integral(s_txn_id), "Unexpected transaction id!");
 
     // Execute trigger only if rules engine is initialized.
     if (s_txn_commit_trigger

--- a/production/db/core/src/rdb_internal.cpp
+++ b/production/db/core/src/rdb_internal.cpp
@@ -58,7 +58,7 @@ std::string rdb_internal_t::begin_txn(const rocksdb::WriteOptions& options, cons
     auto duration = now.time_since_epoch();
     auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
     std::stringstream rdb_txn_name;
-    rdb_txn_name << txn_id << "." << nanoseconds.count();
+    rdb_txn_name << to_integral(txn_id) << "." << nanoseconds.count();
     ASSERT_PRECONDITION(m_txn_db != nullptr, c_message_rocksdb_not_initialized);
     rocksdb::Transaction* txn = m_txn_db->BeginTransaction(options, txn_opts);
     rocksdb::Status s = txn->SetName(rdb_txn_name.str());

--- a/production/db/core/tests/test_record_list.cpp
+++ b/production/db/core/tests/test_record_list.cpp
@@ -18,16 +18,17 @@ using namespace gaia::db::storage;
 TEST(storage, record_list)
 {
     constexpr size_t c_range_size = 3;
-    constexpr gaia_locator_t c_starting_locator = 1000;
-    constexpr gaia_locator_t c_count_locators = 10;
-    constexpr gaia_locator_t c_new_locator = 88;
+    constexpr gaia_locator_t c_starting_locator{1000};
+    constexpr size_t c_count_locators = 10;
+    constexpr gaia_locator_t c_new_locator{88};
 
     record_list_t record_list(c_range_size);
 
     // Add some locator values to our list.
-    for (gaia_locator_t locator = c_starting_locator; locator < c_starting_locator + c_count_locators; locator++)
+
+    for (auto locator = to_integral(c_starting_locator); locator < to_integral(c_starting_locator) + c_count_locators; locator++)
     {
-        record_list.add(locator);
+        record_list.add(gaia_locator_t{locator});
     }
 
     // Start an iteration over the list.
@@ -36,7 +37,7 @@ TEST(storage, record_list)
     ASSERT_EQ(true, return_value);
     ASSERT_EQ(false, iterator.at_end());
 
-    gaia_locator_t expected_locator = c_starting_locator;
+    auto expected_locator = to_integral(c_starting_locator);
     record_range_t* current_range = iterator.current_range;
 
     // Iterate over the list and verify content and range changes.
@@ -44,15 +45,15 @@ TEST(storage, record_list)
     do
     {
         // Verify that ranges change as expected.
-        if (expected_locator > c_starting_locator
-            && (expected_locator - c_starting_locator) % c_range_size == 0)
+        if (expected_locator > to_integral(c_starting_locator)
+            && (expected_locator - to_integral(c_starting_locator)) % c_range_size == 0)
         {
             ASSERT_TRUE(iterator.current_range != current_range);
             current_range = iterator.current_range;
         }
 
         ASSERT_EQ(current_range, iterator.current_range);
-        ASSERT_EQ(expected_locator, record_list_t::get_record_data(iterator).locator);
+        ASSERT_EQ(expected_locator, to_integral(record_list_t::get_record_data(iterator).locator));
 
         if (expected_locator % 2 != 0)
         {
@@ -70,12 +71,12 @@ TEST(storage, record_list)
     ASSERT_EQ(true, return_value);
     ASSERT_EQ(false, iterator.at_end());
 
-    expected_locator = c_starting_locator;
+    expected_locator = to_integral(c_starting_locator);
 
     // Iterate over the list and verify content.
     do
     {
-        ASSERT_EQ(expected_locator, record_list_t::get_record_data(iterator).locator);
+        ASSERT_EQ(expected_locator, to_integral(record_list_t::get_record_data(iterator).locator));
 
         expected_locator += 2;
     } while (record_list_t::move_next(iterator));
@@ -94,7 +95,7 @@ TEST(storage, record_list)
     ASSERT_EQ(true, return_value);
     ASSERT_EQ(false, iterator.at_end());
 
-    expected_locator = c_starting_locator;
+    expected_locator = to_integral(c_starting_locator);
 
     // Iterate over the list and verify content.
     do
@@ -103,7 +104,7 @@ TEST(storage, record_list)
         gaia_locator_t current_locator = record_list_t::get_record_data(iterator).locator;
         if (current_locator != c_new_locator)
         {
-            ASSERT_EQ(expected_locator, current_locator);
+            ASSERT_EQ(expected_locator, to_integral(current_locator));
             expected_locator += 2;
         }
     } while (record_list_t::move_next(iterator));

--- a/production/db/core/tests/test_record_list_manager.cpp
+++ b/production/db/core/tests/test_record_list_manager.cpp
@@ -18,8 +18,8 @@ using namespace gaia::db::storage;
 
 TEST(storage, record_list_manager)
 {
-    constexpr gaia_locator_t c_starting_locator = 1000;
-    constexpr gaia_locator_t c_count_locators = 10;
+    constexpr gaia_locator_t c_starting_locator{1000};
+    constexpr size_t c_count_locators = 10;
 
     constexpr gaia_type_t c_type_even = 1000;
     constexpr gaia_type_t c_type_odd = 1001;
@@ -27,26 +27,26 @@ TEST(storage, record_list_manager)
     record_list_manager_t* record_list_manager = record_list_manager_t::get();
 
     // Add some locator values to our list.
-    for (gaia_locator_t locator = c_starting_locator; locator < c_starting_locator + c_count_locators; locator++)
+    for (auto locator = to_integral(c_starting_locator); locator < to_integral(c_starting_locator) + c_count_locators; locator++)
     {
         if (locator % 2 == 0)
         {
             shared_ptr<record_list_t> record_list = record_list_manager->get_record_list(c_type_even);
             cout << "Adding " << locator << " to even type record list" << endl;
-            record_list->add(locator);
+            record_list->add(gaia_locator_t{locator});
         }
         else
         {
             shared_ptr<record_list_t> record_list = record_list_manager->get_record_list(c_type_odd);
             cout << "Adding " << locator << " to odd type record list" << endl;
-            record_list->add(locator);
+            record_list->add(gaia_locator_t{locator});
         }
     }
 
     // Start an iteration over the even locator list.
     shared_ptr<record_list_t> record_list = record_list_manager->get_record_list(c_type_even);
     record_iterator_t iterator;
-    gaia_locator_t locator;
+    auto locator = to_integral(c_invalid_gaia_locator);
     bool return_value = record_list->start(iterator);
     ASSERT_EQ(true, return_value);
     ASSERT_EQ(false, iterator.at_end());
@@ -54,7 +54,7 @@ TEST(storage, record_list_manager)
     // Iterate over the list and verify content.
     do
     {
-        locator = record_list_t::get_record_data(iterator).locator;
+        locator = to_integral(record_list_t::get_record_data(iterator).locator);
         cout << "Found " << locator << " in even type record list" << endl;
         ASSERT_EQ(0, locator % 2);
     } while (record_list_t::move_next(iterator));
@@ -70,7 +70,7 @@ TEST(storage, record_list_manager)
     // Iterate over the list and verify content.
     do
     {
-        locator = record_list_t::get_record_data(iterator).locator;
+        locator = to_integral(record_list_t::get_record_data(iterator).locator);
         cout << "Found " << locator << " in odd type record list" << endl;
         ASSERT_EQ(1, locator % 2);
     } while (record_list_t::move_next(iterator));

--- a/production/db/index/src/index.cpp
+++ b/production/db/index/src/index.cpp
@@ -111,11 +111,11 @@ std::size_t index_key_hash::operator()(index_key_t const& key) const
 std::ostream& operator<<(std::ostream& os, const index_record_t& record)
 {
     os << "locator: "
-       << record.locator
+       << to_integral(record.locator)
        << "\ttxn_id: "
-       << record.txn_id
+       << to_integral(record.txn_id)
        << "\toffset: "
-       << record.offset
+       << to_integral(record.offset)
        << "\tdeleted: "
        << record.deleted
        << std::endl;

--- a/production/db/index/tests/test_index.cpp
+++ b/production/db/index/tests/test_index.cpp
@@ -13,14 +13,14 @@ using namespace gaia::db::payload_types;
 using namespace gaia::db::index;
 
 // Placeholder values for index records.
-constexpr gaia::db::gaia_txn_id_t c_fake_txn_id = 777;
-constexpr gaia::db::gaia_offset_t c_fake_offset = 0;
+constexpr gaia::db::gaia_txn_id_t c_fake_txn_id{777};
+constexpr gaia::db::gaia_offset_t c_fake_offset{0};
 
 index_record_t create_index_record()
 {
-    thread_local static gaia::db::gaia_locator_t locator = 0;
+    thread_local static auto locator = to_integral(gaia::db::c_invalid_gaia_locator);
 
-    return {c_fake_txn_id, c_fake_offset, locator++, false};
+    return {c_fake_txn_id, c_fake_offset, gaia::db::gaia_locator_t{locator++}, false};
 }
 
 TEST(index, empty_range_index)

--- a/production/inc/gaia_internal/db/db_types.hpp
+++ b/production/inc/gaia_internal/db/db_types.hpp
@@ -7,10 +7,32 @@
 
 #include <cstdint>
 
+#include <atomic>
+
 namespace gaia
 {
 namespace db
 {
+
+// Convenience method to safely cast from a scoped enum to its underlying type.
+template <typename T>
+constexpr auto to_integral(T e)
+{
+    return static_cast<std::underlying_type_t<T>>(e);
+}
+
+// This overload is for scoped enums nested in atomic types.
+template <typename T>
+constexpr auto to_integral(const std::atomic<T>& e)
+{
+    return static_cast<std::underlying_type_t<T>>(e.load());
+}
+
+template <typename T>
+constexpr auto from_integral(size_t n)
+{
+    return T{static_cast<std::underlying_type_t<T>>(n)};
+}
 
 /**
  * The type of a Gaia transaction id.
@@ -18,12 +40,14 @@ namespace db
  * This type is used for both transaction begin and commit timestamps, which are
  * obtained by incrementing a global atomic counter in shared memory.
  */
-typedef uint64_t gaia_txn_id_t;
+enum class gaia_txn_id_t : uint64_t
+{
+};
 
 /**
  * The value of an invalid gaia_txn_id.
  */
-constexpr gaia_txn_id_t c_invalid_gaia_txn_id = 0;
+constexpr gaia_txn_id_t c_invalid_gaia_txn_id{0};
 
 /**
  * The type of a Gaia locator id.
@@ -33,17 +57,20 @@ constexpr gaia_txn_id_t c_invalid_gaia_txn_id = 0;
  * data segment. Each gaia_id corresponds to a unique locator for the lifetime
  * of the server process.
  */
-typedef uint64_t gaia_locator_t;
+enum class gaia_locator_t : uint64_t
+{
+};
 
 /**
  * The value of an invalid gaia_locator.
  */
-constexpr gaia_locator_t c_invalid_gaia_locator = 0;
+constexpr gaia_locator_t c_invalid_gaia_locator{0};
 
 /**
  * The value of the first gaia_locator.
  */
-constexpr gaia_locator_t c_first_gaia_locator = c_invalid_gaia_locator + 1;
+constexpr gaia_locator_t c_first_gaia_locator{
+    to_integral(c_invalid_gaia_locator) + 1};
 
 /**
  * The type of a Gaia data offset.
@@ -52,12 +79,14 @@ constexpr gaia_locator_t c_first_gaia_locator = c_invalid_gaia_locator + 1;
  * data shared memory segment, which can be added to the local base address of
  * the mapped data segment to obtain a valid local pointer to the object.
  */
-typedef uint32_t gaia_offset_t;
+enum class gaia_offset_t : uint32_t
+{
+};
 
 /**
  * The value of an invalid gaia_offset.
  */
-constexpr gaia_offset_t c_invalid_gaia_offset = 0;
+constexpr gaia_offset_t c_invalid_gaia_offset{0};
 
 } // namespace db
 } // namespace gaia

--- a/production/inc/gaia_internal/db/gaia_ptr.hpp
+++ b/production/inc/gaia_internal/db/gaia_ptr.hpp
@@ -153,6 +153,8 @@ public:
     void update_parent_reference(common::gaia_id_t new_parent_id, common::reference_offset_t parent_offset);
 
 protected:
+    gaia_ptr_t(gaia_locator_t locator);
+
     gaia_ptr_t(gaia_locator_t locator, memory_manager::address_offset_t offset);
 
     void allocate(size_t size);

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -14,6 +14,7 @@
 #include "gaia/rules/rules.hpp"
 
 #include "gaia_internal/db/db_catalog_test_base.hpp"
+#include "gaia_internal/db/db_types.hpp"
 #include "gaia_internal/db/triggers.hpp"
 
 #include "event_manager_test_helpers.hpp"
@@ -225,7 +226,7 @@ static field_position_list_t g_value{c_value};
 static field_position_list_t g_timestamp{c_timestamp};
 static field_position_list_t g_id{c_id};
 
-static constexpr gaia_txn_id_t dummy_txn_id = 0;
+static constexpr gaia_txn_id_t dummy_txn_id = c_invalid_gaia_txn_id;
 
 /**
  * Table Rule functions.


### PR DESCRIPTION
This is just a proof-of-concept to see whether strongly typing our internal db types is worth the effort. The current diff is pretty messy, but I think most of the noise could be removed with some judicious operator overloading (really just a few arithmetic and `ostream` operators). I don't want to spend time on enhancements, though, until I get feedback on whether this approach is worth pursuing.

FWIW, after making the strong typing changes, the compiler found 2 places where `gaia_locator_t` was incorrectly used in boolean context (I believe @LaurentiuCristofor tried to scrub the codebase for such usage a while back). This points to the value of strong typing; we just need to decide if it's worth the inconvenience.