### PR TITLE
Fix a build break

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -149,6 +149,7 @@ install(TARGETS gaia_db_server DESTINATION ${CMAKE_INSTALL_BINDIR})
 set(GAIA_DB_CORE_TEST_INCLUDES
   ${GAIA_DB_CORE_PUBLIC_INCLUDES}
   ${GAIA_DB_CORE_PRIVATE_INCLUDES}
+  ${FLATBUFFERS_INC}
 )
 
 ###############################################
@@ -216,12 +217,12 @@ target_link_libraries(gaia_db_catalog_test PUBLIC gaia_build_options)
 target_include_directories(gaia_db_catalog_test PRIVATE ${GAIA_DB_CATALOG_TEST_PRIVATE_INCLUDES})
 target_link_libraries(gaia_db_catalog_test PRIVATE gaia_common gaia_db_client gaia_schema_loader gtest)
 
-add_gtest(test_rdb_object_converter tests/test_rdb_object_converter.cpp "${FLATBUFFERS_INC};${GEN_DIR};${GAIA_DB_CORE_TEST_INCLUDES}" "rocks_wrapper")
+add_gtest(test_rdb_object_converter tests/test_rdb_object_converter.cpp "${GEN_DIR};${GAIA_DB_CORE_TEST_INCLUDES}" "rocks_wrapper")
 add_gtest(test_record_list tests/test_record_list.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_storage")
 add_gtest(test_record_list_manager tests/test_record_list_manager.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_storage")
-add_gtest(test_db_client tests/test_db_client.cpp "${FLATBUFFERS_INC};${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_db_client;gaia_direct;gaia_catalog")
+add_gtest(test_db_client tests/test_db_client.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_db_client;gaia_direct;gaia_catalog")
 add_gtest(test_db_internals tests/test_db_internals.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_storage;gaia_db_client")
-add_gtest(test_db_references tests/test_db_references.cpp "${FLATBUFFERS_INC};${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_db_client;gaia_direct;gaia_catalog")
+add_gtest(test_db_references tests/test_db_references.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_db_client;gaia_direct;gaia_catalog")
 add_gtest(test_env_instance_name tests/test_db_server_env.cpp "${GAIA_DB_CORE_TEST_INCLUDES}" "gaia_common;gaia_db_client;gaia_direct")
 
 add_gtest(test_multiple_server_instances


### PR DESCRIPTION
Two DB unit tests now need to call catalog APIs. As a result, they will also need fbs headers in order to work.