### PR TITLE
Move static asserts closer to the code that they apply to

### DIFF
--- a/production/inc/gaia_internal/db/db_object.hpp
+++ b/production/inc/gaia_internal/db/db_object.hpp
@@ -59,23 +59,6 @@ struct alignas(gaia::db::memory_manager::c_allocation_alignment) db_object_t
 // object header!
 constexpr size_t c_db_object_header_size = offsetof(db_object_t, payload);
 
-// We want to ensure that the object header size never changes accidentally.
-constexpr size_t c_db_object_expected_header_size = 16;
-
-// The entire object can have maximum size 64KB, so user-defined data can
-// have minimum size 0 bytes (implying that the references array and the
-// serialized flatbuffer are both empty), and maximum size 64KB - 16B.
-constexpr size_t c_db_object_max_size = static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1;
-
-constexpr size_t c_db_object_max_payload_size = c_db_object_max_size - c_db_object_header_size;
-
-// Check for overflow.
-static_assert(c_db_object_max_payload_size <= std::numeric_limits<uint16_t>::max());
-
-// The object header size may change in the future, but we want to explicitly
-// assert that it is a specific value to catch any inadvertent changes.
-static_assert(c_db_object_header_size == c_db_object_expected_header_size, "Object header size must be 16 bytes!");
-
 // Due to our memory management requirements, we never want the object header
 // size to be larger than the object alignment.
 static_assert(c_db_object_header_size <= gaia::db::memory_manager::c_allocation_alignment, "Object header size must not exceed object alignment!");
@@ -87,6 +70,23 @@ static_assert(c_db_object_header_size <= gaia::db::memory_manager::c_allocation_
 // we assert that the payload field is correctly aligned, to avoid having the
 // compiler silently insert padding if the field isn't naturally aligned.
 static_assert(c_db_object_header_size % sizeof(uint64_t) == 0, "Payload must be 8-byte-aligned!");
+
+// We want to ensure that the object header size never changes accidentally.
+constexpr size_t c_db_object_expected_header_size = 16;
+
+// The object header size may change in the future, but we want to explicitly
+// assert that it is a specific value to catch any inadvertent changes.
+static_assert(c_db_object_header_size == c_db_object_expected_header_size, "Object header size must be 16 bytes!");
+
+// The entire object can have maximum size 64KB, so user-defined data can
+// have minimum size 0 bytes (implying that the references array and the
+// serialized flatbuffer are both empty), and maximum size 64KB - 16B.
+constexpr size_t c_db_object_max_size = static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1;
+
+constexpr size_t c_db_object_max_payload_size = c_db_object_max_size - c_db_object_header_size;
+
+// Check for overflow.
+static_assert(c_db_object_max_payload_size <= std::numeric_limits<uint16_t>::max());
 
 // According to the standard, sizeof(T) is always a multiple of alignof(T).
 // We need this multiple to be 1 to simplify memory management.


### PR DESCRIPTION
As the title says: this makes it easier for someone changing a constant to see what restrictions apply to it.