### PR TITLE
Fix a random build failure

### DIFF
--- a/production/catalog/CMakeLists.txt
+++ b/production/catalog/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(gaia_catalog PUBLIC gaia_build_options)
 target_include_directories(gaia_catalog PUBLIC ${GAIA_CATALOG_PUBLIC_INCLUDES})
 target_include_directories(gaia_catalog PRIVATE ${GAIA_CATALOG_PRIVATE_INCLUDES})
 target_link_libraries(gaia_catalog PRIVATE gaia_direct flatbuffers edc_catalog)
+add_dependencies(gaia_catalog gaia_parser)
 
 add_gtest(test_ddl_executor
   "tests/test_ddl_executor.cpp"


### PR DESCRIPTION
There is a race condition where gaia parser headers could be generated before catalog needs it. Add the explicit dependency to make sure the parser header is available before the catalog target build. 

Failure:
http://192.168.0.250:8111/viewLog.html?buildId=15472&buildTypeId=GaiaPlatform_ProductionGaiaLLVMTestsGdev

Pass:
http://192.168.0.250:8111/viewLog.html?buildId=15503&buildTypeId=GaiaPlatform_ProductionGaiaLLVMTestsGdev