### PR TITLE
Add CMake EXPORT_SYMBOLS option and enable for FDW build

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -25,6 +25,8 @@ option(BUILD_GAIA_RELEASE "Build Gaia Release packages and binaries" OFF)
 
 option(ENABLE_SDK_TESTS "Build and execute ruleset translation tests" ON)
 
+option(EXPORT_SYMBOLS "Export symbols by default from shared libraries" OFF)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   option(ENABLE_CLANG_TIDY "Enable clang tidy" ON)
 else()
@@ -334,7 +336,10 @@ if(BUILD_GAIA_RELEASE)
 endif()
 
 # Query processors.
+# We want to export all global symbols from the FDW shared library.
+set(EXPORT_SYMBOLS ON)
 add_subdirectory(sql)
+set(EXPORT_SYMBOLS OFF)
 
 # SDK
 # Be sure to add the SDK directory after the sql directory because the package mechanism

--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -23,16 +23,18 @@ endfunction()
 #
 function(configure_gaia_target TARGET)
   target_link_libraries(${TARGET} PUBLIC gaia_build_options)
-  # See https://cmake.org/cmake/help/latest/policy/CMP0063.html.
-  cmake_policy(SET CMP0063 NEW)
-  # This property sets the compiler option -fvisibility=hidden, so all symbols
-  # are "hidden" (i.e., not exported) from our shared library (libgaia.so).
-  # See https://gcc.gnu.org/wiki/Visibility.
-  set_target_properties(${TARGET} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-  # This property sets the compiler option -fvisibility-inlines-hidden.
-  # "This causes all inlined class member functions to have hidden visibility"
-  # (https://gcc.gnu.org/wiki/Visibility).
-  set_target_properties(${TARGET} PROPERTIES VISIBILITY_INLINES_HIDDEN ON)
+  if(NOT EXPORT_SYMBOLS)
+    # See https://cmake.org/cmake/help/latest/policy/CMP0063.html.
+    cmake_policy(SET CMP0063 NEW)
+    # This property sets the compiler option -fvisibility=hidden, so all symbols
+    # are "hidden" (i.e., not exported) from our shared library (libgaia.so).
+    # See https://gcc.gnu.org/wiki/Visibility.
+    set_target_properties(${TARGET} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    # This property sets the compiler option -fvisibility-inlines-hidden.
+    # "This causes all inlined class member functions to have hidden visibility"
+    # (https://gcc.gnu.org/wiki/Visibility).
+    set_target_properties(${TARGET} PROPERTIES VISIBILITY_INLINES_HIDDEN ON)
+  endif(EXPORT_SYMBOLS)
 endfunction(configure_gaia_target)
 
 #


### PR DESCRIPTION
This is kind of a hack, and I didn't try to understand exactly which symbols needed to be exported for the FDW to work, but at least it's not intrusive on the FDW itself at all.

The FDW tests still fail, but at least the FDW lib is loaded successfully:
```
sudo -u postgres psql
postgres=# create extension gaia_fdw;
ERROR:  Error opening COW-SE session.
HINT:  Exception: 'Connect failed! - Connection refused'.
```