### PR TITLE
Fix a CMake issue in palletbox test suite

### DIFF
--- a/production/tests/workloads/palletbox/CMakeLists.txt
+++ b/production/tests/workloads/palletbox/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}
   PRIVATE
     ${GAIA_INC})
-target_link_libraries(palletbox ${GAIA_LIB})
+target_link_libraries(palletbox gaia)
 
 #if(ENABLE_STACKTRACE)
 #    target_link_libraries(palletbox PRIVATE gaia_stack_trace)


### PR DESCRIPTION
The CMake should link to `gaia` instead of `GAIA_LIB`. The SDK's cmake helper creates the gaia target not `GAIA_LIB` variable. 