### PR TITLE
Fix an error message and remove an info message

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -200,8 +200,6 @@ void generate_edc(const string& db_name, const filesystem::path& output_path)
         throw std::invalid_argument("Invalid output path: '" + output_path.string() + "'.");
     }
 
-    cout << "Generating Direct Access classes in: " << absolute_output_path << "." << endl;
-
     generate_fbs_headers(db_name, absolute_output_path);
     generate_edc_code(db_name, absolute_output_path);
 }

--- a/production/inc/gaia_internal/catalog/catalog.hpp
+++ b/production/inc/gaia_internal/catalog/catalog.hpp
@@ -385,7 +385,7 @@ public:
     explicit cannot_drop_table_with_data(const std::string& name)
     {
         std::stringstream message;
-        message << "Cannot drop the table '" << name << "' because it still contains data."
+        message << "Cannot drop the table '" << name << "' because it still contains data. "
                 << "Please delete all records of the table before dropping it.";
         m_message = message.str();
     }


### PR DESCRIPTION
Remove an informational message in `gaiac`. The info message is quit trivial and we do not show such information for other functionalities of `gaiac`.  Remove it for consistency.

Also add a missing space in the `cannot_drop_table_with_data` exception message. 