### PR TITLE
Show a different prompt when expecting more input

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -69,7 +69,7 @@ void start_repl(parser_t& parser)
     initialize_catalog();
 
     const auto prompt = "gaiac> ";
-    const auto wait_for_more_prompt = "... gaiac> ";
+    const auto wait_for_more_prompt = "> ";
     const auto exit_command = "exit";
 
     string ddl_buffer;


### PR DESCRIPTION
Add `...` before the standard gaiac prompt when we expecting more input from the user. This should make it less confusing as people might think the input was executed silently without given any error.