### PR TITLE
Make last semicolon optional for DDL input from a file

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -100,7 +100,7 @@ void start_repl(parser_t& parser)
 
             if (rtrim(line).back() == ';')
             {
-                parser.parse_line(ddl_buffer + line);
+                parser.parse_string(ddl_buffer + line);
                 execute(parser.statements);
                 ddl_buffer = "";
             }

--- a/production/catalog/parser/inc/gaia_parser.hpp
+++ b/production/catalog/parser/inc/gaia_parser.hpp
@@ -53,7 +53,8 @@ public:
         m_file = filename;
         location.initialize(&m_file);
         scan_begin();
-        const auto finish_scan = common::scope_guard::make_scope_guard([this]() { scan_end(); });
+        const auto finish_scan = common::scope_guard::make_scope_guard([this]()
+                                                                       { scan_end(); });
 
         yy::parser parse(*this);
         parse.set_debug_level(trace_parsing);
@@ -66,10 +67,11 @@ public:
             "Failed to handle parsing errors in the DDL file '" + filename + "'.");
     };
 
-    void parse_line(const std::string& line)
+    void parse_string(const std::string& str)
     {
-        scan_string_begin(line);
-        const auto finish_scan_string = common::scope_guard::make_scope_guard([this]() { scan_string_end(); });
+        scan_string_begin(str);
+        const auto finish_scan_string = common::scope_guard::make_scope_guard([this]()
+                                                                              { scan_string_end(); });
 
         yy::parser parse(*this);
         parse.set_debug_level(trace_parsing);
@@ -79,7 +81,7 @@ public:
         // Any violation below means there are unhandled parsing errors.
         ASSERT_POSTCONDITION(
             parsing_result == EXIT_SUCCESS,
-            "Failed to handle parsing errors in the line: '" + line + "'.");
+            "Failed to handle parsing errors in the line: '" + str + "'.");
     }
 
     yy::location location;

