### PR TITLE
[GAIAPLAT-1024] get_txn_id() is redundant once get_current_txn_id() is implemented

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -52,6 +52,7 @@ class client_t
     friend gaia::db::data_t* gaia::db::get_data();
     friend gaia::db::id_index_t* gaia::db::get_id_index();
     friend gaia::db::index::indexes_t* gaia::db::get_indexes();
+    friend gaia_txn_id_t gaia::db::get_current_txn_id();
 
     friend class gaia::db::query_processor::db_client_proxy_t;
 
@@ -86,7 +87,6 @@ public:
     static void rollback_transaction();
     static void commit_transaction();
 
-    static inline gaia_txn_id_t get_txn_id();
     static inline int get_session_socket_for_txn();
 
     // This returns a generator object for gaia_ids of a given type.

--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -18,11 +18,6 @@ inline void client_t::set_commit_trigger(triggers::commit_trigger_fn trigger_fn)
     s_txn_commit_trigger = trigger_fn;
 }
 
-inline gaia_txn_id_t client_t::get_txn_id()
-{
-    return s_txn_id;
-}
-
 inline int client_t::get_session_socket_for_txn()
 {
     return s_session_socket;

--- a/production/db/core/src/db_shared_data_client.cpp
+++ b/production/db/core/src/db_shared_data_client.cpp
@@ -73,7 +73,7 @@ gaia::db::id_index_t* gaia::db::get_id_index()
 
 gaia::db::gaia_txn_id_t gaia::db::get_current_txn_id()
 {
-    return gaia::db::client_t::get_txn_id();
+    return gaia::db::client_t::s_txn_id;
 }
 
 gaia::db::index::indexes_t* gaia::db::get_indexes()

--- a/production/db/core/src/gaia_db.cpp
+++ b/production/db/core/src/gaia_db.cpp
@@ -56,8 +56,3 @@ void gaia::db::clear_shared_memory()
 {
     gaia::db::client_t::clear_shared_memory();
 }
-
-gaia::db::gaia_txn_id_t gaia::db::get_txn_id()
-{
-    return gaia::db::client_t::get_txn_id();
-}

--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -368,7 +368,7 @@ void gaia_ptr_t::create_insert_trigger(gaia_type_t type, gaia_id_t id)
 {
     if (client_t::is_valid_event(type))
     {
-        client_t::s_events.emplace_back(event_type_t::row_insert, type, id, empty_position_list, get_txn_id());
+        client_t::s_events.emplace_back(event_type_t::row_insert, type, id, empty_position_list, get_current_txn_id());
     }
 }
 
@@ -614,7 +614,7 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
 
     if (client_t::is_valid_event(new_this->type))
     {
-        client_t::s_events.emplace_back(event_type_t::row_update, new_this->type, new_this->id, changed_fields, get_txn_id());
+        client_t::s_events.emplace_back(event_type_t::row_update, new_this->type, new_this->id, changed_fields, get_current_txn_id());
     }
 
     return *this;

--- a/production/inc/gaia_internal/db/gaia_db_internal.hpp
+++ b/production/inc/gaia_internal/db/gaia_db_internal.hpp
@@ -25,9 +25,9 @@ void set_commit_trigger(gaia::db::triggers::commit_trigger_fn trigger_fn);
 void clear_shared_memory();
 
 /**
- * Internal API for getting the begin_ts of the current txn.
- */
-gaia_txn_id_t get_txn_id();
+* Internal API for getting the begin_ts of the current txn.
+*/
+gaia_txn_id_t get_current_txn_id();
 
 // The name of the SE server binary.
 constexpr char c_db_server_exec_name[] = "gaia_db_server";

--- a/production/rules/event_manager/src/rule_thread_pool.cpp
+++ b/production/rules/event_manager/src/rule_thread_pool.cpp
@@ -242,7 +242,7 @@ void rule_thread_pool_t::invoke_rule_inner(invocation_t& invocation)
             // before an enqueued rule has been invoked.
             if (!m_rule_checker.is_valid_row(rule_invocation.record))
             {
-                gaia_log::rules().trace("invalid anchor row: rule '{}' was not invoked, src_txn:'{}', new_txn:'{}'", rule_id, rule_invocation.src_txn_id, gaia::db::get_txn_id());
+                gaia_log::rules().trace("invalid anchor row: rule '{}' was not invoked, src_txn:'{}', new_txn:'{}'", rule_id, rule_invocation.src_txn_id, gaia::db::get_current_txn_id());
 
                 // It is safe to exit early out of this routine. The transaction will clean up on
                 // exit of the function and there will be no pending rule invocations to process.
@@ -263,7 +263,7 @@ void rule_thread_pool_t::invoke_rule_inner(invocation_t& invocation)
 
             // Invoke the rule.
             auto fn_start = gaia::common::timer_t::get_time_point();
-            gaia_log::rules().trace("call:'{}', src_txn:'{}', new_txn:'{}'", rule_id, rule_invocation.src_txn_id, gaia::db::get_txn_id());
+            gaia_log::rules().trace("call:'{}', src_txn:'{}', new_txn:'{}'", rule_id, rule_invocation.src_txn_id, gaia::db::get_current_txn_id());
             rule_invocation.rule_fn(&context);
             gaia_log::rules().trace("return:'{}'", rule_id);
             m_stats_manager.compute_rule_execution_time(rule_id, fn_start);


### PR DESCRIPTION
Removed the client-only get_txn_id() method and switched all uses get_current_txn_id()