### PR TITLE
Fix incubator build with ASAN enabled

### DIFF
--- a/production/examples/incubator/CMakeLists.txt
+++ b/production/examples/incubator/CMakeLists.txt
@@ -22,7 +22,7 @@ add_link_options(-stdlib=libc++)
 # Debug build-specific options.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_options(-O0 -g3 -ggdb -fno-limit-debug-info -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf)
-  if("$CACHE{SANITIZER}" STREQUAL "ASAN")
+  if(SANITIZER STREQUAL "ASAN")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)
     add_link_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)
   endif()


### PR DESCRIPTION
Using `SANITIZER` as a cached variable doesn't work when you're not building at the top level (the cached variable is defined in `production/CMakeLists.txt`). With this change, the incubator app builds properly with `-DCMAKE_BUILD_TYPE=Debug -DSANITIZER=ASAN`.