### PR TITLE
Disable one rule to prevent rule execution ordering failures

### DIFF
--- a/production/tools/gaia_translate/tests/test_insert_delete.cpp
+++ b/production/tools/gaia_translate/tests/test_insert_delete.cpp
@@ -278,7 +278,13 @@ TEST_F(test_insert_delete_code, build_database)
         {
             row_count++;
             auto course = registration.registered_course();
-            EXPECT_EQ(student.total_hours() * 2, course.hours());
+            // Enable the following statement when the issue of rule ordering is resolved. The corresponding
+            // rule, on_insert(course) in test_insert_delete_2, should be enabled at the same time.
+            // Currently when that rule and the on_insert(student) rule execute in different orders, the
+            // results change and this test fails.
+            // GAIAPLAT-1422
+            // EXPECT_EQ(student.total_hours() * 2, course.hours());
+            EXPECT_EQ(student.total_hours(), course.hours());
             EXPECT_STREQ(student.surname(), registration.status());
             EXPECT_EQ(registration.grade(), c_grade_d + c_grade_plus);
         }

--- a/production/tools/gaia_translate/tests/test_rulesets.ruleset
+++ b/production/tools/gaia_translate/tests/test_rulesets.ruleset
@@ -635,10 +635,14 @@ ruleset test_insert_delete_2
         student.total_hours += course.hours;
     }
 
+    /* Re-enable this rule when rule ordering issues are resolved. Must also update the
+       code in test_insert_delete_code.build_database (as documented there).
+       GAIAPLAT-1422
     on_insert(course)
     {
         hours *= 2;
     }
+    */
 
     on_insert(registration)
     {


### PR DESCRIPTION
When I re-enabled this test (`test_insert_delete_code.build_database`) and moved a rule to allow it to execute properly to completion, I have forgotten that this is also the test that exposed the problem with rule-ordering dependencies. When two of this test's rules execute in a different order, the test results are different and the rule fails. See GAIAPLAT-1422.

Rule ordering is a problem to be solved in a later release. Rather than disabling this test, I have eliminated one of the rules that causes the ordering dependency. This way, we can add the rule back in at a later time when it should work correctly.