### PR TITLE
New/rearranged tests for warnings & translation correctness.

### DIFF
--- a/production/tools/tests/gaiat/break_continue_test03.ruleset
+++ b/production/tools/tests/gaiat/break_continue_test03.ruleset
@@ -13,3 +13,4 @@ ruleset test03
 }
 
 // CHECK: 'break' statement not in loop or switch statement
+// GAIAPLAT-1067 (fixed)

--- a/production/tools/tests/gaiat/break_continue_test16.ruleset
+++ b/production/tools/tests/gaiat/break_continue_test16.ruleset
@@ -1,0 +1,35 @@
+// RUN: %gaiat %s -- 2>&1| FileCheck  %s
+
+// TESTCASE: break within declarative for
+ruleset test3
+{
+    on_update(incubator)
+    {
+        for (S:sensor)
+        {
+            if (S.value > 99.0)
+            {
+                break;
+            }
+        }
+    }
+}
+
+// TESTCASE: continue within declarative for
+ruleset test4
+{
+    on_update(incubator)
+    {
+        for (S:sensor)
+        {
+            if (S.value > 99.0)
+            {
+                continue;
+            }
+        }
+    }
+}
+
+// CHECK: Use of non declarative break in declarative statements may lead to unexpected results
+// CHECK: Use of non declarative continue in declarative statements may lead to unexpected results
+// GAIAPLAT-1083 (fixed)

--- a/production/tools/tests/gaiat/break_continue_tests.ruleset
+++ b/production/tools/tests/gaiat/break_continue_tests.ruleset
@@ -1,37 +1,5 @@
 // RUN: %gaiat %s --
 
-#include "tags_test.h"
-
-// TESTCASE: break within declarative for
-ruleset test3
-{
-    on_update(incubator)
-    {
-        for (S:sensor)
-        {
-            if (S.value > 99.0)
-            {
-                break;
-            }
-        }
-    }
-}
-
-// TESTCASE: continue within declarative for
-ruleset test4
-{
-    on_update(incubator)
-    {
-        for (S:sensor)
-        {
-            if (S.value > 99.0)
-            {
-                continue;
-            }
-        }
-    }
-}
-
 // TESTCASE: break from multiple outer loops from implicit query
 // GAIAPLAT-1073 (won't do)
 ruleset test5

--- a/production/tools/tests/gaiat/statements_tests.ruleset
+++ b/production/tools/tests/gaiat/statements_tests.ruleset
@@ -1023,3 +1023,18 @@ ruleset test65
         while (farmer->yield.bushels < 10);
     }
 }
+
+void printf(const char*, ...);
+
+// check for meta-rule 2 compliance
+// GAIAPLAT-1252
+ruleset test66
+{
+    on_update(incubator.min_temp)
+    {
+        if (actuator.value > 50.0)
+        {
+            printf("%s, %ul\n", actuator.name, actuator.timestamp);
+        }
+    }
+}


### PR DESCRIPTION
Verify that new warning messages are produced (GAIAPLAT-1083) and that a meta-rule 2 rule gets translated correctly.

The new ruleset test66 in statements_tests.ruleset can be translated for visual review of correct translation (GAIAPLAT-1252).