--- a/production/catalog/parser/tests/test_ddl_parser.cpp
+++ b/production/catalog/parser/tests/test_ddl_parser.cpp
@@ -15,7 +15,7 @@ using namespace gaia::catalog::ddl;
 TEST(catalog_ddl_parser_test, create_table)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t (c INT32);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t (c INT32);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -31,7 +31,7 @@ TEST(catalog_ddl_parser_test, create_table)
 TEST(catalog_ddl_parser_test, create_table_if_not_exists)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE IF NOT EXISTS t (c INT32);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE IF NOT EXISTS t (c INT32);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -47,7 +47,7 @@ TEST(catalog_ddl_parser_test, create_table_if_not_exists)
 TEST(catalog_ddl_parser_test, create_table_multiple_fields)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t (c1 INT32[], c2 DOUBLE[]);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t (c1 INT32[], c2 DOUBLE[]);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -82,7 +82,7 @@ TEST(catalog_ddl_parser_test, create_table_multiple_fields)
 TEST(catalog_ddl_parser_test, drop_table)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("DROP TABLE t;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP TABLE t;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
@@ -93,7 +93,7 @@ TEST(catalog_ddl_parser_test, drop_table)
     EXPECT_EQ(drop_stmt->name, "t");
     EXPECT_FALSE(drop_stmt->if_exists);
 
-    ASSERT_NO_THROW(parser.parse_line("DROP TABLE IF EXISTS t;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP TABLE IF EXISTS t;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
@@ -108,20 +108,20 @@ TEST(catalog_ddl_parser_test, drop_table)
 TEST(catalog_ddl_parser_test, case_sensitivity)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t (c INT32);"));
-    ASSERT_NO_THROW(parser.parse_line("create table t (c int32);"));
-    ASSERT_NO_THROW(parser.parse_line("cReAte taBle T (c int32);"));
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE T (c int32, C int32);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t (c INT32);"));
+    ASSERT_NO_THROW(parser.parse_string("create table t (c int32);"));
+    ASSERT_NO_THROW(parser.parse_string("cReAte taBle T (c int32);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE T (c int32, C int32);"));
 
-    ASSERT_NO_THROW(parser.parse_line("DROP TABLE t;"));
-    ASSERT_NO_THROW(parser.parse_line("drop table t;"));
-    ASSERT_NO_THROW(parser.parse_line("DrOp TaBle T;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP TABLE t;"));
+    ASSERT_NO_THROW(parser.parse_string("drop table t;"));
+    ASSERT_NO_THROW(parser.parse_string("DrOp TaBle T;"));
 }
 
 TEST(catalog_ddl_parser_test, create_active_field)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t (id INT32[] ACTIVE, name STRING ACTIVE);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t (id INT32[] ACTIVE, name STRING ACTIVE);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -156,7 +156,7 @@ TEST(catalog_ddl_parser_test, create_active_field)
 TEST(catalog_ddl_parser_test, create_database)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE DATABASE db;"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE DATABASE db;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -172,7 +172,7 @@ TEST(catalog_ddl_parser_test, create_database)
 TEST(catalog_ddl_parser_test, create_database_if_not_exists)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE DATABASE IF NOT EXISTS db;"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE DATABASE IF NOT EXISTS db;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -188,7 +188,7 @@ TEST(catalog_ddl_parser_test, create_database_if_not_exists)
 TEST(catalog_ddl_parser_test, create_table_in_database)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE d.t (id INT32);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE d.t (id INT32);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -207,7 +207,7 @@ TEST(catalog_ddl_parser_test, create_table_in_database)
 TEST(catalog_ddl_parser_test, drop_database)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("DROP DATABASE d;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP DATABASE d;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
@@ -218,7 +218,7 @@ TEST(catalog_ddl_parser_test, drop_database)
     EXPECT_EQ(drop_stmt->name, "d");
     EXPECT_FALSE(drop_stmt->if_exists);
 
-    ASSERT_NO_THROW(parser.parse_line("DROP DATABASE IF EXISTS d;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP DATABASE IF EXISTS d;"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::drop);
@@ -233,23 +233,23 @@ TEST(catalog_ddl_parser_test, drop_database)
 TEST(catalog_ddl_parser_test, illegal_characters)
 {
     parser_t parser;
-    EXPECT_THROW(parser.parse_line("CREATE TABLE t(id : int8);"), parsing_error);
-    EXPECT_THROW(parser.parse_line("CREATE : TABLE t(id int8);"), parsing_error);
-    EXPECT_THROW(parser.parse_line("CREATE TABLE t(id - int8);"), parsing_error);
+    EXPECT_THROW(parser.parse_string("CREATE TABLE t(id : int8);"), parsing_error);
+    EXPECT_THROW(parser.parse_string("CREATE : TABLE t(id int8);"), parsing_error);
+    EXPECT_THROW(parser.parse_string("CREATE TABLE t(id - int8);"), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, fixed_size_array)
 {
     parser_t parser;
-    ASSERT_THROW(parser.parse_line("CREATE TABLE t (c INT32[2]);"), parsing_error);
-    ASSERT_THROW(parser.parse_line("CREATE TABLE t (c INT32[1]);"), parsing_error);
-    ASSERT_THROW(parser.parse_line("CREATE TABLE t (c INT32[0]);"), parsing_error);
+    ASSERT_THROW(parser.parse_string("CREATE TABLE t (c INT32[2]);"), parsing_error);
+    ASSERT_THROW(parser.parse_string("CREATE TABLE t (c INT32[1]);"), parsing_error);
+    ASSERT_THROW(parser.parse_string("CREATE TABLE t (c INT32[0]);"), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, vector_of_strings)
 {
     parser_t parser;
-    ASSERT_THROW(parser.parse_line("CREATE TABLE t (c STRING[]);"), parsing_error);
+    ASSERT_THROW(parser.parse_string("CREATE TABLE t (c STRING[]);"), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, code_comments)
@@ -272,17 +272,17 @@ CREATE TABLE t -- create table t
 
     parser_t parser;
 
-    ASSERT_NO_THROW(parser.parse_line(correct_ddl_text));
+    ASSERT_NO_THROW(parser.parse_string(correct_ddl_text));
     EXPECT_EQ(1, parser.statements.size());
 
-    ASSERT_THROW(parser.parse_line(incorrect_ddl_text), parsing_error);
+    ASSERT_THROW(parser.parse_string(incorrect_ddl_text), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, create_empty_table)
 {
     parser_t parser;
 
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t ();"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t ();"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -309,7 +309,7 @@ CREATE RELATIONSHIP r (
   d2.t2.link2 -> d1.t1
 );
 )";
-    ASSERT_NO_THROW(parser.parse_line(ddl_text_full_db));
+    ASSERT_NO_THROW(parser.parse_string(ddl_text_full_db));
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
     auto create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
@@ -322,7 +322,7 @@ CREATE RELATIONSHIP r (
   t2.link2 -> t1
 );
 )";
-    ASSERT_NO_THROW(parser.parse_line(ddl_text_no_db));
+    ASSERT_NO_THROW(parser.parse_string(ddl_text_no_db));
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
     create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
@@ -335,7 +335,7 @@ CREATE RELATIONSHIP r (
   t2.link2 -> d1.t1
 );
 )";
-    ASSERT_NO_THROW(parser.parse_line(ddl_text_partial_db));
+    ASSERT_NO_THROW(parser.parse_string(ddl_text_partial_db));
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
     create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
@@ -348,20 +348,20 @@ CREATE RELATIONSHIP (
   t2.link2 -> t1
 );
 )";
-    ASSERT_THROW(parser.parse_line(ddl_text_negative_case_no_name), parsing_error);
+    ASSERT_THROW(parser.parse_string(ddl_text_negative_case_no_name), parsing_error);
 
     const string ddl_text_negative_case_single_link = R"(
 CREATE RELATIONSHIP r (
   t1.link -> t2,
 );
 )";
-    ASSERT_THROW(parser.parse_line(ddl_text_negative_case_single_link), parsing_error);
+    ASSERT_THROW(parser.parse_string(ddl_text_negative_case_single_link), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, create_index)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE INDEX IF NOT EXISTS idx ON d.t (name);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE INDEX IF NOT EXISTS idx ON d.t (name);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -383,7 +383,7 @@ TEST(catalog_ddl_parser_test, create_index)
 TEST(catalog_ddl_parser_test, create_unique_index)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE UNIQUE INDEX idx ON d.t (name);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE UNIQUE INDEX idx ON d.t (name);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -405,7 +405,7 @@ TEST(catalog_ddl_parser_test, create_unique_index)
 TEST(catalog_ddl_parser_test, create_hash_index)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE UNIQUE HASH INDEX idx ON d.t (name);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE UNIQUE HASH INDEX idx ON d.t (name);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -427,7 +427,7 @@ TEST(catalog_ddl_parser_test, create_hash_index)
 TEST(catalog_ddl_parser_test, create_range_index)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE RANGE INDEX IF NOT EXISTS idx ON d.t (name);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE RANGE INDEX IF NOT EXISTS idx ON d.t (name);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -457,7 +457,7 @@ CREATE RELATIONSHIP r (
 );
 )";
 
-    ASSERT_NO_THROW(parser.parse_line(ddl_one_to_one));
+    ASSERT_NO_THROW(parser.parse_string(ddl_one_to_one));
     auto create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
     auto create_stmt = dynamic_cast<create_statement_t*>(create_list->statements[0].get());
     EXPECT_EQ(create_stmt->type, create_type_t::create_relationship);
@@ -493,7 +493,7 @@ CREATE RELATIONSHIP r (
 );
 )";
 
-    ASSERT_NO_THROW(parser.parse_line(ddl_one_to_one));
+    ASSERT_NO_THROW(parser.parse_string(ddl_one_to_one));
     auto create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
     auto create_stmt = dynamic_cast<create_statement_t*>(create_list->statements[0].get());
     EXPECT_EQ(create_stmt->type, create_type_t::create_relationship);
@@ -521,7 +521,7 @@ CREATE RELATIONSHIP r (
 TEST(catalog_ddl_parser_test, create_unique_field)
 {
     parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("CREATE TABLE t (id UINT64 UNIQUE, name STRING UNIQUE ACTIVE, ssn STRING ACTIVE UNIQUE);"));
+    ASSERT_NO_THROW(parser.parse_string("CREATE TABLE t (id UINT64 UNIQUE, name STRING UNIQUE ACTIVE, ssn STRING ACTIVE UNIQUE);"));
 
     EXPECT_EQ(1, parser.statements.size());
     EXPECT_EQ(parser.statements[0]->type(), statement_type_t::create_list);
@@ -575,7 +575,7 @@ CREATE RELATIONSHIP r (
 );
 )";
 
-    ASSERT_NO_THROW(parser.parse_line(create_relationship_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_relationship_ddl));
     auto create_list = dynamic_cast<create_list_t*>(parser.statements[0].get());
     auto create_stmt = dynamic_cast<create_statement_t*>(create_list->statements[0].get());
     EXPECT_EQ(create_stmt->type, create_type_t::create_relationship);
@@ -631,9 +631,9 @@ CREATE RELATIONSHIP r (
 );
 )";
 
