### PR TITLE
Fix gaiac code generation for empty database

### DIFF
--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -287,7 +287,7 @@ function(add_gaia_sdk_gtest)
       -I ${FLATBUFFERS_INC}
       -I ${GAIA_SPDLOG_INC}
       -I ${EDC_INCLUDE}
-      -I /usr/lib/clang/12.0.1/include
+      -I /usr/include/clang/10/include/
       -std=c++${CMAKE_CXX_STANDARD}
     COMMAND pkill -f -KILL gaia_db_server &
 

--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -119,7 +119,7 @@ target_link_libraries(rocks_wrapper PUBLIC rocksdb gaia_storage)
 # Choose static version of the library.
 message(CHECK_START "Looking for liburing")
 find_path(LIBURING_INCLUDE_DIR NAMES liburing.h)
-find_library(LIBURING_LIBRARY NAMES liburing.so)
+find_library(LIBURING_LIBRARY NAMES liburing.a)
 if (LIBURING_LIBRARY)
   message(CHECK_PASS "found")
 else()

--- a/third_party/production/flatbuffers/tests/arrays_test_generated.h
+++ b/third_party/production/flatbuffers/tests/arrays_test_generated.h
@@ -153,7 +153,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) ArrayStruct FLATBUFFERS_FINAL_CLASS {
         padding3__(0) {
     std::memset(b_, 0, sizeof(b_));
     (void)padding0__;    (void)padding1__;    (void)padding2__;
-    std::memset(static_cast<void *>(d_), 0, sizeof(d_));
+    std::memset(d_, 0, sizeof(d_));
     (void)padding3__;
     std::memset(f_, 0, sizeof(f_));
   }

--- a/third_party/production/rocksdb/util/channel.h
+++ b/third_party/production/rocksdb/util/channel.h
@@ -31,7 +31,7 @@ class channel {
     return buffer_.empty() && eof_;
   }
 
-  size_t size() {
+  size_t size() const {
     std::lock_guard<std::mutex> lk(lock_);
     return buffer_.size();
   }


### PR DESCRIPTION
Fix the following issue. `gaiac` will throw when trying to generate code for the empty database.

https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1237