### PR TITLE
Actually re-enable the new_registration test

### DIFF
--- a/production/tools/gaia_translate/tests/test_queries.cpp
+++ b/production/tools/gaia_translate/tests/test_queries.cpp
@@ -266,7 +266,7 @@ TEST_F(test_queries_code, implicit_navigation_fork)
     EXPECT_EQ(g_onupdate_value, 7) << "Incorrect sum";
 }
 
-TEST_F(test_queries_code, DISABLED_new_registration)
+TEST_F(test_queries_code, new_registration)
 {
     const int num_inserts = 4;
 


### PR DESCRIPTION
Well that's embarrassing.  I didn't actually re-enable the test that was causing spurious failures when I checked in the race condition fix.  The test was re-enabled in earlier commits for [PR-731](https://github.com/gaia-platform/GaiaPlatform/pull/731) but then undone in the final commit.