### PR TITLE
Revert "Pass gcc-compatible LDFLAGS to libexplain configure script (#…

### DIFF
--- a/third_party/production/libexplain/gdev.cfg
+++ b/third_party/production/libexplain/gdev.cfg
@@ -15,14 +15,7 @@ third_party/production/bison
 [run]
 cd libexplain
 QUILT_PATCHES=debian/patches quilt push -a
-# The configure script used by the libexplain build doesn't seem to respect the
-# set value of CC as the linker frontend in libtool link mode, so we end up
-# passing LDFLAGS=-fuse-ld=lld-10 to gcc, which doesn't like it because it's
-# not in the canonical form -fuse-ld={bfd,gold,lld}. Clang has no problem with
-# -fuse-ld=lld-10, but we need to make gcc happy, so we rely on the fact that
-# we've already symlinked ld.lld to ld.lld-10 and pass LDFLAGS=-fuse-ld=lld to
-# configure instead.
-CPPFLAGS='-fPIC' ./configure LDFLAGS=-fuse-ld=lld --prefix=/usr
+CPPFLAGS='-fPIC' ./configure --prefix=/usr
 make -j$(nproc)
 make install
 cd ..


### PR DESCRIPTION
…758)"

This reverts commit 0864ff8456c929f84f864add1d0078f3bffb6865.

Needed to diagnose build error that this change apparently did not fix.