### PR TITLE
Fix gaiac dependency on gaia_db_server and add gaiat dependency

### DIFF
--- a/production/catalog/gaiac/CMakeLists.txt
+++ b/production/catalog/gaiac/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(gaiac
 
 configure_gaia_target(gaiac)
 target_include_directories(gaiac PRIVATE ${GAIA_CATALOG_TOOL_INCLUDES})
-add_dependencies(gaiac gaia_db_server)
+add_dependencies(gaiac gaia_db_server_exec)
 target_link_libraries(gaiac PRIVATE rt gaia_common gaia_catalog gaia_parser flatbuffers tabulate Threads::Threads)
 
 if(ENABLE_STACKTRACE)

--- a/production/tools/gaia_translate/CMakeLists.txt
+++ b/production/tools/gaia_translate/CMakeLists.txt
@@ -28,6 +28,7 @@ link_directories(
 add_executable(gaiat ${GAIAT_SRCS})
 configure_gaia_target(gaiat)
 target_include_directories(gaiat PRIVATE ${TRANSLATION_ENGINE_INCLUDES})
+add_dependencies(gaiat gaia_db_server_exec)
 target_link_libraries(gaiat
   PRIVATE
   rt


### PR DESCRIPTION
I forgot to change the `add_dependencies()` target for `gaiac` from `gaia_db_server` to `gaia_db_server_exec` when I renamed the DB server executable target in https://github.com/gaia-platform/GaiaPlatform/pull/972. Also, I think `gaiat` needs an explicit build dependency on `gaia_db_server_exec` (which it may have been getting previously via a transitive dependency through `gaiac`).

This should fix a CI build break:
http://192.168.0.250:8111/viewLog.html?buildId=17039&buildTypeId=GaiaPlatform_ProductionGaiaLLVMTestsGdev&tab=buildLog.