### PR TITLE
Fix Postgres header inclusion to allow using fprintf

### DIFF
--- a/production/sql/inc/gaia_fdw_adapter.hpp
+++ b/production/sql/inc/gaia_fdw_adapter.hpp
@@ -5,8 +5,13 @@
 
 #pragma once
 
-#include <string>
-#include <unordered_map>
+/*
+ * PostgresSQL "port.h" tries to replace printf() and friends with macros to
+ * their own versions. This leads to build error in other headers like spdlog.
+ */
+#ifdef fprintf
+#undef fprintf
+#endif
 
 // All Postgres headers and function declarations must have C linkage.
 extern "C"
@@ -23,6 +28,11 @@ extern "C"
 #include "utils/lsyscache.h"
 
 } // extern "C"
+
+#define fprintf fprintf
+
+#include <string>
+#include <unordered_map>
 
 #include "gaia/common.hpp"
 

--- a/production/sql/src/gaia_fdw_adapter.cpp
+++ b/production/sql/src/gaia_fdw_adapter.cpp
@@ -5,14 +5,6 @@
 
 #include "gaia_fdw_adapter.hpp"
 
-/*
- * PostgresSQL "port.h" tries to replace printf() and friends with macros to
- * their own versions. This leads to build error in other headers like spdlog.
- */
-#ifdef fprintf
-#undef fprintf
-#endif
-
 #include <sstream>
 
 #include "gaia_internal/catalog/catalog.hpp"


### PR DESCRIPTION
I was trying to use `fmt::format()` in my code and that turned out to be impossible because the Postgres headers redefine `fprintf()` via a macro, and `fmt` uses `fprintf()` internally. This change simply redefines `fprintf()` after all the Postgres headers have been included.