### PR TITLE
Pass gcc-compatible LDFLAGS to libexplain configure script

### DIFF
--- a/third_party/production/libexplain/gdev.cfg
+++ b/third_party/production/libexplain/gdev.cfg
@@ -15,6 +15,13 @@ third_party/production/bison
 [run]
 cd libexplain
 QUILT_PATCHES=debian/patches quilt push -a
+# The configure script used by the libexplain build doesn't seem to respect the
+# set value of CC as the linker frontend in libtool link mode, so we end up
+# passing LDFLAGS=-fuse-ld=lld-10 to gcc, which doesn't like it because it's
+# not in the canonical form -fuse-ld={bfd,gold,lld}. Clang has no problem with
+# -fuse-ld=lld-10, but we need to make gcc happy, so we rely on the fact that
+# we've already symlinked ld.lld to ld.lld-10 and pass LDFLAGS=-fuse-ld=lld to
+# configure instead.
 CPPFLAGS='-fPIC' ./configure LDFLAGS=-fuse-ld=lld --prefix=/usr
 make -j$(nproc)
 make install


### PR DESCRIPTION
This should fix the CI build regression on Ubuntu 20.04. Briefly, the `configure` script used by the `libexplain` build doesn't seem to respect the set value of `CC` as the linker frontend in `libtool` link mode, so we end up passing `LDFLAGS=-fuse-ld=lld-10` to `gcc`, which doesn't like it because it's not in the canonical form `-fuse-ld={bfd,gold,lld}`. Clang has no problem with `-fuse-ld=lld-10`, but we need to make `gcc` happy, so we rely on the fact that we've already symlinked `ld.lld` to `ld.lld-10` and pass `LDFLAGS=-fuse-ld=lld` to `configure` instead.

PS: If you hate CMake, you should try autotools!