### PR TITLE
[GAIAPLAT-1386] Make EDC and declarative method names consistent

### DIFF
--- a/production/catalog/src/edc_generator.cpp
+++ b/production/catalog/src/edc_generator.cpp
@@ -331,7 +331,7 @@ std::string class_writer_t::generate_public_constructor()
 std::string class_writer_t::generate_insert()
 {
     flatbuffers::CodeWriter code = create_code_writer();
-    code += "static gaia::common::gaia_id_t insert_row(\\";
+    code += "static gaia::common::gaia_id_t insert(\\";
     code += generate_method_params(m_table.fields()) + "\\";
     code += ");";
     return code.ToString();
@@ -340,7 +340,7 @@ std::string class_writer_t::generate_insert()
 std::string class_writer_t::generate_insert_cpp()
 {
     flatbuffers::CodeWriter code = create_code_writer();
-    code += "gaia::common::gaia_id_t {{TABLE_NAME}}_t::insert_row(\\";
+    code += "gaia::common::gaia_id_t {{TABLE_NAME}}_t::insert(\\";
     code += generate_method_params(m_table.fields()) + "\\";
     code += ") {";
     code.IncrementIdentLevel();
@@ -359,7 +359,7 @@ std::string class_writer_t::generate_insert_cpp()
         code += field.field_name() + "\\";
     }
     code += "));";
-    code += "return edc_object_t::insert_row(b);";
+    code += "return edc_object_t::insert(b);";
     code.DecrementIdentLevel();
     code += "}";
     return code.ToString();

--- a/production/catalog/src/gaia_catalog.cpp
+++ b/production/catalog/src/gaia_catalog.cpp
@@ -19,10 +19,10 @@ const char* gaia_index_t::gaia_typename() {
     static const char* gaia_typename = "gaia_index_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_index_t::insert_row(const char* name, bool unique, uint8_t type, const std::vector<uint64_t>& fields) {
+gaia::common::gaia_id_t gaia_index_t::insert(const char* name, bool unique, uint8_t type, const std::vector<uint64_t>& fields) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_indexDirect(b, name, unique, type, &fields));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_index, gaia_index_t> gaia_index_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_index, gaia_index_t>();
@@ -50,10 +50,10 @@ const char* gaia_rule_t::gaia_typename() {
     static const char* gaia_typename = "gaia_rule_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_rule_t::insert_row(const char* name) {
+gaia::common::gaia_id_t gaia_rule_t::insert(const char* name) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_ruleDirect(b, name));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_rule, gaia_rule_t> gaia_rule_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_rule, gaia_rule_t>();
@@ -72,10 +72,10 @@ const char* gaia_ruleset_t::gaia_typename() {
     static const char* gaia_typename = "gaia_ruleset_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_ruleset_t::insert_row(const char* name, bool active_on_startup, const std::vector<uint64_t>& table_ids, const char* source_location, const char* serial_stream) {
+gaia::common::gaia_id_t gaia_ruleset_t::insert(const char* name, bool active_on_startup, const std::vector<uint64_t>& table_ids, const char* source_location, const char* serial_stream) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_rulesetDirect(b, name, active_on_startup, &table_ids, source_location, serial_stream));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t> gaia_ruleset_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t>();
@@ -106,10 +106,10 @@ const char* gaia_relationship_t::gaia_typename() {
     static const char* gaia_typename = "gaia_relationship_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_relationship_t::insert_row(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions) {
+gaia::common::gaia_id_t gaia_relationship_t::insert(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_relationshipDirect(b, name, to_parent_link_name, to_child_link_name, cardinality, parent_required, deprecated, first_child_offset, next_child_offset, parent_offset, &parent_field_positions, &child_field_positions));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> gaia_relationship_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t>();
@@ -161,10 +161,10 @@ const char* gaia_field_t::gaia_typename() {
     static const char* gaia_typename = "gaia_field_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_field_t::insert_row(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique) {
+gaia::common::gaia_id_t gaia_field_t::insert(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_fieldDirect(b, name, type, repeated_count, position, deprecated, active, unique));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_field, gaia_field_t> gaia_field_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_field, gaia_field_t>();
@@ -201,10 +201,10 @@ const char* gaia_table_t::gaia_typename() {
     static const char* gaia_typename = "gaia_table_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_table_t::insert_row(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template) {
+gaia::common::gaia_id_t gaia_table_t::insert(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_tableDirect(b, name, type, is_system, &binary_schema, &serialization_template));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_table, gaia_table_t> gaia_table_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_table, gaia_table_t>();
@@ -247,10 +247,10 @@ const char* gaia_database_t::gaia_typename() {
     static const char* gaia_typename = "gaia_database_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_database_t::insert_row(const char* name) {
+gaia::common::gaia_id_t gaia_database_t::insert(const char* name) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
     b.Finish(internal::Creategaia_databaseDirect(b, name));
-    return edc_object_t::insert_row(b);
+    return edc_object_t::insert(b);
 }
 gaia::direct_access::edc_container_t<c_gaia_type_gaia_database, gaia_database_t> gaia_database_t::list() {
     return gaia::direct_access::edc_container_t<c_gaia_type_gaia_database, gaia_database_t>();

--- a/production/catalog/tests/test_gaiac_generation.cpp
+++ b/production/catalog/tests/test_gaiac_generation.cpp
@@ -38,7 +38,7 @@ TEST_F(gaia_generate_test, use_create_table)
     EXPECT_NE(0, header_str.find("class airport_t"));
 
     auto cpp_str = generate_edc_cpp("airport_test", "gaia_airport.h");
-    EXPECT_NE(0, header_str.find("trip_segment_t::insert_row"));
+    EXPECT_NE(0, header_str.find("trip_segment_t::insert"));
 }
 
 // Start from Gaia DDL to create an EDC header.
@@ -54,7 +54,7 @@ TEST_F(gaia_generate_test, parse_ddl)
     EXPECT_NE(0, header_str.find("class tmp_airport"));
 
     auto cpp_str = generate_edc_cpp(c_empty_db_name, "gaia_airport.h");
-    EXPECT_NE(0, header_str.find("tmp_airport::insert_row"));
+    EXPECT_NE(0, header_str.find("tmp_airport::insert"));
 }
 
 TEST_F(gaia_generate_test, airport_example)
@@ -64,13 +64,13 @@ TEST_F(gaia_generate_test, airport_example)
     // flies from Denver to Chicago. A segment 888 miles long, no status, no
     // miles flown.
     const int32_t c_miles1 = 888;
-    auto segment_1 = segment_t::get(segment_t::insert_row(c_miles1, 0, 0));
+    auto segment_1 = segment_t::get(segment_t::insert(c_miles1, 0, 0));
 
     // An airport.
     auto airport_1 = airport_t::get(
-        airport_t::insert_row("Denver International", "Denver", "DEN"));
+        airport_t::insert("Denver International", "Denver", "DEN"));
     auto airport_2 = airport_t::get(
-        airport_t::insert_row("Chicago O'Hare International", "Chicago", "ORD"));
+        airport_t::insert("Chicago O'Hare International", "Chicago", "ORD"));
 
     // Connect the segment to the source and destination airports.
     airport_1.segments_from().insert(segment_1);
@@ -80,15 +80,15 @@ TEST_F(gaia_generate_test, airport_example)
     begin_transaction();
     // A 606 mile segment.
     const int c_miles2 = 606;
-    auto segment_2 = segment_t::get(segment_t::insert_row(c_miles2, 0, 0));
+    auto segment_2 = segment_t::get(segment_t::insert(c_miles2, 0, 0));
     auto airport_3 = airport_t::get(
-        airport_t::insert_row("Atlanta International", "Atlanta", "ATL"));
+        airport_t::insert("Atlanta International", "Atlanta", "ATL"));
     airport_2.segments_from().insert(segment_2);
     airport_3.segments_to().insert(segment_2);
 
     // Create the flight #58 that spans two segments.
     const int c_flight = 58;
-    auto flight_1 = flight_t::get(flight_t::insert_row(c_flight, {0}));
+    auto flight_1 = flight_t::get(flight_t::insert(c_flight, {0}));
     // Insert both segments to the flight's list of segments.
     flight_1.segments().insert(segment_1);
     flight_1.segments().insert(segment_2);

--- a/production/common/tests/test_multi_process.cpp
+++ b/production/common/tests/test_multi_process.cpp
@@ -36,7 +36,7 @@ using namespace gaia::addr_book;
 employee_t insert_employee(employee_writer& writer, const char* name_first)
 {
     writer.name_first = name_first;
-    return employee_t::get(writer.insert_row());
+    return employee_t::get(writer.insert());
 }
 
 // Utility function that creates one address row provided the writer.
@@ -44,7 +44,7 @@ address_t insert_address(address_writer& writer, const char* street, const char*
 {
     writer.street = street;
     writer.city = city;
-    return address_t::get(writer.insert_row());
+    return address_t::get(writer.insert());
 }
 
 // Utility function that creates one named employee row.
@@ -52,7 +52,7 @@ employee_t create_employee(const char* name)
 {
     auto w = employee_writer();
     w.name_first = name;
-    gaia_id_t id = w.insert_row();
+    gaia_id_t id = w.insert();
     auto e = employee_t::get(id);
     EXPECT_STREQ(e.name_first(), name);
     return e;

--- a/production/db/core/tests/test_multiple_server_instances.cpp
+++ b/production/db/core/tests/test_multiple_server_instances.cpp
@@ -74,7 +74,7 @@ public:
             employee_writer ew;
             ew.name_first = std::string("name_") + std::to_string(i);
             ew.name_last = std::string("surname_") + std::to_string(i);
-            ew.insert_row();
+            ew.insert();
         }
 
         commit_transaction();

--- a/production/db/index/tests/test_index.cpp
+++ b/production/db/index/tests/test_index.cpp
@@ -281,8 +281,8 @@ TEST_F(index_test, unique_constraint_same_txn)
     const int32_t flight_number = 1766;
 
     auto_transaction_t txn;
-    flight_t::insert_row(flight_number, {});
-    flight_t::insert_row(flight_number, {});
+    flight_t::insert(flight_number, {});
+    flight_t::insert(flight_number, {});
     EXPECT_THROW(txn.commit(), unique_constraint_violation);
 }
 
@@ -291,11 +291,11 @@ TEST_F(index_test, unique_constraint_different_txn)
     const int32_t flight_number = 1766;
 
     auto_transaction_t txn;
-    flight_t::insert_row(flight_number, {});
+    flight_t::insert(flight_number, {});
     txn.commit();
 
     // Attempt to re-insert the same key - we should trigger the conflict.
-    flight_t::insert_row(flight_number, {});
+    flight_t::insert(flight_number, {});
     EXPECT_THROW(txn.commit(), unique_constraint_violation);
 }
 
@@ -305,13 +305,13 @@ TEST_F(index_test, unique_constraint_rollback_transaction)
     const int32_t second_flight_number = 1767;
 
     auto_transaction_t txn;
-    flight_t::insert_row(first_flight_number, {});
+    flight_t::insert(first_flight_number, {});
     txn.commit();
 
     // Insert a second key and then attempt to re-insert the first key.
     // We should trigger the conflict and our transactions should be rolled back.
