### PR TITLE
Add logging that tells from which rule the serialization exception comes from

### DIFF
--- a/production/rules/event_manager/src/rule_thread_pool.cpp
+++ b/production/rules/event_manager/src/rule_thread_pool.cpp
@@ -282,7 +282,7 @@ void rule_thread_pool_t::invoke_rule_inner(invocation_t& invocation)
             should_schedule = false;
             if (invocation.num_retries >= m_max_rule_retries)
             {
-                gaia_log::rules().error("serialization exception: '{}'", rule_id);
+                gaia_log::rules().error("'{}': Transaction update conflict.", rule_id);
                 throw;
             }
             else


### PR DESCRIPTION
I noticed that we log the rule that triggers generic exceptions but we don't log the rule from which a serialziation_exception is triggered. 

See this:

```
[2021-10-04T15:32:31.787] [info] [3041825 3043111] <app>: Fired on bot_moving_to_station_event
[2021-10-04T15:32:31.902] [info] [3041825 3043119] <app>: Fired on bot_battery_charge_update_event
terminate called after throwing an instance of 'gaia::db::transaction_update_conflict'
  what():  Transaction was aborted due to a serialization error.
```

It is unclear from which rule the serialization error comes from.