### PR TITLE
[GAIAPLAT-1636] Remove trailing semicolons in edc code that cause compiler warnings

### DIFF
--- a/production/catalog/src/edc_generator.cpp
+++ b/production/catalog/src/edc_generator.cpp
@@ -676,7 +676,7 @@ std::string class_writer_t::generate_expr_namespace()
         code += "static auto& {{FIELD_NAME}} = {{TABLE_NAME}}_t::expr::{{FIELD_NAME}};";
     }
     code.DecrementIdentLevel();
-    code += "};";
+    code += "}";
 
     return code.ToString();
 }
@@ -749,7 +749,7 @@ std::string class_writer_t::generate_ref_class_cpp()
     code += "{{TABLE_NAME}}_ref_t::{{TABLE_NAME}}_ref_t(gaia::common::gaia_id_t parent, "
             "gaia::common::gaia_id_t child, gaia::common::reference_offset_t child_offset)";
     code.IncrementIdentLevel();
-    code += ": {{TABLE_NAME}}_t(child), direct_access::edc_base_reference_t(parent, child_offset) {};";
+    code += ": {{TABLE_NAME}}_t(child), direct_access::edc_base_reference_t(parent, child_offset) {}";
     code.DecrementIdentLevel();
 
     // disconnect()

--- a/production/inc/gaia/direct_access/edc_object.hpp
+++ b/production/inc/gaia/direct_access/edc_object.hpp
@@ -147,7 +147,7 @@ protected:
     static edc_vector_t<T_type> to_edc_vector(const flatbuffers::Vector<T_type>* vector_ptr)
     {
         return edc_vector_t<T_type>(vector_ptr);
-    };
+    }
 };
 
 template <gaia::common::gaia_type_t container_type_id, typename T_gaia, typename T_fb, typename T_obj>

--- a/production/inc/gaia/direct_access/edc_object.inc
+++ b/production/inc/gaia/direct_access/edc_object.inc
@@ -127,7 +127,9 @@ void edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>
 }
 template <gaia::common::gaia_type_t container_type_id, typename T_gaia, typename T_fb, typename T_obj>
 edc_object_t<container_type_id, T_gaia, T_fb, T_obj>::edc_object_t()
-    : edc_base_t(){};
+    : edc_base_t()
+{
+}
 
 template <gaia::common::gaia_type_t container_type_id, typename T_class, typename T_flatbuffer, typename T_flatbuffer_object>
 gaia::common::gaia_type_t edc_object_t<container_type_id, T_class, T_flatbuffer, T_flatbuffer_object>::s_gaia_type


### PR DESCRIPTION
We had a few cases of trailing semicolons in both our edc header classes and in our generated headers.  This causes warnings in pedantic mode (see [GAIAPLAT-1636](https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1636)).  

The warnings are numerous enough that they can hide actual warnings in customer code.  With this fix, indy builds warning-free.
```
[Processing: race_decision_engine]
Finished <<< race_decision_engine [42.8s]
Starting >>> svl_tests
Finished <<< svl_tests [1.49s]

Summary: 33 packages finished [50.1s]
dax@ade:~/art-core (next $% u=)$
```