-    flight_t::insert_row(second_flight_number, {});
-    flight_t::insert_row(first_flight_number, {});
+    flight_t::insert(second_flight_number, {});
+    flight_t::insert(first_flight_number, {});
     EXPECT_THROW(txn.commit(), unique_constraint_violation);
 
     // Attempt to insert the second key again.
@@ -319,6 +319,6 @@ TEST_F(index_test, unique_constraint_rollback_transaction)
     // We need to manually start a transaction because the exception generated earlier
     // prevented the automatic restart.
     txn.begin();
-    flight_t::insert_row(second_flight_number, {});
+    flight_t::insert(second_flight_number, {});
     txn.commit();
 }

--- a/production/db/query_processor/tests/test_index_scan.cpp
+++ b/production/db/query_processor/tests/test_index_scan.cpp
@@ -45,7 +45,7 @@ public:
             w.str = ""; // SAME
             w.f = static_cast<float>(i); // ASC
             w.i = c_num_initial_rows - i; // DESC
-            w.insert_row();
+            w.insert();
         }
 
         txn.commit();
@@ -404,7 +404,7 @@ TEST_F(test_index_scan, insert_followed_by_delete)
     w.str = "HELLO";
     w.f = 21.0;
     w.i = -1;
-    to_delete = w.insert_row();
+    to_delete = w.insert();
 
     // Insert should be visible.
     gaia_id_t type_record_id = type_id_mapping_t::instance().get_record_id(gaia::index_sandbox::sandbox_t::s_gaia_type);
@@ -424,7 +424,7 @@ TEST_F(test_index_scan, insert_followed_by_delete)
     gaia::db::commit_transaction();
 
     gaia::db::begin_transaction();
-    gaia::index_sandbox::sandbox_t::get(to_delete).delete_row();
+    gaia::index_sandbox::sandbox_t::get(to_delete).remove();
 
     // Delete in effect.
     for (const auto& idx : catalog_core_t::list_indexes(type_record_id))
@@ -451,9 +451,9 @@ TEST_F(test_index_scan, multi_insert_followed_by_delete)
     w.str = "HELLO";
     w.f = 21.0;
     w.i = -1;
-    to_delete = w.insert_row();
-    to_delete2 = w.insert_row();
-    to_delete3 = w.insert_row();
+    to_delete = w.insert();
+    to_delete2 = w.insert();
+    to_delete3 = w.insert();
 
     // Insert should be visible.
     gaia_id_t type_record_id = type_id_mapping_t::instance().get_record_id(gaia::index_sandbox::sandbox_t::s_gaia_type);
@@ -473,9 +473,9 @@ TEST_F(test_index_scan, multi_insert_followed_by_delete)
     gaia::db::commit_transaction();
 
     gaia::db::begin_transaction();
-    gaia::index_sandbox::sandbox_t::get(to_delete).delete_row();
-    gaia::index_sandbox::sandbox_t::get(to_delete2).delete_row();
-    gaia::index_sandbox::sandbox_t::get(to_delete3).delete_row();
+    gaia::index_sandbox::sandbox_t::get(to_delete).remove();
+    gaia::index_sandbox::sandbox_t::get(to_delete2).remove();
+    gaia::index_sandbox::sandbox_t::get(to_delete3).remove();
 
     // Delete in effect.
     for (const auto& idx : catalog_core_t::list_indexes(type_record_id))

--- a/production/direct_access/tests/test_auto_connect.cpp
+++ b/production/direct_access/tests/test_auto_connect.cpp
@@ -29,12 +29,12 @@ TEST_F(auto_connect_test, child_insert_connect)
 {
     const int32_t flight_number = 1701;
     auto_transaction_t txn;
-    gaia_id_t flight_id = flight_t::insert_row(flight_number, {});
+    gaia_id_t flight_id = flight_t::insert(flight_number, {});
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 0);
 
-    gaia_id_t passenger_id = passenger_t::insert_row("Spock", "Vulcan", flight_number);
+    gaia_id_t passenger_id = passenger_t::insert("Spock", "Vulcan", flight_number);
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 1);
@@ -46,8 +46,8 @@ TEST_F(auto_connect_test, child_update_connect)
 {
     const int32_t flight_number = 1701;
     auto_transaction_t txn;
-    gaia_id_t passenger_id = passenger_t::insert_row("Spock", "Vulcan", 0);
-    gaia_id_t flight_id = flight_t::insert_row(flight_number, {});
+    gaia_id_t passenger_id = passenger_t::insert("Spock", "Vulcan", 0);
+    gaia_id_t flight_id = flight_t::insert(flight_number, {});
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 0);
@@ -55,7 +55,7 @@ TEST_F(auto_connect_test, child_update_connect)
 
     auto passenger_writer = passenger_t::get(passenger_id).writer();
     passenger_writer.return_flight_number = flight_number;
-    passenger_writer.update_row();
+    passenger_writer.update();
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 1);
@@ -67,8 +67,8 @@ TEST_F(auto_connect_test, child_update_disconnect)
 {
     const int32_t flight_number = 1701;
     auto_transaction_t txn;
-    gaia_id_t flight_id = flight_t::insert_row(flight_number, {});
-    gaia_id_t passenger_id = passenger_t::insert_row("Spock", "Vulcan", flight_number);
+    gaia_id_t flight_id = flight_t::insert(flight_number, {});
+    gaia_id_t passenger_id = passenger_t::insert("Spock", "Vulcan", flight_number);
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 1);
@@ -77,7 +77,7 @@ TEST_F(auto_connect_test, child_update_disconnect)
 
     auto passenger_writer = passenger_t::get(passenger_id).writer();
     passenger_writer.return_flight_number = 0;
-    passenger_writer.update_row();
+    passenger_writer.update();
     txn.commit();
 
     ASSERT_EQ(flight_t::get(flight_id).return_passengers().size(), 0);
@@ -91,11 +91,11 @@ TEST_F(auto_connect_test, child_update_reconnect)
 
     auto_transaction_t txn;
 
-    gaia_id_t enterprise_flight_id = flight_t::insert_row(enterprise_flight_number, {});
-    gaia_id_t voyager_flight_id = flight_t::insert_row(voyager_flight_number, {});
+    gaia_id_t enterprise_flight_id = flight_t::insert(enterprise_flight_number, {});
+    gaia_id_t voyager_flight_id = flight_t::insert(voyager_flight_number, {});
     txn.commit();
 
-    gaia_id_t passenger_id = passenger_t::insert_row("Spock", "Vulcan", enterprise_flight_number);
+    gaia_id_t passenger_id = passenger_t::insert("Spock", "Vulcan", enterprise_flight_number);
     txn.commit();
 
     ASSERT_EQ(flight_t::get(voyager_flight_id).return_passengers().size(), 0);
@@ -105,7 +105,7 @@ TEST_F(auto_connect_test, child_update_reconnect)
 
     auto passenger_writer = passenger_t::get(passenger_id).writer();
     passenger_writer.return_flight_number = voyager_flight_number;
-    passenger_writer.update_row();
+    passenger_writer.update();
     txn.commit();
 
     ASSERT_EQ(flight_t::get(enterprise_flight_id).return_passengers().size(), 0);

--- a/production/direct_access/tests/test_default_db.cpp
+++ b/production/direct_access/tests/test_default_db.cpp
@@ -29,11 +29,11 @@ TEST_F(default_db_test, direct_access)
     // in the DDL. The direct access classes generated from the default database
     // will be under the `gaia` namespace (instead of `gaia::[database]`).
     auto_transaction_t txn;
-    gaia_id_t dr_house_id = gaia::doctor_t::insert_row("Gregory House", "greg.house@ppth.org");
-    gaia_id_t dr_wilson_id = gaia::doctor_t::insert_row("James Wilson", "james.wilson@ppth.org");
+    gaia_id_t dr_house_id = gaia::doctor_t::insert("Gregory House", "greg.house@ppth.org");
+    gaia_id_t dr_wilson_id = gaia::doctor_t::insert("James Wilson", "james.wilson@ppth.org");
     txn.commit();
     gaia_id_t patient_id
-        = gaia::patient_t::insert_row(
+        = gaia::patient_t::insert(
             "Rebecca Adler",
             "james.wilson@ppth.org",
             "greg.house@ppth.org");

--- a/production/direct_access/tests/test_expressions.cpp
+++ b/production/direct_access/tests/test_expressions.cpp
@@ -87,7 +87,7 @@ protected:
         employee_w.name_last = last_name;
         employee_w.email = email;
         employee_w.hire_date = hire_date;
-        gaia_id_t id = employee_w.insert_row();
+        gaia_id_t id = employee_w.insert();
         employee_t employee = employee_t::get(id);
 
         employee.addresses().insert(address);
@@ -100,7 +100,7 @@ protected:
         auto address_w = address_writer();
         address_w.city = city;
         address_w.state = state;
-        return address_t::get(address_w.insert_row());
+        return address_t::get(address_w.insert());
     }
 
     phone_t create_phone(const string& number, const string& type, address_t& address)
@@ -108,7 +108,7 @@ protected:
         phone_writer writer;
         writer.phone_number = number;
         writer.type = type;
-        phone_t phone = phone_t::get(writer.insert_row());
+        phone_t phone = phone_t::get(writer.insert());
 
         address.phones().insert(phone);
 
@@ -117,13 +117,13 @@ protected:
 
     customer_t create_customer(const char* name, const std::vector<int32_t>& sales_by_quarter)
     {
-        return customer_t::get(customer_t::insert_row(name, sales_by_quarter));
+        return customer_t::get(customer_t::insert(name, sales_by_quarter));
     }
 
     internet_contract_t create_internet_contract(const char* provider, address_t address, employee_t owner)
     {
         internet_contract_t internet_contract = internet_contract_t::get(
-            internet_contract_t::insert_row(provider));
+            internet_contract_t::insert(provider));
 
         address.internet_contract().connect(internet_contract);
         owner.internet_contract().connect(internet_contract);
@@ -342,7 +342,7 @@ TEST_F(test_expressions, object_eq)
     auto employee_writer = gaia::addr_book::employee_writer();
     employee_writer.name_first = "Zack";
     employee_writer.name_last = "Nolan";
-    auto zack = employee_t::get(employee_writer.insert_row());
+    auto zack = employee_t::get(employee_writer.insert());
 
     assert_empty(
         address_t::list()
@@ -365,7 +365,7 @@ TEST_F(test_expressions, object_ne)
     auto employee_writer = gaia::addr_book::employee_writer();
     employee_writer.name_first = "Zack";
     employee_writer.name_last = "Nolan";
-    auto zack = employee_t::get(employee_writer.insert_row());
+    auto zack = employee_t::get(employee_writer.insert());
 
     assert_contains(
         address_t::list()

--- a/production/direct_access/tests/test_expressions_perf.cpp
+++ b/production/direct_access/tests/test_expressions_perf.cpp
@@ -122,14 +122,14 @@ public:
             employee_writer.name_first = "Name_" + to_string(index_employee);
             employee_writer.name_last = "Surname_" + to_string(index_employee);
             employee_writer.hire_date = static_cast<int64_t>(index_employee);
-            auto employee = employee_t::get(employee_writer.insert_row());
+            auto employee = employee_t::get(employee_writer.insert());
 
             for (uint64_t index_address = 0; index_address < c_num_employee_addresses; index_address++)
             {
                 auto address_w = address_writer();
                 address_w.city = "city_" + to_string(index_address);
                 address_w.state = "state_" + to_string(index_address);
-                employee.addresses().insert(address_w.insert_row());
+                employee.addresses().insert(address_w.insert());
             }
 
             if (index_employee % 10000 == 0)

--- a/production/direct_access/tests/test_incubator.cpp
+++ b/production/direct_access/tests/test_incubator.cpp
@@ -31,7 +31,7 @@ protected:
         w.name = name;
         w.min_temp = min_temp;
         w.max_temp = max_temp;
-        return w.insert_row();
+        return w.insert();
     }
 };
 
