### PR TITLE
[GAIAPLAT-1240] Improve gaiac parameters checking

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -200,7 +200,7 @@ void generate_edc(const string& db_name, const filesystem::path& output_path)
         throw std::invalid_argument("Invalid output path: '" + output_path.string() + "'.");
     }
 
-    cout << "Generating Direct Access classes in: " << absolute_output_path << "." << endl;
+    cerr << "Generating Direct Access classes in: " << absolute_output_path << "." << endl;
 
     generate_fbs_headers(db_name, absolute_output_path);
     generate_edc_code(db_name, absolute_output_path);
@@ -368,12 +368,12 @@ int main(int argc, char* argv[])
         }
         else if (argv[i] == string("-h") || argv[i] == string("--help"))
         {
-            cout << usage();
+            cerr << usage();
             exit(EXIT_SUCCESS);
         }
         else if (argv[i] == string("-v") || argv[i] == string("--version"))
         {
-            cout << version();
+            cerr << version();
             exit(EXIT_SUCCESS);
         }
         else if (argv[i][0] == '-')


### PR DESCRIPTION
https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1240?focusedCommentId=11101

This task addressed the "specs" listed here:

1. -o without -g shall fail
2. Force gaiac users to provide an output folder.
3. If you don’t give -g it does not make sense to give --db-name
4. We shall error out when an unexpected argument is passed: catalog/gaiac/gaiac --db-asdajh whvbw file.dd

This is the result of a discussion between me, Don, Chuan, and other DB team members.

I added the following check:
-  The specified DDL file must exist. Previously the error message was rather cryptic:
```
gaiac awregerbh.ddl                    
ERROR: Parsing error at location 1.1: syntax error, unexpected END, expecting INDEX
```

I modified requirement 2: `2. Force gaiac users to provide an output folder.`. See TODO in code.