### PR TITLE
Generate only source line tables for Release builds

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -260,7 +260,7 @@ if(ENABLE_STACKTRACE)
   add_subdirectory("${GAIA_REPO}/third_party/production/backward" backward)
   add_library(gaia_stack_trace INTERFACE)
   target_sources(gaia_stack_trace INTERFACE "${GAIA_INC}/gaia_internal/common/backward.cpp")
-  target_compile_options(gaia_stack_trace INTERFACE -g -funwind-tables -fno-omit-frame-pointer)
+  target_compile_options(gaia_stack_trace INTERFACE -gline-tables-only -funwind-tables -fno-omit-frame-pointer)
   target_link_libraries(gaia_stack_trace INTERFACE backward)
 endif()
 # Cpptoml.


### PR DESCRIPTION
This is just a trivial compiler flag change that came out of #789. We don't actually need to generate full debug info to get usable stack traces, just source line tables. This will presumably avoid some binary bloat in Release binaries (although I haven't measured the savings). I verified that Release builds still generate readable stack traces with this change.