@@ -48,7 +48,7 @@ TEST_F(gaia_incubator_test, schema_read_write_test)
         incubator_id = insert_incubator(c_chicken, c_chicken_min, c_chicken_max);
         ASSERT_TRUE(incubator_id != c_invalid_gaia_id);
         auto incubator = incubator_t::get(incubator_id);
-        auto sensor = sensor_t::insert_row(c_sensor_a, 0, c_chicken_min);
+        auto sensor = sensor_t::insert(c_sensor_a, 0, c_chicken_min);
         incubator.sensors().insert(sensor);
         txn.commit();
     }

--- a/production/direct_access/tests/test_iterators.cpp
+++ b/production/direct_access/tests/test_iterators.cpp
@@ -43,12 +43,12 @@ public:
 
         employee_writer.name_first = "Many";
         employee_writer.name_last = "Addresses";
-        m_employee = employee_t::get(employee_writer.insert_row());
+        m_employee = employee_t::get(employee_writer.insert());
 
         for (size_t i = 0; i < count; i++)
         {
             address_writer.street = to_string(i);
-            address_t address = address_t::get(address_writer.insert_row());
+            address_t address = address_t::get(address_writer.insert());
             m_employee.addresses().insert(address);
         }
     }

--- a/production/direct_access/tests/test_one_to_many.cpp
+++ b/production/direct_access/tests/test_one_to_many.cpp
@@ -28,14 +28,14 @@ protected:
         employee_writer ew;
         ew.name_first = name.c_str();
         ew.name_last = surname.c_str();
-        return employee_t::get(ew.insert_row());
+        return employee_t::get(ew.insert());
     }
 
     address_t insert_address(const std::string& city)
     {
         address_writer aw;
         aw.city = city.c_str();
-        return address_t::get(aw.insert_row());
+        return address_t::get(aw.insert());
     }
 };
 

--- a/production/direct_access/tests/test_one_to_one.cpp
+++ b/production/direct_access/tests/test_one_to_one.cpp
@@ -26,7 +26,7 @@ protected:
     template <class T_edc, typename... T_args>
     T_edc create(T_args... args)
     {
-        return T_edc::get(T_edc::insert_row(args...));
+        return T_edc::get(T_edc::insert(args...));
     }
 };
 

--- a/production/examples/default/hello.cpp
+++ b/production/examples/default/hello.cpp
@@ -20,9 +20,9 @@ int main()
     gaia::system::initialize();
 
     gaia::db::begin_transaction();
-    gaia::names_t::insert_row("Alice");
-    gaia::names_t::insert_row("Bob");
-    gaia::names_t::insert_row("Charles");
+    gaia::names_t::insert("Alice");
+    gaia::names_t::insert("Bob");
+    gaia::names_t::insert("Charles");
     gaia::db::commit_transaction();
 
     gaia::system::shutdown();

--- a/production/examples/default/hello.ruleset
+++ b/production/examples/default/hello.ruleset
@@ -20,7 +20,7 @@ ruleset hello_ruleset
         string new_greeting = "Hello " + string(names.name) + "!";
 
         // Insert the greeting.
-        gaia::greetings_t::insert_row(new_greeting.c_str());
+        gaia::greetings_t::insert(new_greeting.c_str());
     }
     // Rule 2: Whenever a greeting is inserted,
     // output it to the console.

--- a/production/examples/hello/hello.cpp
+++ b/production/examples/hello/hello.cpp
@@ -20,9 +20,9 @@ int main()
     gaia::system::initialize();
 
     gaia::db::begin_transaction();
-    gaia::hello::names_t::insert_row("Alice");
-    gaia::hello::names_t::insert_row("Bob");
-    gaia::hello::names_t::insert_row("Charles");
+    gaia::hello::names_t::insert("Alice");
+    gaia::hello::names_t::insert("Bob");
+    gaia::hello::names_t::insert("Charles");
     gaia::db::commit_transaction();
 
     gaia::system::shutdown();

--- a/production/examples/hello/hello.ruleset
+++ b/production/examples/hello/hello.ruleset
@@ -20,7 +20,7 @@ ruleset hello_ruleset
         string new_greeting = "Hello " + string(names.name) + "!";
 
         // Insert the greeting.
-        gaia::hello::greetings_t::insert_row(new_greeting.c_str());
+        gaia::hello::greetings_t::insert(new_greeting.c_str());
     }
     // Rule 2: Whenever a greeting is inserted,
     // output it to the console.

--- a/production/examples/incubator/incubator.cpp
+++ b/production/examples/incubator/incubator.cpp
@@ -55,7 +55,7 @@ gaia_id_t insert_incubator(const char* name, float min_temp, float max_temp)
     w.is_on = false;
     w.min_temp = min_temp;
     w.max_temp = max_temp;
-    return w.insert_row();
+    return w.insert();
 }
 
 void restore_sensor(sensor_t& sensor, float min_temp)
@@ -63,7 +63,7 @@ void restore_sensor(sensor_t& sensor, float min_temp)
     sensor_writer w = sensor.writer();
     w.timestamp = 0;
     w.value = min_temp;
-    w.update_row();
+    w.update();
 }
 
 void restore_actuator(actuator_t& actuator)
@@ -71,7 +71,7 @@ void restore_actuator(actuator_t& actuator)
     actuator_writer w = actuator.writer();
     w.timestamp = 0;
     w.value = 0.0;
-    w.update_row();
+    w.update();
 }
 
 void restore_incubator(incubator_t& incubator, float min_temp, float max_temp)
@@ -80,7 +80,7 @@ void restore_incubator(incubator_t& incubator, float min_temp, float max_temp)
     w.is_on = false;
     w.min_temp = min_temp;
     w.max_temp = max_temp;
-    w.update_row();
+    w.update();
 
     for (auto& sensor : incubator.sensors())
     {
@@ -127,15 +127,15 @@ void init_storage()
 
     // Chicken Incubator: 2 sensors, 1 fan
     auto incubator = incubator_t::get(insert_incubator(c_chicken, c_chicken_min, c_chicken_max));
-    incubator.sensors().insert(sensor_t::insert_row(c_sensor_a, 0, c_chicken_min));
-    incubator.sensors().insert(sensor_t::insert_row(c_sensor_c, 0, c_chicken_min));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_a, 0, 0.0));
+    incubator.sensors().insert(sensor_t::insert(c_sensor_a, 0, c_chicken_min));
+    incubator.sensors().insert(sensor_t::insert(c_sensor_c, 0, c_chicken_min));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_a, 0, 0.0));
 
     // Puppy Incubator: 1 sensor, 2 fans
     incubator = incubator_t::get(insert_incubator(c_puppy, c_puppy_min, c_puppy_max));
-    incubator.sensors().insert(sensor_t::insert_row(c_sensor_b, 0, c_puppy_min));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_b, 0, 0.0));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_c, 0, 0.0));
+    incubator.sensors().insert(sensor_t::insert(c_sensor_b, 0, c_puppy_min));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_b, 0, 0.0));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_c, 0, 0.0));
 
     tx.commit();
 }
@@ -195,7 +195,7 @@ void set_power(bool is_on)
     {
         auto w = i.writer();
         w.is_on = is_on;
-        w.update_row();
+        w.update();
     }
     tx.commit();
 }
@@ -244,7 +244,7 @@ void simulation()
                 new_temp = calc_new_temp(s.value(), fan_a);
                 w.value = new_temp;
                 w.timestamp = g_timestamp;
-                w.update_row();
+                w.update();
             }
             else if (strcmp(s.name(), c_sensor_b) == 0)
             {
@@ -252,14 +252,14 @@ void simulation()
                 new_temp = calc_new_temp(new_temp, fan_c);
                 w.value = new_temp;
                 w.timestamp = g_timestamp;
-                w.update_row();
+                w.update();
             }
             else if (strcmp(s.name(), c_sensor_c) == 0)
             {
                 new_temp = calc_new_temp(s.value(), fan_a);
                 w.value = new_temp;
                 w.timestamp = g_timestamp;
-                w.update_row();
+                w.update();
             }
         }
         tx.commit();
@@ -581,7 +581,7 @@ public:
         {
             incubator_writer w = m_current_incubator.writer();
             w.is_on = turn_on;
-            w.update_row();
+            w.update();
         }
         commit_transaction();
     }
@@ -606,7 +606,7 @@ public:
             }
             else
             {
-                w.update_row();
+                w.update();
                 changed = true;
             }
         }

--- a/production/inc/gaia/direct_access/edc_base.hpp
+++ b/production/inc/gaia/direct_access/edc_base.hpp
@@ -164,7 +164,7 @@ public:
 };
 
 // To connect two objects, a gaia_id() is needed but not available until SE create is called during
