### PR TITLE
Eliminate compiler warnings when compiling translated rules

### DIFF
--- a/production/tools/gaia_translate/tests/test_rulesets.ruleset
+++ b/production/tools/gaia_translate/tests/test_rulesets.ruleset
@@ -434,9 +434,10 @@ ruleset test_query_10
 // This ruleset is not used, but its translation must compile with C++.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-label"
-// The pragma is because the break labels, BREAK1_TARGET, etc. are left in
-// the code and result in compiler warnings. The Jira issue, when fixed,
-// will eliminate any unused labels. These pragmas should be removed then.
+// These pragmas are needed to prevent compiler warnings resulting from unused labels
+// in the translated code. The break labels, BREAK1_TARGET, etc. are currently left in
+// the code unconditionally. The Jira issue, when fixed, will eliminate any unused labels.
+// These pragmas should be removed then.
 // GAIAPLAT-1198
 ruleset test_compile
 {


### PR DESCRIPTION
Anticipating GAIAPLAT-1198.

Add pragmas that eliminate the obnoxious compiler warnings the occur when goto labels are not used in the code.