### PR TITLE
Disallow creating relationship across databases

### DIFF
--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -385,6 +385,11 @@ gaia_id_t ddl_executor_t::create_relationship(
         throw tables_not_match(name, link1.to_table, link2.from_table);
     }
 
+    if (gaia_table_t::get(link1_src_table_id).database() != gaia_table_t::get(link1_dest_table_id).database())
+    {
+        throw no_cross_db_relationship(name);
+    }
+
     if (link1.cardinality == relationship_cardinality_t::many
         && link2.cardinality == relationship_cardinality_t::many)
     {

--- a/production/catalog/tests/test_ddl_execution.cpp
+++ b/production/catalog/tests/test_ddl_execution.cpp
@@ -7,6 +7,7 @@
 
 #include "gaia/direct_access/auto_transaction.hpp"
 
+#include "gaia_internal/catalog/catalog.hpp"
 #include "gaia_internal/catalog/ddl_execution.hpp"
 #include "gaia_internal/catalog/gaia_catalog.h"
 #include "gaia_internal/db/db_catalog_test_base.hpp"
@@ -422,4 +423,20 @@ create table employee (
         ASSERT_NO_THROW(parser.parse_string(ddl));
         ASSERT_THROW(execute(parser.statements), invalid_field_map);
     }
+}
+
+TEST_F(ddl_execution_test, cross_db_relationship)
+{
+    string ddl =
+        R"(
+create database d1;
+create database d2;
+create table d1.t1(c1 int32);
+create table d2.t2(c2 int32);
+create relationship r (d1.t1.link2 -> d2.t2, d2.t2.link1 -> d1.t1);
+)";
+
+    ddl::parser_t parser;
+    ASSERT_NO_THROW(parser.parse_string(ddl));
+    ASSERT_THROW(execute(parser.statements), no_cross_db_relationship);
 }

--- a/production/inc/gaia_internal/catalog/catalog.hpp
+++ b/production/inc/gaia_internal/catalog/catalog.hpp
@@ -253,6 +253,20 @@ public:
 };
 
 /**
+ * Thrown when creating a relationship between tables from different databases.
+ */
+class no_cross_db_relationship : public gaia::common::gaia_exception
+{
+public:
+    explicit no_cross_db_relationship(const std::string& name)
+    {
+        std::stringstream message;
+        message << "Cannot create the relationship '" << name << "' across databases.";
+        m_message = message.str();
+    }
+};
+
+/**
  * Thrown when the tables specified in the relationship definition do not match.
  */
 class tables_not_match : public gaia::common::gaia_exception
@@ -718,7 +732,7 @@ struct drop_statement_t : statement_t
 
 /**
  * Initialize the catalog.
-*/
+ */
 void initialize_catalog();
 
 /**


### PR DESCRIPTION
As discussed in https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1001, this disables creating relationships across databases.