### PR TITLE
Make LLD linker flags GCC-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export CXX=/usr/bin/clang++-10
 Additionally, the build system expects the LLVM linker `ld.lld` to be present in your `PATH` and to resolve to the `ld.lld-10` executable. You can ensure this by installing the `lld-10` package on Debian-derived systems (such as Ubuntu) and adding the following line to your `.bashrc`:
 
 ```
-export LDFLAGS=-fuse-ld=lld-10
+export LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 ```
 
 ## Folder structuring
@@ -181,18 +181,18 @@ When we are ready to release a new version of Gaia this is the process to follow
 1. Ensure you are on `master` and have the latest changed:
    ```shell
    git checkout master
-   git pull 
+   git pull
    ```
 2. Bump the project version in the [production/CMakeLists.txt](production/CMakeLists.txt) according to Semantic Versioning 2.0 spec. Note that Major version bumps should involve consultation with a number of folks across the team.
    ```cmake
-   # From 
+   # From
    project(production VERSION 0.2.5)
    # To
    project(production VERSION 0.3.0)
    ```
 3. Change, if necessary, the `PRE_RELEASE_IDENTIFIER` in the [production/CMakeLists.txt](production/CMakeLists.txt). For GA releases leave the `PRE_RELEASE_IDENTIFIER` empty.
    ```cmake
-   # From  
+   # From
    set(PRE_RELEASE_IDENTIFIER "alpha")
    # To
    set(PRE_RELEASE_IDENTIFIER "beta")

--- a/dev_tools/sdk/test/Dockerfile_gaia_sdk_18
+++ b/dev_tools/sdk/test/Dockerfile_gaia_sdk_18
@@ -14,7 +14,7 @@ COPY $gaia_sdk_deb .
 ENV CC=/usr/bin/clang-10
 ENV CPP=/usr/bin/clang-cpp-10
 ENV CXX=/usr/bin/clang++-10
-ENV LDFLAGS=-fuse-ld=lld-10
+ENV LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 
 RUN apt-get update \
     && apt-get install -y ./$gaia_sdk_deb

--- a/dev_tools/sdk/test/Dockerfile_gaia_sdk_20
+++ b/dev_tools/sdk/test/Dockerfile_gaia_sdk_20
@@ -14,7 +14,7 @@ COPY $gaia_sdk_deb .
 ENV CC=/usr/bin/clang-10
 ENV CPP=/usr/bin/clang-cpp-10
 ENV CXX=/usr/bin/clang++-10
-ENV LDFLAGS=-fuse-ld=lld-10
+ENV LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 
 RUN apt-get update \
     && apt-get install -y ./$gaia_sdk_deb

--- a/dev_tools/sdk/test/Dockerfile_gaia_ubuntu_18
+++ b/dev_tools/sdk/test/Dockerfile_gaia_ubuntu_18
@@ -17,7 +17,7 @@ RUN apt-get update \
 ENV CC=/usr/bin/clang-10
 ENV CPP=/usr/bin/clang-cpp-10
 ENV CXX=/usr/bin/clang++-10
-ENV LDFLAGS=-fuse-ld=lld-10
+ENV LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 
 # Install newer version of cmake than is available by default on Ubuntu 18.04.
 RUN mkdir ~/temp \

--- a/production/examples/hello/README.md
+++ b/production/examples/hello/README.md
@@ -21,7 +21,7 @@ You can also build this code with the `cmake` and `make` tools, by using the inc
 export CC=/usr/bin/clang-10
 export CPP=/usr/bin/clang-cpp-10
 export CXX=/usr/bin/clang++-10
-export LDFLAGS=-fuse-ld=lld-10
+export LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 ```
 
 The steps for the cmake build are:

--- a/third_party/production/cmake/gdev.cfg
+++ b/third_party/production/cmake/gdev.cfg
@@ -16,7 +16,7 @@ lld-10
 CC=/usr/bin/clang-10
 CPP=/usr/bin/clang-cpp-10
 CXX=/usr/bin/clang++-10
-LDFLAGS=-fuse-ld=lld-10
+LDFLAGS="-B/usr/lib/llvm-10/bin/ -fuse-ld=lld"
 
 [pre_run]
 # This ensures that the LLVM toolchain works as expected.

--- a/third_party/production/libexplain/gdev.cfg
+++ b/third_party/production/libexplain/gdev.cfg
@@ -15,14 +15,7 @@ third_party/production/bison
 [run]
 cd libexplain
 QUILT_PATCHES=debian/patches quilt push -a
-# The configure script used by the libexplain build doesn't seem to respect the
-# set value of CC as the linker frontend in libtool link mode, so we end up
-# passing LDFLAGS=-fuse-ld=lld-10 to gcc, which doesn't like it because it's
-# not in the canonical form -fuse-ld=bfd|gold|lld. Clang has no problem with
-# -fuse-ld=lld-10, but we need to make gcc happy, so we rely on the fact that
-# we've already symlinked ld.lld to ld.lld-10 and pass LDFLAGS=-fuse-ld=lld to
-# configure instead.
-CPPFLAGS='-fPIC' ./configure LDFLAGS=-fuse-ld=lld --prefix=/usr
+CPPFLAGS='-fPIC' ./configure --prefix=/usr
 make -j$(nproc)
 make install
 cd ..


### PR DESCRIPTION
This is the main incompatible option with GCC, so removing it brings us one step closer to compatibility. Also, this allowed me to remove a hack in the libexplain build (which requires gcc compatibility because of a broken configure script).