### PR TITLE
Clarify transaction_conflict_exception message

### DIFF
--- a/production/inc/gaia/db/db.hpp
+++ b/production/inc/gaia/db/db.hpp
@@ -92,7 +92,7 @@ class transaction_update_conflict : public common::gaia_exception
 public:
     transaction_update_conflict()
     {
-        m_message = "Transaction was aborted due to a serialization error.";
+        m_message = "Transaction was aborted due to a conflict with another transaction.";
     }
 };
 


### PR DESCRIPTION
Note this is consistent with the existing doc comments for `commit_transaction()`:
```
 * \exception gaia::db::no_open_transaction no transaction is open in this session.
 * \exception gaia::db::transaction_update_conflict transaction conflicts with another transaction.
 */
void commit_transaction();
```