-// the insert_row().
+// the insert().
 class edc_invalid_state : public common::gaia_exception
 {
 public:

--- a/production/inc/gaia/direct_access/edc_object.hpp
+++ b/production/inc/gaia/direct_access/edc_object.hpp
@@ -83,7 +83,7 @@ public:
      * Delete the database object. This doesn't destroy the extended data class
      * object.
      */
-    void delete_row();
+    void remove();
 
     /**
      * Delete the database object specified by the id.
@@ -119,9 +119,9 @@ protected:
 
     /**
      * Insert a mutable flatbuffer into a newly created database object. This will be
-     * used by the generated type-specific insert_row() method.
+     * used by the generated type-specific insert() method.
      */
-    static gaia::common::gaia_id_t insert_row(flatbuffers::FlatBufferBuilder& fbb);
+    static gaia::common::gaia_id_t insert(flatbuffers::FlatBufferBuilder& fbb);
 
     /**
      * Materialize the flatbuffer associated with this record
@@ -159,12 +159,12 @@ public:
      * Insert the values in this new object into a newly created database object.
      * The user can get a new object by fetching the returned id using get(id)
      */
-    gaia::common::gaia_id_t insert_row();
+    gaia::common::gaia_id_t insert();
 
     /**
      * Update the row values stored in this writer.
      */
-    void update_row();
+    void update();
 
 private:
     flatbuffers::FlatBufferBuilder m_builder;

--- a/production/inc/gaia/direct_access/edc_object.inc
+++ b/production/inc/gaia/direct_access/edc_object.inc
@@ -107,14 +107,14 @@ gaia::common::gaia_id_t edc_object_t<container_type_id, T_class, T_flatbuffer, T
 }
 
 template <gaia::common::gaia_type_t container_type_id, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row(
+gaia::common::gaia_id_t edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::insert(
     flatbuffers::FlatBufferBuilder& fbb)
 {
     return edc_base_t::insert(container_type_id, fbb.GetSize(), fbb.GetBufferPointer());
 }
 
 template <gaia::common::gaia_type_t container_type_id, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-void edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::delete_row()
+void edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::remove()
 {
     if (!edc_base_t::exists())
     {
@@ -141,7 +141,7 @@ gaia::common::gaia_type_t edc_object_t<container_type_id, T_class, T_flatbuffer,
 // The edc_writer_t implementation.
 //
 template <gaia::common::gaia_type_t container_type_id, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-gaia::common::gaia_id_t edc_writer_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::insert_row()
+gaia::common::gaia_id_t edc_writer_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::insert()
 {
     auto u = T_flatbuffer::Pack(m_builder, this);
     m_builder.Finish(u);
@@ -151,7 +151,7 @@ gaia::common::gaia_id_t edc_writer_t<container_type_id, T_class, T_flatbuffer, T
 }
 
 template <gaia::common::gaia_type_t container_type_id, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
-void edc_writer_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::update_row()
+void edc_writer_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::update()
 {
     auto u = T_flatbuffer::Pack(m_builder, this);
     m_builder.Finish(u);

--- a/production/inc/gaia_internal/catalog/gaia_catalog.h
+++ b/production/inc/gaia_internal/catalog/gaia_catalog.h
@@ -74,7 +74,7 @@ class gaia_index_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_i
 public:
     gaia_index_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, bool unique, uint8_t type, const std::vector<uint64_t>& fields);
+    static gaia::common::gaia_id_t insert(const char* name, bool unique, uint8_t type, const std::vector<uint64_t>& fields);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_index, gaia_index_t> list();
     const char* name() const;
     bool unique() const;
@@ -119,7 +119,7 @@ class gaia_rule_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_ru
 public:
     gaia_rule_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name);
+    static gaia::common::gaia_id_t insert(const char* name);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_rule, gaia_rule_t> list();
     const char* name() const;
     gaia_ruleset_t ruleset() const;
@@ -153,7 +153,7 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<gaia_rule_t> gaia_rules_list_t;
     gaia_ruleset_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, bool active_on_startup, const std::vector<uint64_t>& table_ids, const char* source_location, const char* serial_stream);
+    static gaia::common::gaia_id_t insert(const char* name, bool active_on_startup, const std::vector<uint64_t>& table_ids, const char* source_location, const char* serial_stream);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t> list();
     const char* name() const;
     bool active_on_startup() const;
@@ -202,7 +202,7 @@ class gaia_relationship_t : public gaia::direct_access::edc_object_t<c_gaia_type
 public:
     gaia_relationship_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions);
+    static gaia::common::gaia_id_t insert(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> list();
     const char* name() const;
     const char* to_parent_link_name() const;
@@ -279,7 +279,7 @@ class gaia_field_t : public gaia::direct_access::edc_object_t<c_gaia_type_gaia_f
 public:
     gaia_field_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique);
+    static gaia::common::gaia_id_t insert(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_field, gaia_field_t> list();
     const char* name() const;
     uint8_t type() const;
@@ -340,7 +340,7 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<gaia_field_t> gaia_fields_list_t;
     gaia_table_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template);
+    static gaia::common::gaia_id_t insert(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_table, gaia_table_t> list();
     const char* name() const;
     uint32_t type() const;
@@ -406,7 +406,7 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<gaia_table_t> gaia_tables_list_t;
     gaia_database_t() : edc_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name);
+    static gaia::common::gaia_id_t insert(const char* name);
     static gaia::direct_access::edc_container_t<c_gaia_type_gaia_database, gaia_database_t> list();
     const char* name() const;
     gaia_tables_list_t gaia_tables() const;

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -562,7 +562,7 @@ public:
         auto entry = *(gaia::event_log::event_log_t::list().begin());
         while (entry)
         {
-            entry.delete_row();
+            entry.remove();
             entry = *(gaia::event_log::event_log_t::list().begin());
             rows_cleared++;
         }

--- a/production/rules/event_manager/tests/test_rule_checker.cpp
+++ b/production/rules/event_manager/tests/test_rule_checker.cpp
@@ -70,7 +70,7 @@ void load_catalog()
         {
             continue;
         }
-        writer.update_row();
+        writer.update();
     }
     commit_transaction();
 }

--- a/production/rules/event_manager/tests/test_rule_exceptions.cpp
+++ b/production/rules/event_manager/tests/test_rule_exceptions.cpp
@@ -111,7 +111,7 @@ void rule_conflict_exception(const rule_context_t* context)
     {
         auto ew = employee_t::get(context->record).writer();
         ew.name_first = "Success";
-        ew.update_row();
+        ew.update();
     }
 
     thread([&context] {
@@ -120,7 +120,7 @@ void rule_conflict_exception(const rule_context_t* context)
             auto_transaction_t txn(auto_transaction_t::no_auto_begin);
             auto ew = employee_t::get(context->record).writer();
             ew.name_first = "Conflict";
-            ew.update_row();
+            ew.update();
             txn.commit();
         }
         end_session();
@@ -182,7 +182,7 @@ public:
         auto_transaction_t txn(auto_transaction_t::no_auto_begin);
         employee_writer writer;
         writer.name_first = c_name;
-        writer.insert_row();
+        writer.insert();
         txn.commit();
     }
 

--- a/production/sdk/tests/test_sdk.cpp
+++ b/production/sdk/tests/test_sdk.cpp
@@ -103,9 +103,9 @@ TEST_F(sdk_test, auto_txn)
     employee_writer w;
     w.name_first = "Public";
     w.name_last = "Headers";
-    gaia_id_t id = w.insert_row();
+    gaia_id_t id = w.insert();
     employee_t e = employee_t::get(id);
-    e.delete_row();
+    e.remove();
     tx.commit();
 }
 
@@ -121,11 +121,11 @@ TEST_F(sdk_test, rule_subscribe_unsubscribe)
         employee_writer w;
         w.name_first = "Public";
         w.name_last = "Headers";
-        w.insert_row();
+        w.insert();
         // [GAIAPLAT-1205]:  We now do not fire an event if
         // the anchor row has been deleted.
         // employee_t e = employee_t::get(id);
-        // e.delete_row();
+        // e.remove();
         tx.commit();
 
         wait_for_rule(g_rule_1_called);

--- a/production/sdk/tests/test_sdk_no_init_rules.cpp
+++ b/production/sdk/tests/test_sdk_no_init_rules.cpp
@@ -34,7 +34,7 @@ TEST(sdk_test_no_init_rules, app_check)
         employee_writer w;
         w.name_first = "Did_not";
         w.name_last = "Provide_initialize_rules";
-        w.insert_row();
+        w.insert();
         // Don't change the state of the db at all (no commit).
     }
     gaia::system::shutdown();

--- a/production/system/tests/test_gaia_system.cpp
+++ b/production/system/tests/test_gaia_system.cpp
@@ -98,13 +98,13 @@ void perform_transactions(uint32_t count_transactions, uint32_t crud_events_per_
         // Insert row.
         employee_writer w;
         w.name_first = "name";
-        gaia_id_t id = w.insert_row();
+        gaia_id_t id = w.insert();
         auto e = employee_t::get(id);
 
         // Update row.
         w = e.writer();
         w.name_first = "updated_name";
-        w.update_row();
+        w.update();
 
         // [GAIAPLAT-1205]:  We now do not fire an event if
         // the anchor row has been deleted.

--- a/production/system/tests/test_recovery.cpp
+++ b/production/system/tests/test_recovery.cpp
@@ -176,8 +176,7 @@ gaia_id_t recovery_test::get_random_map_key(map<gaia_id_t, employee_copy_t> m)
 
 string recovery_test::generate_string(size_t length_in_bytes)
 {
-    auto randchar = []() -> char
-    {
+    auto randchar = []() -> char {
         const char charset[] = "0123456789"
                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                "abcdefghijklmnopqrstuvwxyz";
@@ -201,7 +200,7 @@ void recovery_test::modify_data()
         auto w1 = e1.writer();
         auto name_first = generate_string(c_field_size_bytes);
         w1.name_first = name_first;
-        w1.update_row();
+        w1.update();
         commit_transaction();
         to_update->second.name_first = name_first;
 
@@ -216,7 +215,7 @@ void recovery_test::modify_data()
         s_employee_map.erase(id);
         begin_transaction();
         auto e = employee_t::get(id);
-        e.delete_row();
+        e.remove();
         commit_transaction();
     }
 }
@@ -232,7 +231,7 @@ employee_t recovery_test::generate_employee_record()
     w.email = generate_string(c_field_size_bytes);
     w.web = generate_string(c_field_size_bytes);
 
-    gaia_id_t id = w.insert_row();
+    gaia_id_t id = w.insert();
     return employee_t::get(id);
 }
 
@@ -327,7 +326,7 @@ void recovery_test::delete_all(int initial_record_count)
             auto e = employee_t::get(id);
             try
             {
-                e.delete_row();
+                e.remove();
             }
             catch (const object_still_referenced& e)
             {
@@ -454,7 +453,7 @@ TEST_F(recovery_test, reference_update_test)
         w.postal = generate_string(c_field_size_bytes);
         w.country = generate_string(c_field_size_bytes);
         w.current = true;
-        address_id = w.insert_row();
+        address_id = w.insert();
         txn.commit();
     }
     ASSERT_NE(address_id, c_invalid_gaia_id);
@@ -470,7 +469,7 @@ TEST_F(recovery_test, reference_update_test)
             w.phone_number = generate_string(c_field_size_bytes);
             w.type = generate_string(c_field_size_bytes);
             w.primary = true;
-            gaia_id_t phone_id = w.insert_row();
+            gaia_id_t phone_id = w.insert();
             ASSERT_NE(phone_id, c_invalid_gaia_id);
             phone_ids.insert(phone_id);
         }
@@ -493,7 +492,7 @@ TEST_F(recovery_test, reference_update_test)
     {
         auto_transaction_t txn;
         // Make sure address cannot be deleted upon recovery.
-        ASSERT_THROW(address_t::get(address_id).delete_row(), object_still_referenced);
+        ASSERT_THROW(address_t::get(address_id).remove(), object_still_referenced);
         for (auto const& phone : address_t::get(address_id).phones())
         {
             recovered_phone_ids.insert(phone.gaia_id());

--- a/production/tests/workloads/mink/mink.cpp
+++ b/production/tests/workloads/mink/mink.cpp
@@ -121,7 +121,7 @@ gaia_id_t insert_incubator(const char* name, float min_temp, float max_temp)
     w.is_on = false;
     w.min_temp = min_temp;
     w.max_temp = max_temp;
-    return w.insert_row();
+    return w.insert();
 }
 
 void restore_sensor(sensor_t& sensor, float min_temp)
@@ -129,7 +129,7 @@ void restore_sensor(sensor_t& sensor, float min_temp)
     sensor_writer w = sensor.writer();
     w.timestamp = 0;
     w.value = min_temp;
-    w.update_row();
+    w.update();
 }
 
 void restore_actuator(actuator_t& actuator)
@@ -137,7 +137,7 @@ void restore_actuator(actuator_t& actuator)
     actuator_writer w = actuator.writer();
     w.timestamp = 0;
     w.value = 0.0;
-    w.update_row();
+    w.update();
 }
 
 void restore_incubator(incubator_t& incubator, float min_temp, float max_temp)
@@ -146,7 +146,7 @@ void restore_incubator(incubator_t& incubator, float min_temp, float max_temp)
     w.is_on = false;
     w.min_temp = min_temp;
     w.max_temp = max_temp;
