### PR TITLE
[GAIAPLAT-1249] Add missing dependencies to gaia_db_server

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -86,7 +86,14 @@ add_library(gaia_db_client STATIC
   src/db_server_instance.cpp
   src/index_builder.cpp)
 
-add_dependencies(gaia_db_client "messages.fbs" "gaia_table.fbs" "gaia_field.fbs" "gaia_relationship.fbs" "gaia_index.fbs" "gaia_db_server")
+add_dependencies(gaia_db_client
+  "gaia_db_server"
+  "gaia_field.fbs"
+  "gaia_index.fbs"
+  "gaia_relationship.fbs"
+  "gaia_table.fbs"
+  "messages.fbs"
+)
 target_link_libraries(gaia_db_client PUBLIC gaia_build_options)
 target_include_directories(gaia_db_client PUBLIC ${GAIA_DB_CORE_PUBLIC_INCLUDES})
 target_include_directories(gaia_db_client PRIVATE ${GAIA_DB_CORE_PRIVATE_INCLUDES})
@@ -155,7 +162,13 @@ set(GAIA_DB_SERVER_SOURCES
   src/type_id_mapping.cpp)
 
 add_executable(gaia_db_server ${GAIA_DB_SERVER_SOURCES})
-add_dependencies(gaia_db_server "messages.fbs" "gaia_table.fbs" "gaia_field.fbs" "gaia_relationship.fbs" "gaia_index.fbs")
+add_dependencies(gaia_db_server
+  "gaia_field.fbs"
+  "gaia_index.fbs"
+  "gaia_relationship.fbs"
+  "gaia_table.fbs"
+  "messages.fbs"
+)
 target_link_libraries(gaia_db_server PUBLIC gaia_build_options)
 target_include_directories(gaia_db_server PRIVATE
   "${GAIA_DB_CORE_PUBLIC_INCLUDES}"
@@ -166,7 +179,18 @@ target_include_directories(gaia_db_server SYSTEM PRIVATE "${FLATBUFFERS_INC}")
 target_include_directories(gaia_db_server SYSTEM PRIVATE "${GEN_DIR}")
 
 # Suppress spurious warnings about zero-initialized structs.
-target_link_libraries(gaia_db_server PRIVATE gaia_common Threads::Threads rocks_wrapper gaia_db_persistence gaia_memory_manager gaia_index ${LIB_EXPLAIN} ${LIB_CAP} dl)
+target_link_libraries(gaia_db_server
+  PRIVATE
+    ${LIB_CAP}
+    ${LIB_EXPLAIN}
+    Threads::Threads
+    dl
+    gaia_common
+    gaia_db_persistence
+    gaia_index
+    gaia_memory_manager
+    rocks_wrapper
+)
 if(ENABLE_STACKTRACE)
   target_link_libraries(gaia_db_server PRIVATE gaia_stack_trace)
 endif()


### PR DESCRIPTION
When attempting to build on a non-supported platform (Ubuntu 20.10), I kept getting errors related to missing files which should have been generated by `flatc` for the target `gaia_db_server`. While these errors may not appear on the target platform (though I don't know why they wouldn't), this target should depend on these files being generated anyway since it expects them to exist.