### PR TITLE
Hide the instance name option in gaiac

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -199,15 +199,15 @@ string usage()
 {
     std::stringstream ss;
     ss << "Usage: gaiac [options] [ddl_file]\n\n"
-          "  -n|--instance-name <name> Specify the database instance name.\n"
-          "                            If not specified will use "
-       << c_default_instance_name << ".\n"
-       << "                            If 'rnd' is specified will use a random name.\n"
           "  -d|--db-name <dbname>     Specify the database name.\n"
           "  -i|--interactive          Interactive prompt, as a REPL.\n"
           "  -g|--generate             Generate direct access API header files.\n"
           "  -o|--output <path>        Set the output directory for all generated files.\n"
 #ifdef DEBUG
+          "  -n|--instance-name <name> Specify the database instance name.\n"
+          "                            If not specified will use "
+       << c_default_instance_name << ".\n"
+       << "                            If 'rnd' is specified will use a random name.\n"
           "  -p|--parse-trace          Print parsing trace.\n"
           "  -s|--scan-trace           Print scanning trace.\n"
           "  -t|--db-server-path       Start the DB server (for testing purposes).\n"


### PR DESCRIPTION
Hide this option in release build as discussed because we do not want to expose this feature to users yet.