### PR TITLE
Fix relationship cardinality definition

### DIFF
--- a/production/catalog/parser/src/parser.yy
+++ b/production/catalog/parser/src/parser.yy
@@ -404,7 +404,7 @@ link_def:
       $$.name = $3;
       $$.to_database = $5.first;
       $$.to_table = $5.second;
-      $$.cardinality = $6 ? cardinality_t::one : cardinality_t::many;
+      $$.cardinality = ($6 == 1) ? cardinality_t::one : cardinality_t::many;
   }
 | IDENTIFIER "." IDENTIFIER "." IDENTIFIER "->" composite_name opt_array {
       $$.from_database = $1;
@@ -412,7 +412,7 @@ link_def:
       $$.name = $5;
       $$.to_database = $7.first;
       $$.to_table = $7.second;
-      $$.cardinality = $8 ? cardinality_t::one : cardinality_t::many;
+      $$.cardinality = ($8 == 1) ? cardinality_t::one : cardinality_t::many;
   }
 ;
 

--- a/production/catalog/src/ddl_execution.cpp
+++ b/production/catalog/src/ddl_execution.cpp
@@ -226,16 +226,10 @@ void convert_references_to_relationships(
 
             check_reference_field_maps(matching_ref->field_map, ref->field_map, ref->table, matching_ref->table);
 
-            // Use the [link1]_[link2] as the relationship name.
+            // Use the [link1]_[link2] as the relationship name. For 1:N
+            // relationships, always place many side first.
             //
             // TODO: Detect name conflict. [GATAPLAT-306]
-            //
-            // For 1:N relationships, always place many side first (including
-            // link placement) before the proper support of one-to-many
-            // relationship definition is ready.
-            //
-            // TODO: Update the code after we can support placing one side link
-            //       before many side link in `create relationship` statements.
             //
             std::string rel_name
                 = (ref->cardinality == relationship_cardinality_t::many
@@ -248,10 +242,7 @@ void convert_references_to_relationships(
                 "", create_table->name, ref->name, "", ref->table, ref->cardinality};
             ddl::link_def_t matching_ref_link{
                 "", ref->table, matching_ref->name, "", matching_ref->table, matching_ref->cardinality};
-            relationships.back()->relationship
-                = (ref->cardinality == relationship_cardinality_t::many
-                       ? std::make_pair(ref_link, matching_ref_link)
-                       : std::make_pair(matching_ref_link, ref_link));
+            relationships.back()->relationship = std::make_pair(matching_ref_link, ref_link);
 
             relationships.back()->has_if_not_exists = false;
 

--- a/production/schemas/test/airport/airport.ddl
+++ b/production/schemas/test/airport/airport.ddl
@@ -47,8 +47,8 @@ relationship segments_from
 
 relationship segments_to
 (
-    airport.segments_to -> segment[],
-    segment.dst -> airport
+    segment.dst -> airport,
+    airport.segments_to -> segment[]
 )
 
 table trip_segment


### PR DESCRIPTION
Previously, the first link defines the cardinality, as well as parent and child side in a relationship.

With this change, if either of the two links has an array indicator, we will mark the relationship cardinality as many, and the one-side will always be the parent in a 1:N relationship, .

In the 1:1 relationship, the first link still defines the parent and child. 
