### PR TITLE
Fix gdev build

### DIFF
--- a/third_party/production/libexplain/gdev.cfg
+++ b/third_party/production/libexplain/gdev.cfg
@@ -18,7 +18,7 @@ QUILT_PATCHES=debian/patches quilt push -a
 # The configure script used by the libexplain build doesn't seem to respect the
 # set value of CC as the linker frontend in libtool link mode, so we end up
 # passing LDFLAGS=-fuse-ld=lld-10 to gcc, which doesn't like it because it's
-# not in the canonical form -fuse-ld={bfd,gold,lld}. Clang has no problem with
+# not in the canonical form -fuse-ld=bfd|gold|lld. Clang has no problem with
 # -fuse-ld=lld-10, but we need to make gcc happy, so we rely on the fact that
 # we've already symlinked ld.lld to ld.lld-10 and pass LDFLAGS=-fuse-ld=lld to
 # configure instead.


### PR DESCRIPTION
I added a comment with embedded braces to a `gdev.cfg` file, which made the `gdev` parser very confused because it blindly performed variable substitution on the text enclosed by the braces. This change removes braces from that comment and reverts the revert I made of my previous build fix (which was only done to narrow down the cause of this build break).

I created https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1035 to track the `gdev.cfg` parsing issue.