### PR TITLE
Add LLVM build option to generate useful stack traces in Release builds

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -78,6 +78,9 @@ if(BUILD_GAIA_RELEASE OR BUILD_GAIA_LLVM_TESTS)
   # LLD/libc++ are necessary for MSan.
   set(LLVM_ENABLE_LLD ON CACHE BOOL "")
   set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
+  if(ENABLE_STACKTRACE)
+    set(LLVM_GENERATE_STACKTRACE_DEBUG_INFO ON CACHE BOOL "")
+  endif()
   if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     # This speeds up linking by separating debug info.
     set(LLVM_USE_SPLIT_DWARF ON CACHE BOOL "")

--- a/third_party/production/TranslationEngineLLVM/llvm/CMakeLists.txt
+++ b/third_party/production/TranslationEngineLLVM/llvm/CMakeLists.txt
@@ -440,6 +440,9 @@ option(LLVM_USE_SPLIT_DWARF
 option(LLVM_USE_GDB_INDEX
   "Use -Wl,--gdb-index when compiling llvm." OFF)
 
+option(LLVM_GENERATE_STACKTRACE_DEBUG_INFO
+  "Generate debug info for stack traces when compiling llvm." OFF)
+
 option(LLVM_POLLY_LINK_INTO_TOOLS "Statically link Polly into tools (if available)" ON)
 option(LLVM_POLLY_BUILD "Build LLVM with Polly" ON)
 

--- a/third_party/production/TranslationEngineLLVM/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/third_party/production/TranslationEngineLLVM/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -737,6 +737,15 @@ if (LLVM_USE_GDB_INDEX AND
   append("-Wl,--gdb-index" CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
 endif()
 
+# Generate enough debug info for stack traces
+if(LLVM_GENERATE_STACKTRACE_DEBUG_INFO)
+  add_flag_if_supported("-fno-omit-frame-pointer" FNO_OMIT_FRAME_POINTER)
+  if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND
+      NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "RELWITHDEBINFO")
+    add_flag_if_supported("-gline-tables-only" GLINE_TABLES_ONLY)
+  endif()
+endif()
+
 add_definitions( -D__STDC_CONSTANT_MACROS )
 add_definitions( -D__STDC_FORMAT_MACROS )
 add_definitions( -D__STDC_LIMIT_MACROS )

--- a/third_party/production/TranslationEngineLLVM/llvm/docs/CMake.rst
+++ b/third_party/production/TranslationEngineLLVM/llvm/docs/CMake.rst
@@ -591,6 +591,12 @@ LLVM-specific variables
   information at link time. Enabling this option can speed up GDB debugging
   startup times in Debug configurations with LLVM_USE_SPLIT_DWARF enabled.
 
+**LLVM_GENERATE_STACKTRACE_DEBUG_INFO**:BOOL
+  If enabled, add compile options to generate useful stack traces (but not
+  necessarily optimized for using a debugger). Enabling this option only affects
+  Release builds (Debug and RelWithDebInfo builds already generate enough debug
+  info for stack traces).
+
 CMake Caches
 ============
 


### PR DESCRIPTION
This was prompted by a conversation with @fineg74 where he showed that even with `-DENABLE_STACKTRACE=ON`, `gaiat` stack traces were not useful where they included only LLVM code, because the LLVM build did not generate any debug info in `Release` mode. This change adds a new LLVM build option `LLVM_GENERATE_STACKTRACE_DEBUG_INFO` (enabled under the default Gaia build setting `ENABLE_STACKTRACE=ON`), that adds `-fno-omit-frame-pointer` and `-gline-tables-only` to compile flags for `Release` builds , which is enough for useful stack traces (but not necessarily enough for using a debugger, in which case you want to build in `Debug` or `RelWithDebInfo` mode).