-    w.update_row();
+    w.update();
 
     for (auto& sensor : incubator.sensors())
     {
@@ -195,16 +195,16 @@ void init_storage()
     auto incubator = incubator_t::get(
         insert_incubator(c_chicken, c_chicken_min, c_chicken_max));
     incubator.sensors().insert(
-        sensor_t::insert_row(c_sensor_a, 0, c_chicken_min));
+        sensor_t::insert(c_sensor_a, 0, c_chicken_min));
     incubator.sensors().insert(
-        sensor_t::insert_row(c_sensor_c, 0, c_chicken_min));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_a, 0, 0.0));
+        sensor_t::insert(c_sensor_c, 0, c_chicken_min));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_a, 0, 0.0));
 
     // Puppy Incubator: 1 sensor, 2 fans
     incubator = incubator_t::get(insert_incubator(c_puppy, c_puppy_min, c_puppy_max));
-    incubator.sensors().insert(sensor_t::insert_row(c_sensor_b, 0, c_puppy_min));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_b, 0, 0.0));
-    incubator.actuators().insert(actuator_t::insert_row(c_actuator_c, 0, 0.0));
+    incubator.sensors().insert(sensor_t::insert(c_sensor_b, 0, c_puppy_min));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_b, 0, 0.0));
+    incubator.actuators().insert(actuator_t::insert(c_actuator_c, 0, 0.0));
 
     tx.commit();
 }
@@ -354,7 +354,7 @@ void set_power(bool is_on)
     {
         auto w = i.writer();
         w.is_on = is_on;
-        w.update_row();
+        w.update();
     }
     tx.commit();
 }
@@ -409,7 +409,7 @@ void simulation_step()
             w.timestamp = g_timestamp;
         }
         my_time_point update_start_mark = my_clock::now();
-        w.update_row();
+        w.update();
         my_time_point update_end_mark = my_clock::now();
         my_duration_in_microseconds update_duration = update_end_mark - update_start_mark;
         g_update_row_duration_in_microseconds += update_duration.count();
@@ -1089,7 +1089,7 @@ public:
         {
             incubator_writer w = m_current_incubator.writer();
             w.is_on = turn_on;
-            w.update_row();
+            w.update();
         }
         commit_transaction();
     }
@@ -1114,7 +1114,7 @@ public:
             }
             else
             {
-                w.update_row();
+                w.update();
                 changed = true;
             }
         }

--- a/production/tools/gaia_translate/tests/test_connect_disconnect.cpp
+++ b/production/tools/gaia_translate/tests/test_connect_disconnect.cpp
@@ -49,9 +49,9 @@ TEST_F(test_connect_disconnect, test_connect_1_1)
     gaia::db::begin_transaction();
 
     // The rule will create a connection between the student and these registrations.
-    student_t student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    registration_t::insert_row("reg006", "stu001", nullptr, c_status_eligible, c_grade_c);
-    registration_t::insert_row("reg007", "stu001", nullptr, c_status_eligible, c_grade_c);
+    student_t student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    registration_t::insert("reg006", "stu001", nullptr, c_status_eligible, c_grade_c);
+    registration_t::insert("reg007", "stu001", nullptr, c_status_eligible, c_grade_c);
 
     gaia::db::commit_transaction();
 
@@ -77,8 +77,8 @@ TEST_F(test_connect_disconnect, test_connect_1_n)
 
     gaia::db::begin_transaction();
 
-    student_t student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    student_t student_2 = student_t::get(student_t::insert_row("stu002", "Hazel", 45, 4, 3.0));
+    student_t student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    student_t student_2 = student_t::get(student_t::insert("stu002", "Hazel", 45, 4, 3.0));
 
     gaia::db::commit_transaction();
 
@@ -101,12 +101,12 @@ TEST_F(test_connect_disconnect, test_disconnect_1_n)
 
     // Create the registrations
     gaia::db::begin_transaction();
-    gaia_id_t reg001 = registration_t::insert_row("reg001", nullptr, nullptr, c_status_eligible, c_grade_c);
-    gaia_id_t reg002 = registration_t::insert_row("reg002", nullptr, nullptr, c_status_eligible, c_grade_c);
+    gaia_id_t reg001 = registration_t::insert("reg001", nullptr, nullptr, c_status_eligible, c_grade_c);
+    gaia_id_t reg002 = registration_t::insert("reg002", nullptr, nullptr, c_status_eligible, c_grade_c);
     gaia::db::commit_transaction();
 
     gaia::db::begin_transaction();
-    student_t student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
+    student_t student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
     student_1.registrations().insert(reg001);
     student_1.registrations().insert(reg002);
     gaia::db::commit_transaction();
@@ -114,7 +114,7 @@ TEST_F(test_connect_disconnect, test_disconnect_1_n)
     gaia::rules::test::wait_for_rules_to_complete();
 
     gaia::db::begin_transaction();
-    student_t student_2 = student_t::get(student_t::insert_row("stu002", "Hazel", 45, 4, 3.0));
+    student_t student_2 = student_t::get(student_t::insert("stu002", "Hazel", 45, 4, 3.0));
     student_2.registrations().insert(reg001);
     student_2.registrations().insert(reg002);
     gaia::db::commit_transaction();
@@ -122,7 +122,7 @@ TEST_F(test_connect_disconnect, test_disconnect_1_n)
     gaia::rules::test::wait_for_rules_to_complete();
 
     gaia::db::begin_transaction();
-    course_t course_1 = course_t::get(course_t::insert_row("cou001", "math101", 8));
+    course_t course_1 = course_t::get(course_t::insert("cou001", "math101", 8));
     course_1.registrations().insert(reg001);
     course_1.registrations().insert(reg002);
     gaia::db::commit_transaction();
@@ -130,7 +130,7 @@ TEST_F(test_connect_disconnect, test_disconnect_1_n)
     gaia::rules::test::wait_for_rules_to_complete();
 
     gaia::db::begin_transaction();
-    course_t course_2 = course_t::get(course_t::insert_row("cou002", "math102", 8));
+    course_t course_2 = course_t::get(course_t::insert("cou002", "math102", 8));
     course_2.registrations().insert(reg001);
     course_2.registrations().insert(reg002);
     gaia::db::commit_transaction();
@@ -150,8 +150,8 @@ TEST_F(test_connect_disconnect, test_disconnect_1_1)
     gaia::rules::subscribe_ruleset("test_disconnect_1_1");
 
     gaia::db::begin_transaction();
-    gaia_id_t parents_1 = parents_t::insert_row("Winnie", "Pontus");
-    student_t student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
+    gaia_id_t parents_1 = parents_t::insert("Winnie", "Pontus");
+    student_t student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
     student_1.parents().connect(parents_1);
     gaia::db::commit_transaction();
 
@@ -167,9 +167,9 @@ TEST_F(test_connect_disconnect, disconnect_delete)
     gaia::rules::subscribe_ruleset("test_disconnect_delete");
 
     gaia::db::begin_transaction();
-    student_t student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    registration_t::insert_row("reg001", "stu001", nullptr, c_status_eligible, c_grade_c);
-    registration_t::insert_row("reg002", "stu001", nullptr, c_status_eligible, c_grade_c);
+    student_t student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    registration_t::insert("reg001", "stu001", nullptr, c_status_eligible, c_grade_c);
+    registration_t::insert("reg002", "stu001", nullptr, c_status_eligible, c_grade_c);
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();

--- a/production/tools/gaia_translate/tests/test_insert_delete.cpp
+++ b/production/tools/gaia_translate/tests/test_insert_delete.cpp
@@ -131,42 +131,42 @@ protected:
         gaia::db::begin_transaction();
 
         // These must be EDC objects. They have insert() methods.
-        student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-        student_2 = student_t::get(student_t::insert_row("stu002", "Russell", 32, 4, 3.0));
-        student_3 = student_t::get(student_t::insert_row("stu003", "Reuben", 26, 4, 3.0));
-        student_4 = student_t::get(student_t::insert_row("stu004", "Rachael", 51, 4, 3.0));
-        student_5 = student_t::get(student_t::insert_row("stu005", "Renee", 65, 4, 3.0));
+        student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+        student_2 = student_t::get(student_t::insert("stu002", "Russell", 32, 4, 3.0));
+        student_3 = student_t::get(student_t::insert("stu003", "Reuben", 26, 4, 3.0));
+        student_4 = student_t::get(student_t::insert("stu004", "Rachael", 51, 4, 3.0));
+        student_5 = student_t::get(student_t::insert("stu005", "Renee", 65, 4, 3.0));
 
         // These must be EDC objects. They have insert() methods.
-        course_1 = course_t::get(course_t::insert_row("cou001", "math101", 3));
-        course_2 = course_t::get(course_t::insert_row("cou002", "math201", 4));
-        course_3 = course_t::get(course_t::insert_row("cou003", "eng101", 3));
-        course_4 = course_t::get(course_t::insert_row("cou004", "sci101", 3));
-        course_5 = course_t::get(course_t::insert_row("cou005", "math301", 5));
+        course_1 = course_t::get(course_t::insert("cou001", "math101", 3));
+        course_2 = course_t::get(course_t::insert("cou002", "math201", 4));
+        course_3 = course_t::get(course_t::insert("cou003", "eng101", 3));
+        course_4 = course_t::get(course_t::insert("cou004", "sci101", 3));
+        course_5 = course_t::get(course_t::insert("cou005", "math301", 5));
 
-        reg_1 = registration_t::get(registration_t::insert_row("reg001", c_status_pending, c_grade_none));
+        reg_1 = registration_t::get(registration_t::insert("reg001", c_status_pending, c_grade_none));
         // These are gaia_id_t.
-        auto reg_2 = registration_t::insert_row("reg002", c_status_eligible, c_grade_c);
-        auto reg_3 = registration_t::insert_row("reg003", c_status_eligible, c_grade_b);
-        auto reg_4 = registration_t::insert_row("reg004", c_status_eligible, c_grade_c);
-        auto reg_5 = registration_t::insert_row("reg005", c_status_eligible, c_grade_d);
-        auto reg_6 = registration_t::insert_row("reg006", c_status_pending, c_grade_none);
-        auto reg_7 = registration_t::insert_row("reg007", c_status_eligible, c_grade_c);
-        auto reg_8 = registration_t::insert_row("reg008", c_status_eligible, c_grade_b);
-        auto reg_9 = registration_t::insert_row("reg009", c_status_eligible, c_grade_b);
-        auto reg_A = registration_t::insert_row("reg00A", c_status_eligible, c_grade_a);
-        auto reg_B = registration_t::insert_row("reg00B", c_status_eligible, c_grade_b);
-        auto reg_C = registration_t::insert_row("reg00C", c_status_eligible, c_grade_b);
-        auto reg_D = registration_t::insert_row("reg00D", c_status_pending, c_grade_none);
-        auto reg_E = registration_t::insert_row("reg00E", c_status_eligible, c_grade_c);
-        auto reg_F = registration_t::insert_row("reg00F", c_status_eligible, c_grade_a);
-        auto reg_G = registration_t::insert_row("reg00G", c_status_eligible, c_grade_b);
+        auto reg_2 = registration_t::insert("reg002", c_status_eligible, c_grade_c);
+        auto reg_3 = registration_t::insert("reg003", c_status_eligible, c_grade_b);
+        auto reg_4 = registration_t::insert("reg004", c_status_eligible, c_grade_c);
+        auto reg_5 = registration_t::insert("reg005", c_status_eligible, c_grade_d);
+        auto reg_6 = registration_t::insert("reg006", c_status_pending, c_grade_none);
+        auto reg_7 = registration_t::insert("reg007", c_status_eligible, c_grade_c);
+        auto reg_8 = registration_t::insert("reg008", c_status_eligible, c_grade_b);
+        auto reg_9 = registration_t::insert("reg009", c_status_eligible, c_grade_b);
+        auto reg_A = registration_t::insert("reg00A", c_status_eligible, c_grade_a);
+        auto reg_B = registration_t::insert("reg00B", c_status_eligible, c_grade_b);
+        auto reg_C = registration_t::insert("reg00C", c_status_eligible, c_grade_b);
+        auto reg_D = registration_t::insert("reg00D", c_status_pending, c_grade_none);
+        auto reg_E = registration_t::insert("reg00E", c_status_eligible, c_grade_c);
+        auto reg_F = registration_t::insert("reg00F", c_status_eligible, c_grade_a);
+        auto reg_G = registration_t::insert("reg00G", c_status_eligible, c_grade_b);
 
         // These are gaia_id_t.
