### PR TITLE
Switch DB context after creation

### DIFF
--- a/production/catalog/src/ddl_execution.cpp
+++ b/production/catalog/src/ddl_execution.cpp
@@ -385,10 +385,6 @@ void execute_create_list_statements(
     {
         auto create_stmt = dynamic_cast<ddl::create_statement_t*>(stmt.get());
         execute_create_statement_no_txn(executor, create_stmt);
-        if (create_stmt->type == ddl::create_type_t::create_database)
-        {
-            executor.switch_db_context(create_stmt->name);
-        }
     }
     txn.commit();
 }

--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -306,10 +306,7 @@ gaia_id_t ddl_executor_t::create_database(const string& name, bool throw_on_exis
 
     gaia_log::catalog().debug("Created database '{}', id:'{}'", name, id);
 
-    if (auto_drop)
-    {
-        switch_db_context(name);
-    }
+    switch_db_context(name);
 
     return id;
 }

--- a/production/catalog/tests/test_ddl_executor.cpp
+++ b/production/catalog/tests/test_ddl_executor.cpp
@@ -95,7 +95,7 @@ TEST_F(ddl_executor_test, create_database)
 
 TEST_F(ddl_executor_test, create_table)
 {
-    string test_db_name{"create_database_test"};
+    string test_db_name{"test_db"};
     create_database(test_db_name);
 
     string test_table_name{"create_table_test"};
@@ -104,8 +104,7 @@ TEST_F(ddl_executor_test, create_table)
     gaia_id_t table_id = create_table(test_table_name, fields);
     check_table_name(table_id, test_table_name);
 
-    table_id = create_table(test_db_name, test_table_name, fields);
-    check_table_name(table_id, test_table_name);
+    ASSERT_THROW(create_table(test_db_name, test_table_name, fields), table_already_exists);
 }
 
 TEST_F(ddl_executor_test, create_existing_table)


### PR DESCRIPTION
This should address @vDonGlover 's concern in https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1240

Users won't need to type `use` statement after DB creation. So there will be no chance for typos. If they want to switch to some existing db context, they will need to explicitly type `use`. In such cases, there will be no excuse for typos. 