### PR TITLE
Reduce minimum hard limit for open fds

### DIFF
--- a/production/db/core/inc/system_checks.hpp
+++ b/production/db/core/inc/system_checks.hpp
@@ -33,16 +33,12 @@ constexpr uint64_t c_min_vm_limit{RLIM_INFINITY};
 // specifies a value one greater than the maximum file descriptor number that
 // can be opened by this process."
 // NB: (2^16 - 1) is the "invalid" value of a txn log fd, so the maximum valid
-// value of a txn log fd is (2^16 - 2). Also, we plan to support up to 2^7
-// sessions (to avoid exhausting virtual memory), and each session requires a
-// few fds for its socket fd, epoll fd, cancellation eventfd, server-side txn
-// log fd, etc., so (2^16 - 1 + 512) seems to be a reasonable minimum hard
-// limit. (The default hard limit on Ubuntu 20.04, as reported by `prlimit -n`,
-// seems to be 2^20, while the default soft limit seems to be 2^10, so a soft
-// limit of (2^16 + 511) is compatible with our preferred platform, in the sense
-// that it should not require any reconfiguration by a privileged
-// administrator.)
-constexpr uint64_t c_min_fd_limit{std::numeric_limits<uint16_t>::max() + 512};
+// value of a txn log fd is (2^16 - 2). (The default hard limit on Ubuntu 20.04,
+// as reported by `prlimit -n`, has been observed to be both 2^20 and (2^16 -
+// 1), while the default soft limit seems to be 2^10, so a minimum hard limit of
+// (2^16 - 1) is compatible with our preferred platform, in the sense that it
+// should not require any reconfiguration by a privileged administrator.)
+constexpr uint64_t c_min_fd_limit{std::numeric_limits<uint16_t>::max()};
 
 struct vm_overcommit_policy
 {

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -2722,18 +2722,18 @@ Save the file and start a new terminal session.
     if (!check_and_adjust_fd_limit())
     {
         std::cerr << R"(
-The Gaia Database Server requires a per-process open file descriptor limit of at least 66047.
+The Gaia Database Server requires a per-process open file descriptor limit of at least 65535.
 
 To temporarily set the minimum open file descriptor limit,
 open a shell with root privileges and type the following command:
 
-  ulimit -n 66047
+  ulimit -n 65535
 
 To permanently set the minimum open file descriptor limit, open /etc/security/limits.conf
 in an editor with root privileges and add the following lines:
 
-  soft nofile 66047
-  hard nofile 66047
+  * soft nofile 65535
+  * hard nofile 65535
 
 Note: For enhanced security, replace the wildcard '*' in these file entries
 with the user name of the account that is running the Gaia Database Server.


### PR DESCRIPTION
@simone-gaia observed that the open fd hard limit on his Ubuntu 20.04 system was `65535`:
```
➜  cmake-build-debug git:(direct_access_example) ✗ ulimit -a
-t: cpu time (seconds)              unlimited
-f: file size (blocks)              unlimited
-d: data seg size (kbytes)          unlimited
-s: stack size (kbytes)             8192
-c: core file size (blocks)         0
-m: resident set size (kbytes)      unlimited
-u: processes                       157901
-n: file descriptors                65535
-l: locked-in-memory size (kbytes)  65536
-v: address space (kbytes)          unlimited
-x: file locks                      unlimited
-i: pending signals                 157901
-q: bytes in POSIX msg queues       819200
-e: max nice                        0
-r: max rt priority                 0
-N 15:                              unlimited
```
We don't want anyone to have to change any config requiring root privileges if we can possibly avoid it, so we'll go with the lowest common denominator as long as it's reasonable.