### PR TITLE
Fix target_name in process_schema

### DIFF
--- a/production/cmake/gaia.cmake
+++ b/production/cmake/gaia.cmake
@@ -144,9 +144,8 @@ function(process_schema)
     get_filename_component(DDL_NAME ${ARG_DDL_FILE} NAME)
     string(REPLACE ".ddl" "" DDL_NAME ${DDL_NAME})
     set(ARG_DATABASE_NAME ${DDL_NAME})
-    message(STATUS "DATABASE_NAME not specified, using: ${ARG_DATABASE_NAME}.")
     set(ARG_TARGET_NAME "generate_${DDL_NAME}_direct_access")
-    message(STATUS "TARGET_NAME not specified, using default value: ${ARG_TARGET_NAME}.")
+    message(STATUS "TARGET_NAME not specified, using value: ${ARG_TARGET_NAME}.")
   endif()
 
   add_custom_target(${ARG_TARGET_NAME} ALL


### PR DESCRIPTION
The `TARGET_NAME` is not in the cmake `process_schema()` named argument list so it cannot be set before. In the code document, we do state it can be set. This change makes the `TARGET_NAME` an argument that can be set by users. In case nothing is set, we will use the name inferred from the `DDL_FILE` as before.