### PR TITLE
Install libstdc++ headers on non-Debug builds

### DIFF
--- a/production/sdk/CMakeLists.txt
+++ b/production/sdk/CMakeLists.txt
@@ -66,7 +66,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   # We only link libc++ in Debug builds.
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-10,lld-10,libc++-10-dev,libc++abi-10-dev")
 else()
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-10,lld-10")
+  # We use libstdc++ in Release builds for compatibility with other software
+  # built with libstdc++ (which is the default stdlib in both gcc and clang).
+  # GCC 9 is installed by default on Ubuntu 20.04 with the build-essential
+  # package, so we try to be compatible with that.
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-10,lld-10,libstdc++-9-dev")
 endif(CMAKE_BUILD_TYPE)
 
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)


### PR DESCRIPTION
The SDK CI job is failing because I forgot to explicitly install `libstdc++` headers after I removed `libc++` from non-Debug builds. This change installs the `libstdc++` development package with non-Debug SDK builds. We use the version compatible with GCC 9 since that's the default GCC version in the `build-essential` package for Ubuntu 20.04 (the only Ubuntu release we officially support).

I tested this change on a release SDK, but that doesn't mean much since my gdev container is so heavily modified. I'll just have to see what happens when this hits CI.