### PR TITLE
Fix test_insert_delete_code.build_database

### DIFF
--- a/production/tools/gaia_translate/tests/test_rulesets.ruleset
+++ b/production/tools/gaia_translate/tests/test_rulesets.ruleset
@@ -582,6 +582,13 @@ ruleset test_compile
             student.parents.disconnect();
         }
     }
+
+    on_update(s:student)
+    {
+        total_hours++;
+        student.total_hours++;
+        s.total_hours++;
+    }
 }
 
 ruleset test_insert_delete


### PR DESCRIPTION
An extra rule in test_rulesets.ruleset was creating an infinite loop in the test_insert_delete_ruleset test. Simply removed the rule.