-    EXPECT_THROW(parser.parse_line(negative_1), parsing_error);
-    EXPECT_THROW(parser.parse_line(negative_2), parsing_error);
-    EXPECT_THROW(parser.parse_line(negative_3), parsing_error);
+    EXPECT_THROW(parser.parse_string(negative_1), parsing_error);
+    EXPECT_THROW(parser.parse_string(negative_2), parsing_error);
+    EXPECT_THROW(parser.parse_string(negative_3), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, create_statement_list)
@@ -670,8 +670,8 @@ CREATE table  t2(
 ;
 )";
 
-    ASSERT_NO_THROW(parser.parse_line(create_list_ddl));
-    ASSERT_NO_THROW(parser.parse_line(create_db_list_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_list_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_db_list_ddl));
 
     // Negative test cases.
     const string negative_1 = R"(
@@ -718,9 +718,9 @@ CREATE table  t2(
   c2 int32
 )
 )";
-    ASSERT_THROW(parser.parse_line(negative_1), parsing_error);
-    ASSERT_THROW(parser.parse_line(negative_2), parsing_error);
-    ASSERT_THROW(parser.parse_line(negative_3), parsing_error);
+    ASSERT_THROW(parser.parse_string(negative_1), parsing_error);
+    ASSERT_THROW(parser.parse_string(negative_2), parsing_error);
+    ASSERT_THROW(parser.parse_string(negative_3), parsing_error);
 }
 
 TEST(catalog_ddl_parser_test, in_table_relationship)
