### PR TITLE
Fix error message by eliminating table name reference

### DIFF
--- a/production/tools/gaia_translate/src/table_navigation.cpp
+++ b/production/tools/gaia_translate/src/table_navigation.cpp
@@ -302,7 +302,7 @@ void table_navigation_t::fill_table_data()
             table_data_t table_data = m_table_data[table.name()];
             if (table_data.field_data.find(field.name()) != table_data.field_data.end())
             {
-                gaiat::diag().emit(diag::err_duplicate_field) << field.name() << table.name();
+                gaiat::diag().emit(diag::err_duplicate_field) << field.name();
                 m_table_data.clear();
                 return;
             }

--- a/third_party/production/TranslationEngineLLVM/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/third_party/production/TranslationEngineLLVM/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9523,7 +9523,7 @@ def err_declarative_label_statement_is_invalid : Error<
 def err_declarative_label_wrong_statement : Error<
   "The statement of the declarative label is not a declarative 'if' or 'for'.">;
 def err_duplicate_field : Error<
-  "Duplicate field '%0' found in table '%1'. Qualify your field with the "
+  "Duplicate field '%0' found in multiple tables. Qualify your field with the "
   "table name (table.field) to disambiguate field names that occur in more "
   "than one table. You can also restrict the list of tables to search by "
   "specifying them in the ruleset 'tables' attribute.">;

--- a/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2156,8 +2156,7 @@ static bool validateRuleAttribute(StringRef attribute,
       {
         if (returnValue)
         {
-          S.Diag(AL.getLoc(), diag::err_duplicate_field)
-            << attribute << table.first;
+          S.Diag(AL.getLoc(), diag::err_duplicate_field) << attribute;
           return false;
         }
         returnValue = true;
@@ -2175,8 +2174,7 @@ static bool validateRuleAttribute(StringRef attribute,
   {
     if (table.second.find(attribute) != table.second.end())
     {
-      S.Diag(AL.getLoc(), diag::err_duplicate_field)
-        << attribute << table.first;
+      S.Diag(AL.getLoc(), diag::err_duplicate_field) << attribute;
       return false;
     }
   }

--- a/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaGaia.cpp
+++ b/third_party/production/TranslationEngineLLVM/clang/lib/Sema/SemaGaia.cpp
@@ -399,7 +399,7 @@ unordered_map<string, unordered_map<string, QualType>> Sema::getTableData(Source
             unordered_map<string, QualType> fields = retVal[tbl.name()];
             if (fields.find(field.name()) != fields.end())
             {
-                Diag(loc, diag::err_duplicate_field) << field.name() << tbl.name();
+                Diag(loc, diag::err_duplicate_field) << field.name();
                 return unordered_map<string, unordered_map<string, QualType>>();
             }
             fields[field.name()] = mapFieldType(static_cast<catalog::data_type_t>(field.type()), &Context);
@@ -1043,7 +1043,7 @@ QualType Sema::getFieldType(const std::string& fieldOrTagName, SourceLocation lo
             }
             if (retVal != Context.VoidTy)
             {
-                Diag(loc, diag::err_duplicate_field) << fieldOrTagName << tableName;
+                Diag(loc, diag::err_duplicate_field) << fieldOrTagName;
                 return Context.VoidTy;
             }
 

--- a/third_party/production/TranslationEngineLLVM/clang/test/Parser/gaia_rule_attributes.cpp
+++ b/third_party/production/TranslationEngineLLVM/clang/test/Parser/gaia_rule_attributes.cpp
@@ -70,7 +70,7 @@ ruleset test38
 
 ruleset test39
 {
-    on_update(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_update(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -91,7 +91,7 @@ ruleset test53
 
 ruleset test53
 {
-    on_update(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_update(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -154,7 +154,7 @@ ruleset test61
 
 ruleset test62
 {
-    on_change(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_change(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -175,7 +175,7 @@ ruleset test64
 
 ruleset test65
 {
-    on_change(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_change(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -237,7 +237,7 @@ ruleset test73
 
 ruleset test74
 {
-    on_insert(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_insert(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -258,7 +258,7 @@ ruleset test76
 
 ruleset test77
 {
-    on_insert(value) // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+    on_insert(value) // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
     {
     }
 }
@@ -274,8 +274,8 @@ ruleset test79
 {
     on_insert(S:sensor)
     {
-        actuator.value += value/2; // expected-error {{Duplicate field 'value' found in table 'actuator'. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}} \
-                                   // expected-error {{use of undeclared identifier 'value'}}
+        actuator.value += value/2; // expected-error {{Duplicate field 'value' found in multiple tables. Qualify your field with the table name (table.field) to disambiguate field names that occur in more than one table. You can also restrict the list of tables to search by specifying them in the ruleset 'tables' attribute.}}
+                                   // expected-error@-1 {{use of undeclared identifier 'value'}}
     }
 }
 


### PR DESCRIPTION
A very explanatory error message had too much information in it. It may have been added by me recently, but it needs to be simplified. The message currently complains about the use of an ambiguous field and also lists a table name. The problem is that there is more than one table involved, and it is misleading to name just one.