### PR TITLE
Log new object versions immediately after creation

### DIFF
--- a/production/tools/gaia_translate/tests/test_connect_disconnect.cpp
+++ b/production/tools/gaia_translate/tests/test_connect_disconnect.cpp
@@ -162,8 +162,7 @@ TEST_F(test_connect_disconnect, test_disconnect_1_1)
     gaia::db::commit_transaction();
 }
 
-// Temporarily disabled until https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1501 is resolved.
-TEST_F(test_connect_disconnect, DISABLED_disconnect_delete)
+TEST_F(test_connect_disconnect, disconnect_delete)
 {
     gaia::rules::subscribe_ruleset("test_disconnect_delete");
 


### PR DESCRIPTION
`gaia_ptr_t::create()` and `gaia_ptr_t::update_payload()` had a bug introduced when the autoconnect feature was added: the version just created would have its old offset saved but was logged *after* the autoconnect logic had executed, with the saved offset. If the autoconnect logic had created a new version, this would end up logging another version with the same "new" version (the one created by autoconnect), but using the "old" version corresponding to the offset saved before the original updated version was created. Therefore, the txn log contained two versions with the same "new" version but different "old" versions, which manifested as an attempted double-free (due to the duplicated "new" version), which was caught by an assert added in https://github.com/gaia-platform/GaiaPlatform/pull/889. That assert fired in the SDK test `test_connect_disconnect.disconnect_delete` (https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1501), and also in a test run of the `amr_swarm` app (https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1518).