@@ -759,8 +759,8 @@ create table patient (
 );
 )";
 
-    ASSERT_NO_THROW(parser.parse_line(one_to_many_ddl));
-    ASSERT_NO_THROW(parser.parse_line(hybrid_index_ddl));
+    ASSERT_NO_THROW(parser.parse_string(one_to_many_ddl));
+    ASSERT_NO_THROW(parser.parse_string(hybrid_index_ddl));
 }
 
 TEST(catalog_ddl_parser_test, invalid_create_list)
@@ -782,7 +782,7 @@ create table t2(c2 int32);
     for (const auto& ddl : ddls)
     {
         parser_t parser;
-        ASSERT_THROW(parser.parse_line(ddl), parsing_error);
+        ASSERT_THROW(parser.parse_string(ddl), parsing_error);
     }
 }
 
@@ -811,6 +811,6 @@ create table t2(c2 int32);
     for (const auto& ddl : ddls)
     {
         parser_t parser;
-        ASSERT_NO_THROW(parser.parse_line(ddl));
+        ASSERT_NO_THROW(parser.parse_string(ddl));
     }
 }

--- a/production/catalog/src/ddl_execution.cpp
+++ b/production/catalog/src/ddl_execution.cpp
@@ -6,6 +6,7 @@
 #include "gaia_internal/catalog/ddl_execution.hpp"
 
 #include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -436,7 +437,11 @@ void load_catalog(ddl::parser_t& parser, const std::string& ddl_filename)
         throw std::invalid_argument("Invalid DDL file: '" + std::string(file_path.c_str()) + "'.");
     }
 
-    parser.parse(file_path.string());
+    std::ifstream ddl_fstream(file_path, std::ifstream::in);
+    std::stringstream buffer;
+    buffer << ddl_fstream.rdbuf() << ";";
+
+    parser.parse_string(buffer.str());
     execute(parser.statements);
 }
 

--- a/production/catalog/tests/test_ddl_execution.cpp
+++ b/production/catalog/tests/test_ddl_execution.cpp
@@ -38,7 +38,7 @@ protected:
 TEST_F(ddl_execution_test, create_table_with_unique_constraints)
 {
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line("DROP TABLE IF EXISTS t; CREATE TABLE IF NOT EXISTS t(c INT32 UNIQUE);"));
+    ASSERT_NO_THROW(parser.parse_string("DROP TABLE IF EXISTS t; CREATE TABLE IF NOT EXISTS t(c INT32 UNIQUE);"));
     ASSERT_EQ(parser.statements.size(), 2);
     ASSERT_NO_THROW(execute(parser.statements));
 
@@ -70,7 +70,7 @@ CREATE RELATIONSHIP r1 (
 )";
 
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(ddl));
+    ASSERT_NO_THROW(parser.parse_string(ddl));
     ASSERT_NO_THROW(execute(parser.statements));
 
     gaia::direct_access::auto_transaction_t txn(false);
