### PR TITLE
Enable example apps to be built using `make install`

### DIFF
--- a/production/examples/direct_access/CMakeLists.txt
+++ b/production/examples/direct_access/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # --- Generate Direct Access classes from DDL---
 process_schema(

--- a/production/examples/hello/CMakeLists.txt
+++ b/production/examples/hello/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra)

--- a/production/examples/incubator/CMakeLists.txt
+++ b/production/examples/incubator/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra)

--- a/production/examples/incubator/CMakeLists_debug.txt
+++ b/production/examples/incubator/CMakeLists_debug.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra -O0 -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls -ggnu-pubnames -gsplit-dwarf -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -stdlib=libc++)

--- a/production/tests/workloads/mink/CMakeLists.txt
+++ b/production/tests/workloads/mink/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra)

--- a/production/tests/workloads/palletbox/CMakeLists.txt
+++ b/production/tests/workloads/palletbox/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra)

--- a/production/tests/workloads/pingpong/CMakeLists.txt
+++ b/production/tests/workloads/pingpong/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-include("/opt/gaia/cmake/gaia.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake" "/opt/gaia/cmake")
+include(gaia)
 
 # Default compiler/linker flags.
 add_compile_options(-Wall -Wextra)


### PR DESCRIPTION
Right now the example apps cannot be built using `make install`; the root dir `/opt/gaia` is hardcoded in their CMake files so they can only be used with an SDK install (`make install` targets `/usr/local` rather than `/opt/gaia`). I use the example apps often for sanity/stress testing, and `make install` is _much_ faster than building and installing an SDK package, so I need `make install` to work. (If it doesn't work, then there's not much point in having it.)

Using a relative path to the `gaia.cmake` module enables the example apps to be built regardless of whether the sources are under `production/`, `/usr/local/`, or `/opt/gaia/`. I did not modify the test apps  (i.e., those under `production/tests/workloads`), because the relative paths are different and I don't want to disturb anyone's workflow, but relative paths to the `gaia.cmake` module would work there as well. @JackAtGaia can decide if he'd like me to modify those files as well.
