### PR TITLE
Reordered printing of index_record to be the same as the order in the struct

### DIFF
--- a/production/db/index/src/index.cpp
+++ b/production/db/index/src/index.cpp
@@ -110,12 +110,12 @@ std::size_t index_key_hash::operator()(index_key_t const& key) const
 
 std::ostream& operator<<(std::ostream& os, const index_record_t& record)
 {
-    os << "locator: "
-       << record.locator
-       << "\ttxn_id: "
+    os << "\ttxn_id: "
        << record.txn_id
        << "\toffset: "
        << record.offset
+       << "locator: "
+       << record.locator
        << "\tdeleted: "
        << record.deleted
        << std::endl;


### PR DESCRIPTION
Small PR to aid in debugging