@@ -112,7 +112,7 @@ DROP TABLE IF EXISTS t2;
 )";
 
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(create_relationship_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_relationship_ddl));
     ASSERT_NO_THROW(execute(parser.statements));
 
     {
@@ -125,7 +125,7 @@ DROP TABLE IF EXISTS t2;
         ASSERT_EQ(gaia_relationship_t::list().where(gaia_relationship_expr::name == "r2").size(), 1);
     }
 
-    ASSERT_NO_THROW(parser.parse_line(drop_relationship_ddl));
+    ASSERT_NO_THROW(parser.parse_string(drop_relationship_ddl));
     ASSERT_NO_THROW(execute(parser.statements));
 
     {
@@ -138,7 +138,7 @@ DROP TABLE IF EXISTS t2;
         ASSERT_EQ(gaia_table_t::list().where(gaia_table_expr::name == "t2").size(), 0);
     }
 
-    ASSERT_NO_THROW(parser.parse_line("DROP RELATIONSHIP r3;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP RELATIONSHIP r3;"));
     ASSERT_THROW(execute(parser.statements), relationship_not_exists);
 }
 
@@ -153,7 +153,7 @@ CREATE INDEX IF NOT EXISTS c_i ON t(c);
 )";
 
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(create_index_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_index_ddl));
     ASSERT_NO_THROW(execute(parser.statements));
 
     {
@@ -169,7 +169,7 @@ CREATE INDEX IF NOT EXISTS c_i ON t(c);
             1);
     }
 
-    ASSERT_NO_THROW(parser.parse_line("DROP INDEX IF EXISTS c_i;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP INDEX IF EXISTS c_i;"));
     ASSERT_NO_THROW(execute(parser.statements));
 
     {
@@ -178,7 +178,7 @@ CREATE INDEX IF NOT EXISTS c_i ON t(c);
         ASSERT_EQ(gaia_index_t::list().where(gaia_index_expr::name == "c_i").size(), 0);
     }
 
-    ASSERT_NO_THROW(parser.parse_line("DROP INDEX c_i;"));
+    ASSERT_NO_THROW(parser.parse_string("DROP INDEX c_i;"));
     ASSERT_THROW(execute(parser.statements), index_not_exists);
 }
 
@@ -194,7 +194,7 @@ CREATE TABLE t1(c1 INT32)
 CREATE TABLE t2(c2 INT32);
 )";
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(create_list_ddl));
+    ASSERT_NO_THROW(parser.parse_string(create_list_ddl));
     ASSERT_NO_THROW(execute(parser.statements));
 }
 
@@ -341,7 +341,7 @@ drop database hospital;
     for (const auto& ddl : ddls)
     {
         ddl::parser_t parser;
-        ASSERT_NO_THROW(parser.parse_line(ddl));
+        ASSERT_NO_THROW(parser.parse_string(ddl));
         ASSERT_NO_THROW(execute(parser.statements));
     }
 }
@@ -366,7 +366,7 @@ create relationship r (d.t1.link2 -> t2, d.t2.link1 -> t1);
     for (const auto& ddl : ddls)
     {
         ddl::parser_t parser;
-        ASSERT_NO_THROW(parser.parse_line(ddl));
+        ASSERT_NO_THROW(parser.parse_string(ddl));
         ASSERT_THROW(execute(parser.statements), invalid_create_list);
     }
 }
@@ -379,7 +379,7 @@ create table t2(c2 int32, link2a references t1, link2b references t1);
 )"};
 
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(ddl));
+    ASSERT_NO_THROW(parser.parse_string(ddl));
     ASSERT_THROW(execute(parser.statements), ambiguous_reference_definition);
 }
 
@@ -391,6 +391,6 @@ create table t2(c2 int32, link2a references t1, link2b references t1);
 )"};
 
     ddl::parser_t parser;
-    ASSERT_NO_THROW(parser.parse_line(ddl));
+    ASSERT_NO_THROW(parser.parse_string(ddl));
     ASSERT_THROW(execute(parser.statements), orphaned_reference_definition);
 }

