### PR TITLE
GAIAPLAT-1185: Update reset_database.sh to support installing new Gaia SDK packages.

### DIFF
--- a/test/install_sdk_build.sh
+++ b/test/install_sdk_build.sh
@@ -1,0 +1,136 @@
+#! /usr/bin/bash
+
+#############################################
+# Copyright (c) Gaia Platform LLC
+# All rights reserved.
+#############################################
+
+# Simple function to start the process off.
+start_process() {
+    if [ "$VERBOSE_MODE" -ne 0 ]; then
+        echo "Installing a new SDK build..."
+    fi
+}
+
+# Simple function to stop the process, including any cleanup
+complete_process() {
+    local SCRIPT_RETURN_CODE=$1
+
+    if [ "$SCRIPT_RETURN_CODE" -ne 0 ]; then
+        echo "Installation of the new SDK build failed."
+    else
+        if [ "$VERBOSE_MODE" -ne 0 ]; then
+            echo "Installation of the new SDK build succeeded."
+        fi
+    fi
+
+    if [ -f "$TEMP_FILE" ]; then
+        rm "$TEMP_FILE"
+    fi
+
+    exit "$SCRIPT_RETURN_CODE"
+}
+
+# Show how this script can be used.
+show_usage() {
+    local SCRIPT_NAME=$0
+
+    echo "Usage: $(basename "$SCRIPT_NAME") [flags] new_debian_install_file"
+    echo "Flags:"
+    echo "  -v,--verbose                Show lots of information while executing the project."
+    echo "  -h,--help                   Display this help text."
+    echo "Parameters:"
+    echo "  new_debian_install_file     Filename of a debian build file to install while the"
+    echo "                              database is shutdown."
+    echo ""
+    exit 1
+}
+
+# Parse the command line.
+parse_command_line() {
+    VERBOSE_MODE=0
+    PARAMS=()
+    while (( "$#" )); do
+    case "$1" in
+        -v|--verbose)
+            VERBOSE_MODE=1
+            shift
+        ;;
+        -h|--help)
+            show_usage
+        ;;
+        -*) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            show_usage
+        ;;
+        *) # preserve positional arguments
+            PARAMS+=("$1")
+            shift
+        ;;
+    esac
+    done
+}
+
+# Make sure that the install file is present and looks like a debian install file.
+verify_install_file() {
+    INSTALL_FILE=${PARAMS[0]}
+
+    if [ -z "$INSTALL_FILE" ] ; then
+        echo "Install file '$(realpath "$INSTALL_FILE")' does not exist."
+        complete_process 1
+    fi
+
+    # Make sure it exists.
+    if [ ! -f "$INSTALL_FILE" ]; then
+        echo "Install file '$(realpath "$INSTALL_FILE")' does not exist."
+        complete_process 1
+    fi
+
+    if [[ ! "$INSTALL_FILE" == *.deb ]] ; then
+        echo "Install file '$(realpath "$INSTALL_FILE")' does not end with the required suffix '.deb'."
+        complete_process 1
+    fi
+}
+
+# Remove the old package and install the new package.
+install_new_package() {
+    if ! sudo apt --assume-yes remove gaia ; then
+        echo "Removal of old Gaia package did not complete.  Gaia may be in an undefined state."
+        complete_process 1
+    fi
+
+    if ! sudo apt --assume-yes install "$INSTALL_FILE" ; then
+        echo "Installation of new Gaia package did not complete.  Gaia may be in an undefined state."
+        complete_process 1
+    fi
+}
+
+# Set up any global script variables.
+# shellcheck disable=SC2164
+#SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# Set up any project based local script variables.
+TEMP_FILE=/tmp/intall_sdk.db.tmp
+
+
+# Parse any command line values.
+parse_command_line "$@"
+
+verify_install_file
+
+
+# Clean entrance into the script.
+start_process
+
+if ! ./reset_database.sh --stop --database ; then
+    echo "Database service stop did not complete."
+    complete_process 1
+fi
+
+# Install the new package.  Note that the last step of the install
+# is to start the new DB server as a service.  As such, we don't
+# need this script to balance out the stop service with a start service.
+install_new_package
+
+# If we get here, we have a clean exit from the script.
+complete_process 0

--- a/test/reset_database.sh
+++ b/test/reset_database.sh
@@ -37,6 +37,8 @@ show_usage() {
 
     echo "Usage: $(basename "$SCRIPT_NAME") [flags]"
     echo "Flags:"
+    echo "  -s,--stop                   Stop the database service only, but do not restart it."
+    echo "  -d,--database               Reset any database files while database is shutdown."
     echo "  -v,--verbose                Show lots of information while executing the project."
     echo "  -h,--help                   Display this help text."
     echo ""
@@ -47,11 +49,16 @@ show_usage() {
 parse_command_line() {
     VERBOSE_MODE=0
     RESET_DATABASE=0
+    STOP_DATABASE_ONLY=0
     PARAMS=()
     while (( "$#" )); do
     case "$1" in
         -d|--database)
             RESET_DATABASE=1
+            shift
+        ;;
+        -s|--stop)
+            STOP_DATABASE_ONLY=1
             shift
         ;;
         -v|--verbose)
@@ -163,40 +170,6 @@ remove_data_store() {
     fi
 }
 
-# If an install file was specified, make sure it is present and looks like a debian install file.
-verify_install_file_if_present() {
-    INSTALL_FILE=${PARAMS[0]}
-    if [ -n "$INSTALL_FILE" ] ; then
-
-        # Make sure it exists.
-        if [ ! -f "$INSTALL_FILE" ]; then
-            echo "Install file '$(realpath "$INSTALL_FILE")' does not exist."
-            complete_process 1
-        fi
-
-        if [[ ! "$INSTALL_FILE" == *.deb ]] ; then
-            echo "Install file '$(realpath "$INSTALL_FILE")' does not end with the required suffix '.deb'."
-            complete_process 1
-        fi
-
-        echo "Installation of new packages requires resetting of the database.  Option selected."
-        RESET_DATABASE=1
-    fi
-}
-
-# Remove the old package and install the new package.
-install_new_package() {
-    if ! sudo apt --assume-yes remove gaia ; then
-        echo "Removal of old Gaia package did not complete.  Gaia may be in an undefined state."
-        complete_process 1
-    fi
-
-    if ! sudo apt --assume-yes install "$INSTALL_FILE" ; then
-        echo "Installation of new Gaia package did not complete.  Gaia may be in an undefined state."
-        complete_process 1
-    fi
-}
-
 # Set up any global script variables.
 # shellcheck disable=SC2164
 #SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
@@ -211,8 +184,6 @@ service_name=gaia
 # Parse any command line values.
 parse_command_line "$@"
 
-verify_install_file_if_present
-
 
 # Clean entrance into the script.
 start_process
@@ -223,11 +194,9 @@ if [ $RESET_DATABASE -ne 0 ] ; then
     remove_data_store
 fi
 
-if [ -n "$INSTALL_FILE" ] ; then
-    install_new_package
+if [ $STOP_DATABASE_ONLY -eq 0 ]; then
+    start_database_service
 fi
-
-start_database_service
 
 # If we get here, we have a clean exit from the script.
 complete_process 0


### PR DESCRIPTION
https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1185 

Update reset_database.sh to support installing new Gaia SDK packages.

This is a frequent action during testing sessions, so it is very useful to have this process be as painless as possible.