### PR TITLE
Fix double accounting of db_object header size

### DIFF
--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -619,7 +619,7 @@ address_offset_t client_t::allocate_object(
 {
     ASSERT_PRECONDITION(size != 0, "Size passed to client_t::allocate_object() should not be 0!");
 
-    address_offset_t object_offset = s_chunk_manager.allocate(size + c_db_object_header_size);
+    address_offset_t object_offset = s_chunk_manager.allocate(size);
     if (object_offset == c_invalid_address_offset)
     {
         // We ran out of memory in the current chunk. Allocate a new one!

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -662,7 +662,7 @@ address_offset_t server_t::allocate_object(
 {
     ASSERT_PRECONDITION(size != 0, "Size passed to server_t::allocate_object() should not be 0!");
 
-    address_offset_t object_offset = s_chunk_manager.allocate(size + c_db_object_header_size);
+    address_offset_t object_offset = s_chunk_manager.allocate(size);
     if (object_offset == c_invalid_address_offset)
     {
         // We ran out of memory in the current chunk.


### PR DESCRIPTION
@mihirj1993 noticed that we were accounting for the db_object header size both before calling the allocate_object methods as well as within those methods. This change makes allocate_object allocate just the size it was called to allocate.