### PR TITLE
Fix operation of MPSC queue

### DIFF
--- a/production/inc/gaia_internal/common/queue.hpp
+++ b/production/inc/gaia_internal/common/queue.hpp
@@ -86,7 +86,7 @@ struct mpsc_queue_node_t
 
 // This implementation of a multiple-producer single-consumer (mpsc) queue
 // is based on the implementation described at:
-// https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue
+// https://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
 template <class T>
 class mpsc_queue_t
 {
@@ -112,6 +112,7 @@ protected:
     mpsc_queue_node_t<T>* dequeue_internal();
 
 protected:
+    // Nodes are enqueued at tail and removed from head.
     std::atomic<mpsc_queue_node_t<T>*> m_head;
     mpsc_queue_node_t<T>* m_tail;
 

--- a/production/inc/gaia_internal/common/queue.inc
+++ b/production/inc/gaia_internal/common/queue.inc
@@ -255,22 +255,28 @@ mpsc_queue_node_t<T>* mpsc_queue_t<T>::dequeue_internal()
     // Store its current value - other producers may update it.
     mpsc_queue_node_t<T>* head = m_head;
 
-    // DEVNOTE: Original code returned nullptr if head != tail.
-    // But that can only happen if a new node was inserted, in which case
-    // we should be able to continue with the removing of the tail node.
-    if (tail == head)
+    // This check detects another concurrent insertion that conflicts with our remove.
+    // The insertion needs to be allowed to complete updating the next link,
+    // so we cannot remove the last node until that happened. Hence, we abort our operation.
+    if (tail != head)
     {
-        // Push back the stub, so that we have one remaining entry in the queue.
-        enqueue_internal(&m_stub);
+        return nullptr;
     }
+
+    // Push back the stub, so that we have one remaining entry in the queue.
+    enqueue_internal(&m_stub);
 
     // Refresh the tail.next value.
     next = tail->next;
 
-    // DEVNOTE: Original code had a check on next, but we've replaced it with an assert.
-    ASSERT_INVARIANT(next, "Next node was expected to be non-null at this point!");
+    // If next comes up as null, it means that another concurrent insertion preceded ours,
+    // but did not complete the update of the next link, so again, we abort our operation.
+    if (!next)
+    {
+        return nullptr;
+    }
 
-    // Remove tail node now.
+    // The link to the next node is valid, so we can remove the tail node now.
     m_tail = next;
 
     return tail;


### PR DESCRIPTION
This PR fixes the issue I introduced when I modified the code of the MPSC queue. I added comments to explain the situations addressed by the checks in the code and I fixed the url which pointed to a different implementation.

Note: the issue was not hit so far because the way the queue is used right now avoids the special case when an issue could manifest: we're currently only extracting data from the queue when we accumulated enough and we don't attempt to extract the last element (this was originally done to avoid unnecessary producer-consumer concurrency conflicts).