### PR TITLE
Fix bug in misusage of Sema::addMethod()

### DIFF
--- a/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaGaia.cpp
+++ b/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaGaia.cpp
@@ -547,8 +547,8 @@ QualType Sema::getLinkType(const std::string& linkName, const std::string& from_
 
     // TODO we could introspect the catalog and add Connect/Disconnect only when necessary
     //  and accept only the necessary types. Will address in next PR.
-    addMethod(&Context.Idents.get("Connect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true, ParsedType::make(Context.getTagDeclType(RD)));
-    addMethod(&Context.Idents.get("Disconnect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true, ParsedType::make(Context.getTagDeclType(RD)));
+    addMethod(&Context.Idents.get("Connect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true);
+    addMethod(&Context.Idents.get("Disconnect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true);
 
     ActOnFinishCXXMemberSpecification(getCurScope(), loc, RD, loc, loc, attrs);
     ActOnTagFinishDefinition(getCurScope(), RD, SourceRange());
@@ -695,8 +695,8 @@ QualType Sema::getTableType(const std::string& tableName, SourceLocation loc)
 
     // TODO we could introspect the catalog and add Connect/Disconnect only when necessary
     //  and accept only the necessary types. Will address in next PR.
-    addMethod(&Context.Idents.get("Connect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true, ParsedType::make(Context.getTagDeclType(RD)));
-    addMethod(&Context.Idents.get("Disconnect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true, ParsedType::make(Context.getTagDeclType(RD)));
+    addMethod(&Context.Idents.get("Connect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true);
+    addMethod(&Context.Idents.get("Disconnect"), DeclSpec::TST_bool, nullptr, 0, attrFactory, attrs, &S, RD, loc, true);
 
     ActOnFinishCXXMemberSpecification(getCurScope(), loc, RD, loc, loc, attrs);
     ActOnTagFinishDefinition(getCurScope(), RD, SourceRange());


### PR DESCRIPTION
Fix bug found by @waynelwarren due to misusage of `Sema::addMethod()` in the `Connect/Disconnect` implementation. The bug was visible only in Debug mode, because assertions are disabled in Release.

Link to the LLVM tests build: http://segate2:8111/buildConfiguration/GaiaPlatform_ProductionGaiaLLVMTestsGdev/14704