### PR TITLE
Fix SDK break

### DIFF
--- a/production/inc/gaia/int_type.hpp
+++ b/production/inc/gaia/int_type.hpp
@@ -7,6 +7,9 @@
 
 #include <type_traits>
 
+// Export all symbols declared in this file.
+#pragma GCC visibility push(default)
+
 namespace gaia
 {
 /**
@@ -76,3 +79,6 @@ protected:
 } // namespace common
 /*@}*/
 } // namespace gaia
+
+// Restore default hidden visibility for all symbols.
+#pragma GCC visibility pop


### PR DESCRIPTION
Forgot to make the new `int_type_t` header API visible.