### PR TITLE
cleanup rocksdb txn objects post commit/rollback

### DIFF
--- a/production/db/core/src/rdb_internal.cpp
+++ b/production/db/core/src/rdb_internal.cpp
@@ -74,6 +74,8 @@ void rdb_internal_t::prepare_wal_for_write(rocksdb::Transaction* txn)
 
 void rdb_internal_t::rollback(const std::string& txn_name)
 {
+    // https://github.com/facebook/rocksdb/blob/master/include/rocksdb/utilities/transaction_db.h#L398
+    // Caller is responsible for deleting the returned transaction when no longer needed.
     auto txn = std::unique_ptr<rocksdb::Transaction>(get_txn_by_name(txn_name));
     auto s = txn->Rollback();
     handle_rdb_error(s);
@@ -81,6 +83,8 @@ void rdb_internal_t::rollback(const std::string& txn_name)
 
 void rdb_internal_t::commit(const std::string& txn_name)
 {
+    // https://github.com/facebook/rocksdb/blob/master/include/rocksdb/utilities/transaction_db.h#L398
+    // Caller is responsible for deleting the returned transaction when no longer needed.
     auto txn = std::unique_ptr<rocksdb::Transaction>(get_txn_by_name(txn_name));
     auto s = txn->Commit();
     handle_rdb_error(s);


### PR DESCRIPTION
Looks like I had missed cleaning up rocksdb txn objects on commit/rollback -_- 

The cleanup seems to have fixed the leak for a simple workload I generated but I need to investigate more and see if I missed anything else.