### PR TITLE
Fix a clang-tidy warning in ddl execution

### DIFF
--- a/production/inc/gaia_internal/catalog/ddl_execution.hpp
+++ b/production/inc/gaia_internal/catalog/ddl_execution.hpp
@@ -30,7 +30,7 @@ inline void execute(std::vector<std::unique_ptr<ddl::statement_t>>& statements)
             }
             if (create_stmt->type == ddl::create_type_t::create_table)
             {
-                auto create_table_stmt = dynamic_cast<ddl::create_table_t*>(create_stmt);
+                auto create_table_stmt = dynamic_cast<ddl::create_table_t*>(stmt.get());
                 create_table(create_table_stmt->database, create_table_stmt->name, create_table_stmt->fields, throw_on_exist);
             }
             else if (create_stmt->type == ddl::create_type_t::create_database)
@@ -39,7 +39,7 @@ inline void execute(std::vector<std::unique_ptr<ddl::statement_t>>& statements)
             }
             else if (create_stmt->type == ddl::create_type_t::create_relationship)
             {
-                auto create_relationship_stmt = dynamic_cast<ddl::create_relationship_t*>(create_stmt);
+                auto create_relationship_stmt = dynamic_cast<ddl::create_relationship_t*>(stmt.get());
                 create_relationship(
                     create_relationship_stmt->name,
                     create_relationship_stmt->relationship.first,
@@ -48,7 +48,7 @@ inline void execute(std::vector<std::unique_ptr<ddl::statement_t>>& statements)
             }
             else if (create_stmt->type == ddl::create_type_t::create_index)
             {
-                auto create_index_stmt = dynamic_cast<ddl::create_index_t*>(create_stmt);
+                auto create_index_stmt = dynamic_cast<ddl::create_index_t*>(stmt.get());
                 create_index(
                     create_index_stmt->name,
                     create_index_stmt->unique_index,


### PR DESCRIPTION
Dynamic casting on an intermediate pointer causes clang-tidy to complain: "Forming reference to null pointer".  Using the iterator directly fixes the issue. 