### PR TITLE
Do not link libc++ in SDK samples except in Debug builds

### DIFF
--- a/dev_tools/sdk/test/build_sdk_samples.sh
+++ b/dev_tools/sdk/test/build_sdk_samples.sh
@@ -8,9 +8,12 @@
 # Exit the script as soon as any line fails.
 set -e
 
-gaia_db_server &
+# Start the db server.
+gaia_db_server --reset-data-store &
+sleep 1
 
 # Make incubator example.
+rm -rf ./incubator
 cp -r /opt/gaia/examples/incubator .
 pushd incubator
 mkdir build
@@ -20,10 +23,13 @@ make
 popd
 popd
 
-
 # Make and execute Hello World example.
+rm -rf ./hello
 cp -r /opt/gaia/examples/hello .
 pushd hello
 ./build.sh
 ./run.sh
 popd
+
+# Stop the db server.
+pkill -f gaia_db_server

--- a/production/examples/default/CMakeLists.txt
+++ b/production/examples/default/CMakeLists.txt
@@ -19,11 +19,13 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 # Default compiler/linker flags.
-add_compile_options(-c -Wall -Wextra -stdlib=libc++)
-add_link_options(-stdlib=libc++)
+add_compile_options(-Wall -Wextra)
 
 # Debug build-specific options.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # We build the SDK with libc++ in debug mode.
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++)
   add_compile_options(-O0 -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf)
   if("$CACHE{SANITIZER}" STREQUAL "ASAN")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)

--- a/production/examples/hello/CMakeLists.txt
+++ b/production/examples/hello/CMakeLists.txt
@@ -19,11 +19,13 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 # Default compiler/linker flags.
-add_compile_options(-c -Wall -Wextra -stdlib=libc++)
-add_link_options(-stdlib=libc++)
+add_compile_options(-Wall -Wextra)
 
 # Debug build-specific options.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # We build the SDK with libc++ in debug mode.
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++)
   add_compile_options(-O0 -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf)
   if("$CACHE{SANITIZER}" STREQUAL "ASAN")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)

--- a/production/examples/hello/build.sh
+++ b/production/examples/hello/build.sh
@@ -9,4 +9,4 @@ gaiac -g hello.ddl -d hello -o .
 
 gaiat hello.ruleset -output hello_ruleset.cpp -- -I /usr/lib/clang/10/include -I /opt/gaia/include
 
-clang++-10 hello.cpp hello_ruleset.cpp gaia_hello.cpp /usr/local/lib/libgaia.so -I /opt/gaia/include -Wl,-rpath,/usr/local/lib -lpthread -stdlib=libc++ -o hello
+clang++-10 hello.cpp hello_ruleset.cpp gaia_hello.cpp /usr/local/lib/libgaia.so -I /opt/gaia/include -Wl,-rpath,/usr/local/lib -lpthread -o hello

--- a/production/examples/incubator/CMakeLists.txt
+++ b/production/examples/incubator/CMakeLists.txt
@@ -16,11 +16,13 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 # Default compiler/linker flags.
-add_compile_options(-c -Wall -Wextra -stdlib=libc++)
-add_link_options(-stdlib=libc++)
+add_compile_options(-Wall -Wextra)
 
 # Debug build-specific options.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # We build the SDK with libc++ in debug mode.
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++)
   add_compile_options(-O0 -g3 -ggdb -fno-limit-debug-info -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf)
   if(SANITIZER STREQUAL "ASAN")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)

--- a/production/tests/workloads/mink/CMakeLists.txt
+++ b/production/tests/workloads/mink/CMakeLists.txt
@@ -16,11 +16,13 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 # Default compiler/linker flags.
-add_compile_options(-c -Wall -Wextra -stdlib=libc++)
-add_link_options(-stdlib=libc++)
+add_compile_options(-Wall -Wextra)
 
 # Debug build-specific options.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # We build the SDK with libc++ in debug mode.
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++)
   add_compile_options(-O0 -g3 -ggdb -fno-limit-debug-info -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf)
   if("$CACHE{SANITIZER}" STREQUAL "ASAN")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all)


### PR DESCRIPTION
Third time's the charm, right?

In addition to making `libc++` build options conditional on `Debug` build type, I tried to make `dev_tools/sdk/test/build_sdk_samples.sh` a bit more robust. Note that `production/examples/hello/build.sh` doesn't work on a debug SDK at all now, but I assume that's fine, since anyone who wants to build it with a debug SDK can just use CMake.