### PR TITLE
Remove clone to work around regression

### DIFF
--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -218,7 +218,9 @@ bool gaia_ptr_t::remove_child_reference(gaia_id_t child_id, reference_offset_t f
         {
             // Non-first child in the linked list, update the previous child.
             auto prev_ptr = gaia_ptr_t::open(prev_child);
-            prev_ptr.clone_no_txn();
+            // REVIEW: We need to clone prev_ptr before modifying its references,
+            // but the original fix that did this caused a test regression:
+            // https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1279
             prev_ptr.references()[relationship->next_child_offset]
                 = curr_ptr.references()[relationship->next_child_offset];
         }


### PR DESCRIPTION
https://github.com/gaia-platform/GaiaPlatform/pull/888 introduced a regression that I suspect was caused by a bug masked by the missing clone, but I'm reverting one of the clones added by that PR to unblock failing tests. The issue is tracked in https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1279.