--- a/production/catalog/tests/test_gaiac_generation.cpp
+++ b/production/catalog/tests/test_gaiac_generation.cpp
@@ -46,7 +46,7 @@ TEST_F(gaia_generate_test, parse_ddl)
 {
     ddl::parser_t parser;
 
-    EXPECT_NO_THROW(parser.parse_line("create table tmp_airport ( name string );"));
+    EXPECT_NO_THROW(parser.parse_string("create table tmp_airport ( name string );"));
     create_database("tmp_airport");
     execute(parser.statements);
 

--- a/production/schemas/test/addr_book/addr_book.ddl
+++ b/production/schemas/test/addr_book/addr_book.ddl
@@ -49,4 +49,4 @@ table internet_contract (
 table customer (
     name string,
     sales_by_quarter int32[]
-);
+)

--- a/production/schemas/test/airport/airport.ddl
+++ b/production/schemas/test/airport/airport.ddl
@@ -3,18 +3,16 @@
 -- All rights reserved.
 ---------------------------------------------
 
-drop database if exists airport;
+database airport
 
-create database airport
-
-create table airport
+table airport
 (
     name string,
     city string,
     iata string
 )
 
-create table flight
+table flight
 (
     number int32 unique,
     miles_flown_by_quarter int32[],
@@ -23,7 +21,7 @@ create table flight
     return_passengers references passenger[]
 )
 
-create table segment
+table segment
 (
     miles int32,
     status int8,
@@ -32,7 +30,7 @@ create table segment
     trip references trip_segment
 )
 
-create table passenger (
+table passenger (
     name string,
     address string,
     return_flight_number int32,
@@ -41,20 +39,20 @@ create table passenger (
       where passenger.return_flight_number = flight.number
 )
 
-create relationship segments_from
+relationship segments_from
 (
     airport.segments_from -> segment[],
     segment.src -> airport
 )
 
-create relationship segments_to
+relationship segments_to
 (
     airport.segments_to -> segment[],
     segment.dst -> airport
 )
 
-create table trip_segment
+table trip_segment
 (
     who string,
     segment references segment
-);
+)

--- a/production/schemas/test/incubator/incubator.ddl
+++ b/production/schemas/test/incubator/incubator.ddl
@@ -3,11 +3,9 @@
 -- All rights reserved.
 ---------------------------------------------
 
-DROP DATABASE IF EXISTS barn_storage;
+DATABASE barn_storage
 
-CREATE DATABASE barn_storage
-
-CREATE TABLE incubator (
+TABLE incubator (
       name	 STRING,
       min_temp FLOAT,
       max_temp FLOAT,
@@ -15,16 +13,16 @@ CREATE TABLE incubator (
       actuators REFERENCES actuator[]
 )
 
-CREATE TABLE sensor (
+TABLE sensor (
       name STRING,
       timestamp UINT64,
       value FLOAT active,
       incubator REFERENCES incubator
 )
 
-CREATE TABLE actuator (
+TABLE actuator (
       name STRING,
       timestamp UINT64,
       value FLOAT,
       incubator REFERENCES incubator
-);
+)

--- a/production/schemas/test/prerequisites/prerequisites.ddl
+++ b/production/schemas/test/prerequisites/prerequisites.ddl
@@ -3,11 +3,9 @@
 -- All rights reserved.
 ---------------------------------------------
 
-drop database if exists prerequisites;
+database prerequisites
 
-create database prerequisites
-
-create table student (
+table student (
     student_id string,
     surname string,
     age int32,
@@ -17,46 +15,46 @@ create table student (
     registrations references registration[]
 )
 
-create table parents (
+table parents (
     name_father string,
     name_mother string,
     student references student
 )
 
-create table course (
+table course (
     course_id string,
     name string,
     hours int32
 )
 
-create table registration (
+table registration (
     reg_id string,
     status string,
     grade string,
     registered_student references student
 )
 
-create relationship course_reg (
+relationship course_reg (
     course.registrations -> registration[],
     registration.registered_course -> course
 )
 
-create table prereq (
+table prereq (
     prereq_id string,
     min_grade string
 )
 
-create relationship prereq_course (
+relationship prereq_course (
     course.required_by -> prereq[],
     prereq.prereq -> course
 )
 
-create relationship course_prereq (
+relationship course_prereq (
     course.requires -> prereq[],
     prereq.course -> course
 )
 
-create table if not exists enrollment_log (
+table enrollment_log (
     log_student_id string,
     log_surname string,
     log_age int32,
@@ -64,4 +62,4 @@ create table if not exists enrollment_log (
     log_name string,
     log_hours int32,
     log_reg_id string
-);
+)


### PR DESCRIPTION
Make the last semicolon in a DDL file optional so users do not need to enter a semicolon at all in simple form DDL use cases. 