### PR TITLE
Make allocation size handling consistent

### DIFF
--- a/production/db/core/inc/db_object_helpers.hpp
+++ b/production/db/core/inc/db_object_helpers.hpp
@@ -32,7 +32,7 @@ inline db_object_t* create_object(
     size_t total_len = obj_data_size + ref_len;
     gaia::db::hash_node_t* hash_node = db_hash_map::insert(id);
     hash_node->locator = allocate_locator();
-    allocate_object(hash_node->locator, total_len + c_db_object_header_size);
+    allocate_object(hash_node->locator, total_len);
     db_object_t* obj_ptr = locator_to_ptr(hash_node->locator);
     obj_ptr->id = id;
     obj_ptr->type = type;
@@ -53,7 +53,7 @@ inline db_object_t* create_object(
 {
     gaia::db::hash_node_t* hash_node = db_hash_map::insert(id);
     hash_node->locator = allocate_locator();
-    gaia::db::allocate_object(hash_node->locator, obj_data_size + c_db_object_header_size);
+    gaia::db::allocate_object(hash_node->locator, obj_data_size);
     db_object_t* obj_ptr = locator_to_ptr(hash_node->locator);
     obj_ptr->id = id;
     obj_ptr->type = type;

--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -505,9 +505,7 @@ address_offset_t client_t::allocate_object(
     gaia_locator_t locator,
     size_t size)
 {
-    ASSERT_PRECONDITION(size != 0, "Size passed to client_t::allocate_object() should not be 0!");
-
-    address_offset_t object_offset = s_chunk_manager.allocate(size);
+    address_offset_t object_offset = s_chunk_manager.allocate(size + c_db_object_header_size);
     if (object_offset == c_invalid_address_offset)
     {
         // We ran out of memory in the current chunk. Allocate a new one!

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -773,9 +773,7 @@ address_offset_t server_t::allocate_object(
     gaia_locator_t locator,
     size_t size)
 {
-    ASSERT_PRECONDITION(size != 0, "Size passed to server_t::allocate_object() should not be 0!");
-
-    address_offset_t object_offset = s_chunk_manager.allocate(size);
+    address_offset_t object_offset = s_chunk_manager.allocate(size + c_db_object_header_size);
     if (object_offset == c_invalid_address_offset)
     {
         // We ran out of memory in the current chunk.

--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -360,10 +360,9 @@ gaia_ptr_t gaia_ptr_t::create(gaia_id_t id, gaia_type_t type, reference_offset_t
     //  the db_object_t should either be initialized before and passed in
     //  or it should be initialized inside the constructor.
     hash_node_t* hash_node = db_hash_map::insert(id);
-    size_t object_size = total_payload_size + c_db_object_header_size;
     gaia_locator_t locator = allocate_locator();
     hash_node->locator = locator;
-    client_t::allocate_object(locator, object_size);
+    client_t::allocate_object(locator, total_payload_size);
     gaia_ptr_t obj(locator);
     db_object_t* obj_ptr = obj.to_ptr();
     obj_ptr->id = id;
@@ -416,10 +415,11 @@ void gaia_ptr_t::remove(gaia_ptr_t& node)
 void gaia_ptr_t::clone_no_txn()
 {
     db_object_t* old_this = to_ptr();
-    size_t new_size = c_db_object_header_size + old_this->payload_size;
-    client_t::allocate_object(m_locator, new_size);
+    size_t total_payload_size = old_this->payload_size;
+    size_t total_object_size = c_db_object_header_size + total_payload_size;
+    client_t::allocate_object(m_locator, total_payload_size);
     db_object_t* new_this = to_ptr();
-    memcpy(new_this, old_this, new_size);
+    memcpy(new_this, old_this, total_object_size);
 }
 
 gaia_ptr_t& gaia_ptr_t::clone()
@@ -555,7 +555,7 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
     }
 
     // Updates m_locator to point to the new object.
-    client_t::allocate_object(m_locator, c_db_object_header_size + total_payload_size);
+    client_t::allocate_object(m_locator, total_payload_size);
 
     db_object_t* new_this = to_ptr();
 

--- a/production/db/memory_manager/src/chunk_manager.cpp
+++ b/production/db/memory_manager/src/chunk_manager.cpp
@@ -90,6 +90,8 @@ void chunk_manager_t::initialize_internal(
 address_offset_t chunk_manager_t::allocate(
     size_t memory_size)
 {
+    ASSERT_PRECONDITION(memory_size != 0, "Size passed to chunk_manager_t::allocate() should not be 0!");
+
     validate_metadata(m_metadata);
 
     // Adjust the requested memory size, to ensure proper alignment.


### PR DESCRIPTION
The existing code is inconsistent in the sizes it passes to `client_t::allocate_object()` and `server_t::allocate_object()`: sometimes it passes only the payload size (i.e., references array size + serialized flatbuffer size), and sometimes the entire object size (i.e., object header size + payload size). The correct contract is that `allocate_object()` accepts just the payload size (because it knows the object format, so the header size is implicit), while `chunk_manager_t::allocate()` accepts the full object size (because it doesn't know the object format; it only allocates bytes). I had to remove an assert from both versions of `allocate_object()` that assumed that object payloads were never zero-size, since there are existing tests that create zero-size objects (and only worked because the contract was being violated). I moved this assert to `chunk_manager_t::allocate()`, since we don't have any use cases for zero-size byte allocations, and I doubt we ever will.

Eventually it would be nice to deduplicate the two identical versions of `allocate_object()`, but that will have to wait for a later PR.