### PR TITLE
Eagerly close cursor socket on generator exhaustion

### DIFF
--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -136,7 +136,9 @@ client_t::get_stream_generator_for_socket(std::shared_ptr<int> stream_socket_ptr
 
             if (datagram_size == 0)
             {
-                // We received EOF from the server, so tell the caller to stop iteration.
+                // We received EOF from the server, so close the socket and tell
+                // the caller to stop iteration.
+                common::close_fd(*stream_socket_ptr);
                 return std::nullopt;
             }
 


### PR DESCRIPTION
I realized after merging https://github.com/gaia-platform/GaiaPlatform/pull/917 that an invariant had been broken: we assert at the beginning of each call to the generator wrapped by the iterator that the generator's cursor socket hasn't already been closed. The intention of this assert was to ensure that the client didn't misuse the API by continuing to call into the generator after it returned `std::nullopt` (because the server called `shutdown(SHUT_WR)` on the socket). I had removed the socket close on EOF because it's not strictly necessary, since the iterator should be destroyed immediately anyway after it is fully consumed, and I wanted to have only one codepath that closed the socket. But this invariant seems worth preserving, and verifying that the generator isn't called again after returning `std::nullopt`, without checking the socket, would require introducing additional state just for this assert, which seems silly.