### PR TITLE
Fix object cloning

### DIFF
--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -223,14 +223,13 @@ bool gaia_ptr_t::remove_child_reference(gaia_id_t child_id, reference_offset_t f
         {
             // Non-first child in the linked list, update the previous child.
             auto prev_ptr = gaia_ptr_t::open(prev_child);
-            // REVIEW: We need to clone prev_ptr before modifying its references,
-            // but the original fix that did this caused a test regression:
-            // https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1279
+            gaia_offset_t old_prev_offset = prev_ptr.to_offset();
+            prev_ptr.clone_no_txn();
             prev_ptr.references()[relationship->next_child_offset]
                 = curr_ptr.references()[relationship->next_child_offset];
+            client_t::txn_log(prev_ptr.m_locator, old_prev_offset, prev_ptr.to_offset(), gaia_operation_t::update);
         }
 
-        curr_ptr.clone_no_txn();
         curr_ptr.references()[relationship->parent_offset] = c_invalid_gaia_id;
         curr_ptr.references()[relationship->next_child_offset] = c_invalid_gaia_id;
     }


### PR DESCRIPTION
I finally managed to get this right and all unit tests pass (and my debug allocator in another branch no longer segfaults). The correct pattern here for updating references on an object is incredibly error-prone:

1. Save the current offset of the object
2. Clone the object
3. Modify references
4. (Coming soon) In debug builds, write-protect the modified object to detect memory corruption
5. Log the changes, using the current and saved offsets of the object

Some refactoring is definitely in order for V1.