### PR TITLE
Fix broken test ruleset expectation

### DIFF
--- a/production/tools/tests/gaiat/integration_test_expected_table_atribute_reference_warning.ruleset
+++ b/production/tools/tests/gaiat/integration_test_expected_table_atribute_reference_warning.ruleset
@@ -12,4 +12,4 @@ ruleset test : tables(sensor)
     }
 }
 
-// CHECK: :6:9: warning: Table 'actuator' is not referenced in tables attribute.
+// CHECK: warning: Table 'actuator' is not referenced in tables attribute.


### PR DESCRIPTION
My insertion of a copyright changed line numbers, which broke the expectation of this test. Expecting an error on a specific line number seems unusual, so I've just removed that part from the expectation test.