### PR TITLE
Fix debug build break

### DIFF
--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -598,7 +598,7 @@ void server_t::init_shared_memory()
     // Initialize watermarks.
     for (auto& elem : s_watermarks)
     {
-        std::atomic_init(&elem, c_invalid_gaia_txn_id);
+        std::atomic_init(&elem, c_invalid_gaia_txn_id.value());
     }
 
     // We may be reinitializing the server upon receiving a SIGHUP.


### PR DESCRIPTION
Debug build seems pickier about the types used in an `atomic_init` statement, so I modified a parameter to eliminate ambiguity.