### PR TITLE
Disable clang-tidy on gaiat for non Release builds.

### DIFF
--- a/production/tools/CMakeLists.txt
+++ b/production/tools/CMakeLists.txt
@@ -7,14 +7,14 @@
 project(tools)
 
 if(BUILD_GAIA_RELEASE)
-  # clang-tidy takes 1:10 minutes on gaiat, for this reason, I disabled it for non-Release builds.
+  # clang-tidy takes 1:10 minutes on gaiat, for this reason, it is disabled for non-Debug builds.
   # TODO Created this task to find a better solution: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1169
-  if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     unset(CMAKE_CXX_CLANG_TIDY)
   endif()
   add_subdirectory(gaia_translate)
 
-  if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_CLANG_TIDY clang-tidy)
   endif()
 endif()


### PR DESCRIPTION
clang-tidy takes 1:10 minutes on gaiat, for this reason, I disabled it for non-Release builds.
Created this task to find a better solution: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1169

gaiat build time without clang-tidy goes from 1:30 minutes to 20 seconds.