### PR TITLE
Don't clear metadata before transitioning chunk to owned state

### DIFF
--- a/production/db/inc/memory_manager/memory_structures.inc
+++ b/production/db/inc/memory_manager/memory_structures.inc
@@ -148,6 +148,7 @@ void chunk_manager_metadata_t::synchronize_allocation_metadata()
 
 void chunk_manager_metadata_t::clear()
 {
+    // NB: We cannot clear the chunk state and version!
     shared_lock.clear();
     last_allocation_metadata.store({});
     std::fill(allocated_slots_bitmap, allocated_slots_bitmap + c_slot_bitmap_size_in_words, 0);

--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -103,7 +103,8 @@ chunk_offset_t memory_manager_t::allocate_unused_chunk()
 
         // Now try to claim this chunk.
         chunk_manager_t chunk_manager;
-        chunk_manager.initialize(allocated_chunk_offset);
+        // NB: We cannot call initialize() here because we don't own the chunk yet!
+        chunk_manager.load(allocated_chunk_offset);
         // REVIEW: the memory manager should call
         // update_chunk_allocation_status() directly instead of delegating
         // it to chunk_manager_t::allocate_chunk().
@@ -153,7 +154,8 @@ chunk_offset_t memory_manager_t::allocate_used_chunk()
 
         auto available_chunk_offset = static_cast<chunk_offset_t>(found_index);
         chunk_manager_t chunk_manager;
-        chunk_manager.initialize(available_chunk_offset);
+        // NB: We cannot call initialize() here because we don't own the chunk yet!
+        chunk_manager.load(available_chunk_offset);
         // REVIEW: the memory manager should call
         // update_chunk_allocation_status() directly instead of delegating
         // it to chunk_manager_t::allocate_chunk().


### PR DESCRIPTION
While addressing last-minute review feedback, I got confused and forgot why I had used `chunk_manager_t::load()` instead of `chunk_manager_t::initialize()` in `memory_manager_t::allocate_used_chunk()`. The reason was that `chunk_manager_t::initialize()` clears chunk metadata, which we can't safely do until we know we own the chunk. This resulted in a race where a thread might initially try to acquire a used chunk and then get preempted, losing the race to acquire the chunk to another concurrent thread. Then the first thread would wake up and clear the now-in-use chunk's metadata while the second thread was already using it for allocations! This would clear any allocation bits that the second thread had already set, and the missing allocation bits would eventually trigger an assert when those allocations were freed during GC.

The fix was simple: just use `chunk_manager_t::load()` to access the metadata before acquiring the chunk, as I originally did. The metadata will be cleared anyway when `gaia::db::allocate_object()` (the original caller of `memory_manager_t::allocate_chunk()`) calls `chunk_manager_t::initialize()`, which calls `chunk_manager_metadata_t::clear()`.

Note that the above initialization hazard doesn't apply to `memory_manager_t::allocate_unused_chunk()`, but there's no reason to do things any differently, so I made the same change there.

The fact that I got confused about initialization responsibility is evidence that this code needs further refactoring; the existing interfaces have to be contorted to fit the new chunk lifecycle protocol and should be replaced by a new interface design that starts from the protocol itself.