### PR TITLE
Fix LLVM test build

### DIFF
--- a/third_party/production/TranslationEngineLLVM/clang/test/Parser/barn_storage.ddl
+++ b/third_party/production/TranslationEngineLLVM/clang/test/Parser/barn_storage.ddl
@@ -57,14 +57,12 @@ create relationship if not exists incubator_actuators (
 );
 
 create table if not exists raised (
-    animal_name string unique,
     birthdate string
 );
 
 create relationship if not exists animal_raised (
     animal.raised -> raised,
-    raised.animal -> animal,
-    using raised(animal_name), animal(name)
+    raised.animal -> animal
 );
 
 create relationship if not exists farmer_raised (


### PR DESCRIPTION
The  `ProductionGaiaLLVMTests_gdev` build has been failing in TeamCity because a recent change disallowing 1:1 relationships from using hybrid indices. The compile of the LLVM DDL `barn_storage.ddl` failed, and tests failed after that.

This small change corrects the DDL, allowing the tests to run successfully again.