### PR TITLE
Fix test_insert_delete.cpp bug

### DIFF
--- a/production/tools/gaia_translate/tests/test_insert_delete.cpp
+++ b/production/tools/gaia_translate/tests/test_insert_delete.cpp
@@ -235,7 +235,7 @@ TEST_F(test_insert_delete_code, implicit_delete)
     gaia::rules::initialize_rules_engine();
     // Use the rules for insert & delete.
     gaia::rules::unsubscribe_rules();
-    gaia::rules::subscribe_ruleset("test_insert_delete_1");
+    gaia::rules::subscribe_ruleset("test_insert_delete");
 
     // Fire on_update(S:student).
     gaia::db::begin_transaction();


### PR DESCRIPTION
The `test_insert_delete_code.implicit_delete` subscribes to a non-existent ruleset.