### PR TITLE
Add missing clones to gaia_ptr

### DIFF
--- a/production/inc/gaia_internal/db/gaia_ptr.hpp
+++ b/production/inc/gaia_internal/db/gaia_ptr.hpp
@@ -160,8 +160,6 @@ public:
     bool update_parent_reference(common::gaia_id_t new_parent_id, common::reference_offset_t parent_offset);
 
 protected:
-    gaia_ptr_t(gaia_locator_t locator, memory_manager::address_offset_t offset);
-
     void allocate(size_t size);
 
     inline bool is(common::gaia_type_t type) const;


### PR DESCRIPTION
After implementing memory poisoning in my memory management branch, I found 2 cases where object versions were updated in place without a copy-on-write (making the updates non-transactionally visible to txns with references to those versions). I also removed an error-prone gaia_ptr constructor that was used in only 1 place.