-        prereq_1 = prereq_t::get(prereq_t::insert_row("pre001", c_grade_c));
-        prereq_2 = prereq_t::get(prereq_t::insert_row("pre002", c_grade_d));
-        prereq_3 = prereq_t::get(prereq_t::insert_row("pre003", c_grade_c));
-        prereq_4 = prereq_t::get(prereq_t::insert_row("pre004", c_grade_c));
+        prereq_1 = prereq_t::get(prereq_t::insert("pre001", c_grade_c));
+        prereq_2 = prereq_t::get(prereq_t::insert("pre002", c_grade_d));
+        prereq_3 = prereq_t::get(prereq_t::insert("pre003", c_grade_c));
+        prereq_4 = prereq_t::get(prereq_t::insert("pre004", c_grade_c));
 
         student_1.registrations().insert(reg_1);
         student_1.registrations().insert(reg_2);
@@ -227,11 +227,11 @@ protected:
 TEST_F(test_insert_delete_code, implicit_delete)
 {
     gaia::db::begin_transaction();
-    auto student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    registration_t::insert_row("reg001", nullptr, nullptr, c_status_pending, c_grade_none);
-    registration_t::insert_row("reg002", nullptr, nullptr, c_status_eligible, c_grade_c);
-    registration_t::insert_row("reg003", nullptr, nullptr, c_status_eligible, c_grade_b);
-    registration_t::insert_row("reg004", nullptr, nullptr, c_status_eligible, c_grade_c);
+    auto student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    registration_t::insert("reg001", nullptr, nullptr, c_status_pending, c_grade_none);
+    registration_t::insert("reg002", nullptr, nullptr, c_status_eligible, c_grade_c);
+    registration_t::insert("reg003", nullptr, nullptr, c_status_eligible, c_grade_b);
+    registration_t::insert("reg004", nullptr, nullptr, c_status_eligible, c_grade_c);
     gaia::db::commit_transaction();
 
     // Use the rules for insert & delete.
@@ -241,7 +241,7 @@ TEST_F(test_insert_delete_code, implicit_delete)
     gaia::db::begin_transaction();
     auto sw = student_1.writer();
     sw.age = 46;
-    sw.update_row();
+    sw.update();
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -258,14 +258,14 @@ TEST_F(test_insert_delete_code, DISABLED_build_database)
     gaia::rules::subscribe_ruleset("test_insert_delete_2");
 
     gaia::db::begin_transaction();
-    enrollment_log_t::insert_row("stu001", "Wayne", 67, "cou001", "math101", 3, "reg001");
-    enrollment_log_t::insert_row("stu002", "William", 23, "cou002", "csci101", 5, "reg002");
-    enrollment_log_t::insert_row("stu003", "Ward", 56, "cou003", "math201", 3, "reg003");
-    enrollment_log_t::insert_row("stu004", "Walter", 65, "cou004", "engl101", 4, "reg004");
-    enrollment_log_t::insert_row("stu005", "Warren", 67, "cou005", "engl201", 3, "reg005");
-    enrollment_log_t::insert_row("stu006", "Waldo", 37, "cou006", "sosc101", 5, "reg006");
-    enrollment_log_t::insert_row("stu007", "Wilma", 44, "cou007", "sosc201", 5, "reg007");
-    enrollment_log_t::insert_row("stu008", "Wesley", 12, "cou086", "csci302", 5, "reg008");
+    enrollment_log_t::insert("stu001", "Wayne", 67, "cou001", "math101", 3, "reg001");
+    enrollment_log_t::insert("stu002", "William", 23, "cou002", "csci101", 5, "reg002");
+    enrollment_log_t::insert("stu003", "Ward", 56, "cou003", "math201", 3, "reg003");
+    enrollment_log_t::insert("stu004", "Walter", 65, "cou004", "engl101", 4, "reg004");
+    enrollment_log_t::insert("stu005", "Warren", 67, "cou005", "engl201", 3, "reg005");
+    enrollment_log_t::insert("stu006", "Waldo", 37, "cou006", "sosc101", 5, "reg006");
+    enrollment_log_t::insert("stu007", "Wilma", 44, "cou007", "sosc201", 5, "reg007");
+    enrollment_log_t::insert("stu008", "Wesley", 12, "cou086", "csci302", 5, "reg008");
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();

--- a/production/tools/gaia_translate/tests/test_mixed.ruleset
+++ b/production/tools/gaia_translate/tests/test_mixed.ruleset
@@ -11,20 +11,20 @@ extern int g_test_mixed_value;
 
 void f(gaia::barn_storage::incubator_t i)
 {
-    i.sensors().insert(sensor_t::insert_row("TestSensor1", 0, 0.0));
-    i.actuators().insert(actuator_t::insert_row("TestActuator1", 0, 0.0));
+    i.sensors().insert(sensor_t::insert("TestSensor1", 0, 0.0));
+    i.actuators().insert(actuator_t::insert("TestActuator1", 0, 0.0));
 }
 
 void f1(const gaia::barn_storage::incubator_t& i)
 {
-    i.sensors().insert(sensor_t::insert_row("TestSensor2", 0, 0.0));
-    i.actuators().insert(actuator_t::insert_row("TestActuator2", 0, 0.0));
+    i.sensors().insert(sensor_t::insert("TestSensor2", 0, 0.0));
+    i.actuators().insert(actuator_t::insert("TestActuator2", 0, 0.0));
 }
 
 void f2(gaia::barn_storage::incubator_t& i)
 {
-    i.sensors().insert(sensor_t::insert_row("TestSensor3", 0, 0.0));
-    i.actuators().insert(actuator_t::insert_row("TestActuator3", 0, 0.0));
+    i.sensors().insert(sensor_t::insert("TestSensor3", 0, 0.0));
+    i.actuators().insert(actuator_t::insert("TestActuator3", 0, 0.0));
 }
 
 ruleset test_mixed

--- a/production/tools/gaia_translate/tests/test_mixed_ruleset.cpp
+++ b/production/tools/gaia_translate/tests/test_mixed_ruleset.cpp
@@ -54,7 +54,7 @@ TEST_F(test_mixed_code, subscribe_valid_ruleset)
     gaia::db::begin_transaction();
 
     auto incubator = incubator_t::get(
-        incubator_t::insert_row(
+        incubator_t::insert(
             "TestIncubator",
             c_g_incubator_min_temperature,
             c_g_incubator_max_temperature));
@@ -85,8 +85,8 @@ TEST_F(test_mixed_code, insert_delete_row)
 {
     gaia::db::begin_transaction();
 
-    auto sensor = sensor_t::get(sensor_t::insert_row("TestSensor", 20210708, 98.6));
-    sensor.delete_row();
+    auto sensor = sensor_t::get(sensor_t::insert("TestSensor", 20210708, 98.6));
+    sensor.remove();
 
     g_test_mixed_value = 0;
     gaia::db::commit_transaction();

--- a/production/tools/gaia_translate/tests/test_queries.cpp
+++ b/production/tools/gaia_translate/tests/test_queries.cpp
@@ -111,24 +111,24 @@ protected:
     {
         gaia::db::begin_transaction();
 
-        student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-        student_t::get(student_t::insert_row("stu002", "Russell", 32, 4, 3.0));
-        student_t::get(student_t::insert_row("stu003", "Reuben", 26, 4, 3.0));
+        student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+        student_t::get(student_t::insert("stu002", "Russell", 32, 4, 3.0));
+        student_t::get(student_t::insert("stu003", "Reuben", 26, 4, 3.0));
 
-        course_t::get(course_t::insert_row("cou001", "math101", 3));
-        course_t::get(course_t::insert_row("cou002", "math201", 4));
-        course_t::get(course_t::insert_row("cou003", "eng101", 3));
-        course_t::get(course_t::insert_row("cou004", "sci101", 3));
-        course_t::get(course_t::insert_row("cou005", "math301", 5));
+        course_t::get(course_t::insert("cou001", "math101", 3));
+        course_t::get(course_t::insert("cou002", "math201", 4));
+        course_t::get(course_t::insert("cou003", "eng101", 3));
+        course_t::get(course_t::insert("cou004", "sci101", 3));
+        course_t::get(course_t::insert("cou005", "math301", 5));
 
-        registration_t::insert_row("reg001", "stu001", "cou002", c_status_pending, c_grade_none);
-        registration_t::insert_row("reg002", "stu001", "cou004", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg003", "stu002", "cou001", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg004", "stu002", "cou003", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg005", "stu002", "cou004", c_status_eligible, c_grade_d);
-        registration_t::insert_row("reg006", "stu003", "cou005", c_status_pending, c_grade_none);
-        registration_t::insert_row("reg007", "stu003", "cou002", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg008", "stu003", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg001", "stu001", "cou002", c_status_pending, c_grade_none);
+        registration_t::insert("reg002", "stu001", "cou004", c_status_eligible, c_grade_c);
+        registration_t::insert("reg003", "stu002", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg004", "stu002", "cou003", c_status_eligible, c_grade_c);
+        registration_t::insert("reg005", "stu002", "cou004", c_status_eligible, c_grade_d);
+        registration_t::insert("reg006", "stu003", "cou005", c_status_pending, c_grade_none);
+        registration_t::insert("reg007", "stu003", "cou002", c_status_eligible, c_grade_c);
+        registration_t::insert("reg008", "stu003", "cou001", c_status_eligible, c_grade_b);
         gaia::db::commit_transaction();
     }
 
@@ -137,42 +137,42 @@ protected:
         gaia::db::begin_transaction();
 
         // These must be EDC objects. They have insert() methods.
-        student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-        student_2 = student_t::get(student_t::insert_row("stu002", "Russell", 32, 4, 3.0));
-        student_3 = student_t::get(student_t::insert_row("stu003", "Reuben", 26, 4, 3.0));
-        student_4 = student_t::get(student_t::insert_row("stu004", "Rachael", 51, 4, 3.0));
-        student_5 = student_t::get(student_t::insert_row("stu005", "Renee", 65, 4, 3.0));
+        student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+        student_2 = student_t::get(student_t::insert("stu002", "Russell", 32, 4, 3.0));
+        student_3 = student_t::get(student_t::insert("stu003", "Reuben", 26, 4, 3.0));
+        student_4 = student_t::get(student_t::insert("stu004", "Rachael", 51, 4, 3.0));
+        student_5 = student_t::get(student_t::insert("stu005", "Renee", 65, 4, 3.0));
 
         // These must be EDC objects. They have insert() methods.
-        course_1 = course_t::get(course_t::insert_row("cou001", "math101", 3));
-        course_2 = course_t::get(course_t::insert_row("cou002", "math201", 4));
-        course_3 = course_t::get(course_t::insert_row("cou003", "eng101", 3));
-        course_4 = course_t::get(course_t::insert_row("cou004", "sci101", 3));
-        course_5 = course_t::get(course_t::insert_row("cou005", "math301", 5));
+        course_1 = course_t::get(course_t::insert("cou001", "math101", 3));
+        course_2 = course_t::get(course_t::insert("cou002", "math201", 4));
+        course_3 = course_t::get(course_t::insert("cou003", "eng101", 3));
+        course_4 = course_t::get(course_t::insert("cou004", "sci101", 3));
+        course_5 = course_t::get(course_t::insert("cou005", "math301", 5));
 
-        reg_1 = registration_t::get(registration_t::insert_row("reg001", "stu001", "cou002", c_status_pending, c_grade_none));
+        reg_1 = registration_t::get(registration_t::insert("reg001", "stu001", "cou002", c_status_pending, c_grade_none));
         // These are gaia_id_t.
-        registration_t::insert_row("reg002", "stu001", "cou004", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg003", "stu002", "cou001", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg004", "stu002", "cou003", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg005", "stu002", "cou004", c_status_eligible, c_grade_d);
-        registration_t::insert_row("reg006", "stu003", "cou005", c_status_pending, c_grade_none);
-        registration_t::insert_row("reg007", "stu003", "cou002", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg008", "stu003", "cou001", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg009", "stu003", "cou003", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg00A", "stu003", "cou004", c_status_eligible, c_grade_a);
-        registration_t::insert_row("reg00B", "stu004", "cou004", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg00C", "stu004", "cou001", c_status_eligible, c_grade_b);
-        registration_t::insert_row("reg00D", "stu005", "cou002", c_status_pending, c_grade_none);
-        registration_t::insert_row("reg00E", "stu005", "cou003", c_status_eligible, c_grade_c);
-        registration_t::insert_row("reg00F", "stu005", "cou004", c_status_eligible, c_grade_a);
-        registration_t::insert_row("reg00G", "stu005", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg002", "stu001", "cou004", c_status_eligible, c_grade_c);
+        registration_t::insert("reg003", "stu002", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg004", "stu002", "cou003", c_status_eligible, c_grade_c);
+        registration_t::insert("reg005", "stu002", "cou004", c_status_eligible, c_grade_d);
+        registration_t::insert("reg006", "stu003", "cou005", c_status_pending, c_grade_none);
+        registration_t::insert("reg007", "stu003", "cou002", c_status_eligible, c_grade_c);
+        registration_t::insert("reg008", "stu003", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg009", "stu003", "cou003", c_status_eligible, c_grade_b);
+        registration_t::insert("reg00A", "stu003", "cou004", c_status_eligible, c_grade_a);
+        registration_t::insert("reg00B", "stu004", "cou004", c_status_eligible, c_grade_b);
+        registration_t::insert("reg00C", "stu004", "cou001", c_status_eligible, c_grade_b);
+        registration_t::insert("reg00D", "stu005", "cou002", c_status_pending, c_grade_none);
+        registration_t::insert("reg00E", "stu005", "cou003", c_status_eligible, c_grade_c);
+        registration_t::insert("reg00F", "stu005", "cou004", c_status_eligible, c_grade_a);
+        registration_t::insert("reg00G", "stu005", "cou001", c_status_eligible, c_grade_b);
 
         // These are gaia_id_t.
-        auto prereq_1 = prereq_t::get(prereq_t::insert_row("pre001", c_grade_c));
-        auto prereq_2 = prereq_t::get(prereq_t::insert_row("pre002", c_grade_d));
-        auto prereq_3 = prereq_t::get(prereq_t::insert_row("pre003", c_grade_c));
-        auto prereq_4 = prereq_t::get(prereq_t::insert_row("pre004", c_grade_c));
+        auto prereq_1 = prereq_t::get(prereq_t::insert("pre001", c_grade_c));
+        auto prereq_2 = prereq_t::get(prereq_t::insert("pre002", c_grade_d));
+        auto prereq_3 = prereq_t::get(prereq_t::insert("pre003", c_grade_c));
+        auto prereq_4 = prereq_t::get(prereq_t::insert("pre004", c_grade_c));
 
         course_2.requires().insert(prereq_1);
         course_1.required_by().insert(prereq_1);
@@ -204,7 +204,7 @@ TEST_F(test_queries_code, basic_implicit_navigation)
     auto s = student_t::list().where(surname == "Richard").begin();
     auto sw = s->writer();
     sw.age = 46;
-    sw.update_row();
+    sw.update();
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -225,7 +225,7 @@ TEST_F(test_queries_code, implicit_navigation_fork)
     auto r = registration_t::list().where(reg_id == "reg003").begin();
     auto rw = r->writer();
     rw.grade = c_grade_c;
-    rw.update_row();
+    rw.update();
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -249,16 +249,16 @@ TEST_F(test_queries_code, new_registration)
     gaia::db::begin_transaction();
 
     // Richard registers for math301
-    auto reg = registration_t::insert_row("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
+    auto reg = registration_t::insert("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
 
     // Russell registers for math201.
-    reg = registration_t::insert_row("reg00I", "stu002", "cou002", c_status_pending, c_grade_none);
+    reg = registration_t::insert("reg00I", "stu002", "cou002", c_status_pending, c_grade_none);
 
     // Rachael register for eng101.
-    reg = registration_t::insert_row("reg00K", "stu004", "cou003", c_status_pending, c_grade_none);
+    reg = registration_t::insert("reg00K", "stu004", "cou003", c_status_pending, c_grade_none);
 
     // Renee registers for math301
-    reg = registration_t::insert_row("reg00L", "stu005", "cou005", c_status_pending, c_grade_none);
+    reg = registration_t::insert("reg00L", "stu005", "cou005", c_status_pending, c_grade_none);
 
     gaia::db::commit_transaction();
 
@@ -279,7 +279,7 @@ TEST_F(test_queries_code, sum_of_ages)
     // Fire on_insert(student). Expect to see a sum of all student ages.
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
 
     gaia::db::commit_transaction();
 
@@ -299,7 +299,7 @@ TEST_F(test_queries_code, sum_of_hours)
     // on_insert(registration) will sum up the student's hours.
     gaia::db::begin_transaction();
 
-    registration_t::insert_row("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
+    registration_t::insert("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
 
     gaia::db::commit_transaction();
 
@@ -319,7 +319,7 @@ TEST_F(test_queries_code, sum_of_all_hours)
     // on_insert(registration) will sum up the student's hours.
     gaia::db::begin_transaction();
 
-    registration_t::insert_row("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
+    registration_t::insert("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
 
     gaia::db::commit_transaction();
 
@@ -339,7 +339,7 @@ TEST_F(test_queries_code, tag_define_use)
     // on_insert(registration) will sum up the student's hours.
     gaia::db::begin_transaction();
 
-    registration_t::insert_row("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
+    registration_t::insert("reg00H", "stu001", "cou005", c_status_pending, c_grade_none);
 
     gaia::db::commit_transaction();
 
@@ -380,7 +380,7 @@ TEST_F(test_queries_code, if_stmt)
     // on_insert(registration) will sum up the student's hours.
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
 
     gaia::db::commit_transaction();
 
@@ -406,7 +406,7 @@ TEST_F(test_queries_code, if_stmt2)
 
     auto cw = course_1.writer();
     cw.hours = num_updates;
-    cw.update_row();
+    cw.update();
 
     gaia::db::commit_transaction();
 
@@ -431,7 +431,7 @@ TEST_F(test_queries_code, if_stmt3)
 
     auto rw = reg_1.writer();
     rw.grade = c_grade_d;
-    rw.update_row();
+    rw.update();
 
     gaia::db::commit_transaction();
 
@@ -453,7 +453,7 @@ TEST_F(test_queries_code, nomatch_stmt)
 
     auto sw = student_1.writer();
     sw.gpa = 3.5;
-    sw.update_row();
+    sw.update();
 
     gaia::db::commit_transaction();
 
@@ -474,7 +474,7 @@ TEST_F(test_queries_code, nomatch_stmt2)
     g_string_value = "";
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
 
     gaia::db::commit_transaction();
 
@@ -495,8 +495,8 @@ TEST_F(test_queries_code, nomatch_stmt3)
     g_string_value = "";
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
-    registration_t::insert_row("reg00H", "stu006", nullptr, c_status_eligible, c_grade_c);
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
+    registration_t::insert("reg00H", "stu006", nullptr, c_status_eligible, c_grade_c);
 
     gaia::db::commit_transaction();
 
@@ -517,7 +517,7 @@ TEST_F(test_queries_code, nomatch_stmt4)
     g_string_value = "";
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
 
     gaia::db::commit_transaction();
 
@@ -537,9 +537,9 @@ TEST_F(test_queries_code, nomatch_function_query)
     g_string_value = "";
     gaia::db::begin_transaction();
 
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
-    auto registration = registration_t::insert_row("reg00H", "stu006", "cou001", c_status_eligible, c_grade_c);
-    registration = registration_t::insert_row("reg00I", "stu006", "cou002", c_status_eligible, c_grade_d);
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
+    auto registration = registration_t::insert("reg00H", "stu006", "cou001", c_status_eligible, c_grade_c);
+    registration = registration_t::insert("reg00I", "stu006", "cou002", c_status_eligible, c_grade_d);
 
     gaia::db::commit_transaction();
 
@@ -553,16 +553,16 @@ TEST_F(test_queries_code, nomatch_function_query)
 TEST_F(test_queries_code, one_to_one)
 {
     gaia::db::begin_transaction();
-    student_1 = student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    student_2 = student_t::get(student_t::insert_row("stu002", "Russell", 32, 4, 3.0));
-    student_3 = student_t::get(student_t::insert_row("stu003", "Reuben", 26, 4, 3.0));
-    student_4 = student_t::get(student_t::insert_row("stu004", "Rachael", 51, 4, 3.0));
-    student_5 = student_t::get(student_t::insert_row("stu005", "Renee", 65, 4, 3.0));
+    student_1 = student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    student_2 = student_t::get(student_t::insert("stu002", "Russell", 32, 4, 3.0));
+    student_3 = student_t::get(student_t::insert("stu003", "Reuben", 26, 4, 3.0));
+    student_4 = student_t::get(student_t::insert("stu004", "Rachael", 51, 4, 3.0));
+    student_5 = student_t::get(student_t::insert("stu005", "Renee", 65, 4, 3.0));
 
     // Create and connect 1:1 parents for 3 of the students.
-    auto parents_1 = parents_t::get(parents_t::insert_row("Lawrence", "Elizabeth"));
-    auto parents_2 = parents_t::get(parents_t::insert_row("Clarence", "Pauline"));
-    auto parents_3 = parents_t::get(parents_t::insert_row("George", "Irvie"));
+    auto parents_1 = parents_t::get(parents_t::insert("Lawrence", "Elizabeth"));
+    auto parents_2 = parents_t::get(parents_t::insert("Clarence", "Pauline"));
+    auto parents_3 = parents_t::get(parents_t::insert("George", "Irvie"));
 
     student_1.parents().connect(parents_1);
     student_3.parents().connect(parents_2);
@@ -573,7 +573,7 @@ TEST_F(test_queries_code, one_to_one)
 
     g_string_value = "";
     gaia::db::begin_transaction();
-    auto student = student_t::get(student_t::insert_row("stu006", "Paul", 62, 4, 3.3));
+    auto student = student_t::get(student_t::insert("stu006", "Paul", 62, 4, 3.3));
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();

--- a/production/tools/gaia_translate/tests/test_rulesets.ruleset
+++ b/production/tools/gaia_translate/tests/test_rulesets.ruleset
@@ -578,7 +578,7 @@ ruleset test_connect_1_n
 
         gaia::prerequisites::registration_writer w;
         w.reg_id = "reg003";
-        gaia::prerequisites::registration_t r4 = gaia::prerequisites::registration_t::get(w.insert_row());
+        gaia::prerequisites::registration_t r4 = gaia::prerequisites::registration_t::get(w.insert());
         student.connect(r4);
         student.registrations.connect(r4);
 
@@ -601,7 +601,7 @@ ruleset test_connect_1_1
             gaia::prerequisites::parents_writer w;
             w.name_father = "John";
             w.name_mother = "Jane";
-            auto p = gaia::prerequisites::parents_t::get(w.insert_row());
+            auto p = gaia::prerequisites::parents_t::get(w.insert());
             student.parents.connect(p);
         }
     }

--- a/production/tools/gaia_translate/tests/test_serial.cpp
+++ b/production/tools/gaia_translate/tests/test_serial.cpp
@@ -123,8 +123,8 @@ public:
     void init_storage()
     {
         gaia::db::begin_transaction();
-        gaia::barn_storage::incubator_t::insert_row("TestIncubator", c_g_incubator_min_temperature, c_g_incubator_max_temperature);
-        gaia::barn_storage::sensor_t::insert_row("TestSensor", c_g_sensor_timestamp, c_g_sensor_value);
+        gaia::barn_storage::incubator_t::insert("TestIncubator", c_g_incubator_min_temperature, c_g_incubator_max_temperature);
+        gaia::barn_storage::sensor_t::insert("TestSensor", c_g_sensor_timestamp, c_g_sensor_value);
         gaia::db::commit_transaction();
     }
 

--- a/production/tools/gaia_translate/tests/test_tags.cpp
+++ b/production/tools/gaia_translate/tests/test_tags.cpp
@@ -95,7 +95,7 @@ TEST_F(test_tags_code, oninsert)
 
     // Creating a record should fire on_insert and on_change, but not on_update.
     gaia::db::begin_transaction();
-    auto student = student_t::get(student_t::insert_row("stu001", "Warren", 66, 3, 2.9));
+    auto student = student_t::get(student_t::insert("stu001", "Warren", 66, 3, 2.9));
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -125,7 +125,7 @@ TEST_F(test_tags_code, oninsert)
 TEST_F(test_tags_code, onchange)
 {
     gaia::db::begin_transaction();
-    auto student = student_t::get(student_t::insert_row("stu001", "Warren", 66, 3, 2.9));
+    auto student = student_t::get(student_t::insert("stu001", "Warren", 66, 3, 2.9));
     gaia::db::commit_transaction();
 
     // Use the first set of rules.
@@ -135,7 +135,7 @@ TEST_F(test_tags_code, onchange)
     gaia::db::begin_transaction();
     auto sw = student.writer();
     sw.surname = "Hawkins";
-    sw.update_row();
+    sw.update();
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -168,7 +168,7 @@ TEST_F(test_tags_code, onchange)
 TEST_F(test_tags_code, onupdate)
 {
     gaia::db::begin_transaction();
-    auto student = student_t::get(student_t::insert_row("stu001", "Warren", 66, 3, 2.9));
+    auto student = student_t::get(student_t::insert("stu001", "Warren", 66, 3, 2.9));
     gaia::db::commit_transaction();
 
     // Use the first set of rules.
@@ -178,7 +178,7 @@ TEST_F(test_tags_code, onupdate)
     gaia::db::begin_transaction();
     auto sw = student.writer();
     sw.age = 45;
-    sw.update_row();
+    sw.update();
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -219,11 +219,11 @@ TEST_F(test_tags_code, multi_inserts)
     gaia::rules::subscribe_ruleset("test_tags");
 
     gaia::db::begin_transaction();
-    student_t::get(student_t::insert_row("stu001", "Richard", 45, 4, 3.0));
-    student_t::get(student_t::insert_row("stu002", "Russell", 32, 4, 3.0));
-    student_t::get(student_t::insert_row("stu003", "Reuben", 26, 4, 3.0));
-    student_t::get(student_t::insert_row("stu004", "Rachael", 51, 4, 3.0));
-    student_t::get(student_t::insert_row("stu005", "Renee", 65, 4, 3.0));
+    student_t::get(student_t::insert("stu001", "Richard", 45, 4, 3.0));
+    student_t::get(student_t::insert("stu002", "Russell", 32, 4, 3.0));
+    student_t::get(student_t::insert("stu003", "Reuben", 26, 4, 3.0));
+    student_t::get(student_t::insert("stu004", "Rachael", 51, 4, 3.0));
+    student_t::get(student_t::insert("stu005", "Renee", 65, 4, 3.0));
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();
@@ -238,7 +238,7 @@ TEST_F(test_tags_code, basic_tags)
     gaia::rules::subscribe_ruleset("test_tags");
 
     gaia::db::begin_transaction();
-    registration_t::insert_row("reg00H", nullptr, nullptr, c_status_pending, c_grade_none);
+    registration_t::insert("reg00H", nullptr, nullptr, c_status_pending, c_grade_none);
     gaia::db::commit_transaction();
 
     gaia::rules::test::wait_for_rules_to_complete();

--- a/production/tools/gaia_translate/tests/test_translation_engine.cpp
+++ b/production/tools/gaia_translate/tests/test_translation_engine.cpp
@@ -43,15 +43,15 @@ public:
         w.name = name;
         w.min_temp = min_temp;
         w.max_temp = max_temp;
-        return w.insert_row();
+        return w.insert();
     }
 
     void init_storage()
     {
         gaia::db::begin_transaction();
         auto incubator = gaia::barn_storage::incubator_t::get(insert_incubator("TestIncubator", c_g_incubator_min_temperature, c_g_incubator_max_temperature));
-        incubator.sensors().insert(gaia::barn_storage::sensor_t::insert_row("TestSensor1", 0, 0.0));
-        incubator.actuators().insert(gaia::barn_storage::actuator_t::insert_row("TestActuator1", 0, 0.0));
+        incubator.sensors().insert(gaia::barn_storage::sensor_t::insert("TestSensor1", 0, 0.0));
+        incubator.actuators().insert(gaia::barn_storage::actuator_t::insert("TestActuator1", 0, 0.0));
         gaia::db::commit_transaction();
     }
 
@@ -117,7 +117,7 @@ TEST_F(translation_engine_test, subscribe_valid_ruleset)
     {
         auto w = s.writer();
         w.value = c_g_expected_sensor_value;
-        w.update_row();
+        w.update();
     }
     gaia::db::commit_transaction();
 
@@ -156,7 +156,7 @@ TEST_F(translation_engine_test, subscribe_valid_ruleset)
 
     gaia::db::begin_transaction();
 
-    auto s_id = gaia::barn_storage::sensor_t::insert_row("TestSensor2", 0, 0.0);
+    auto s_id = gaia::barn_storage::sensor_t::insert("TestSensor2", 0, 0.0);
     auto incubator = *(gaia::barn_storage::incubator_t::list().begin());
     incubator.sensors().insert(s_id);
     gaia::db::commit_transaction();
@@ -174,7 +174,7 @@ TEST_F(translation_engine_test, subscribe_valid_ruleset)
 
     auto s = gaia::barn_storage::sensor_t::get(s_id);
     s.incubator().sensors().remove(s);
-    s.delete_row();
+    s.remove();
 
     gaia::db::commit_transaction();
 }

--- a/production/tools/tests/gaiat/integration_test.ruleset
+++ b/production/tools/tests/gaiat/integration_test.ruleset
@@ -68,7 +68,7 @@ ruleset test6 : tables(sensor)
 class test
 {
 public:
-    void delete_row()
+    void remove()
     {
     }
 };
@@ -82,7 +82,7 @@ ruleset test7
         if (sensor.value == 5)
         {
             test t;
-            t.delete_row();
+            t.remove();
         }
     }
 }

--- a/production/tools/tests/ping_pong/ping_pong.cpp
+++ b/production/tools/tests/ping_pong/ping_pong.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     gaia_log::app().info("Starting Ping Pong example with {} workers.", num_workers);
 
     gaia::db::begin_transaction();
-    auto ping_pong_id = ping_pong_t::insert_row(c_pong);
+    auto ping_pong_id = ping_pong_t::insert(c_pong);
     gaia::db::commit_transaction();
 
     vector<thread> workers;
@@ -111,7 +111,7 @@ void worker(gaia::common::gaia_id_t ping_pong_id)
                 gaia_log::app().info("Main:'{}'->'{}' iteration:'{}' txn_id:'{}'", ping_pong.status(), c_ping, iteration_count, txn_id);
                 auto ping_pong_writer = ping_pong.writer();
                 ping_pong_writer.status = c_ping;
-                ping_pong_writer.update_row();
+                ping_pong_writer.update();
             }
             gaia::db::commit_transaction();
         }

--- a/third_party/production/flatbuffers/src/idl_gen_gaia_cpp.cpp
+++ b/third_party/production/flatbuffers/src/idl_gen_gaia_cpp.cpp
@@ -531,17 +531,17 @@ namespace flatbuffers
                 }
 
                 code_ += 
-                    "using edc_object_t::insert_row;";
+                    "using edc_object_t::insert;";
 
                 // If the flatbuffer has a string or vector column then 
                 // generate a call to Create{{STRUCT_NAME}}Direct.  Otherwise 
                 // just generate Create{{STRUCT_NAME}}.
                 code_.SetValue("CREATE_SUFFIX", 
                     has_string_or_vector_fields ? "Direct" : "");
-                code_ += "static gaia_id_t insert_row (" + params + "){\n"
+                code_ += "static gaia_id_t insert (" + params + "){\n"
                     "flatbuffers::FlatBufferBuilder b(128);\n"
                     "b.Finish(Create{{STRUCT_NAME}}{{CREATE_SUFFIX}}(b, " + param_Values + "));\n"
-                    "return edc_object_t::insert_row(b);\n"
+                    "return edc_object_t::insert(b);\n"
                     "}";
 
                 code_ += "private:";


### PR DESCRIPTION
Change
- `insert_row()` -> `insert()`
- `delete_row()` -> `remove()`
- `update_row()` -> `update()`

http://segate2:8111/buildConfiguration/GaiaPlatform_ProductionGaiaLLVMTestsGdev/16506