### PR TITLE
Add assert to ensure logs being replayed are of an active transaction

### DIFF
--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -887,7 +887,9 @@ void server_t::create_local_snapshot(bool apply_logs)
 
     if (apply_logs)
     {
-        ASSERT_PRECONDITION(s_txn_id != c_invalid_gaia_txn_id && txn_metadata_t::is_txn_active(s_txn_id), "Current transaction is not active.");
+        ASSERT_PRECONDITION(
+            s_txn_id != c_invalid_gaia_txn_id && txn_metadata_t::is_txn_active(s_txn_id),
+            "create_local_snapshot() must be called from within an active transaction!");
         std::vector<int> txn_log_fds;
         get_txn_log_fds_for_snapshot(s_txn_id, txn_log_fds);
         auto cleanup_log_fds = make_scope_guard([&]() {


### PR DESCRIPTION
ASSERT added to check snapshot replay semantics.