### PR TITLE
Remove gaia_db_internal.hpp from includes in record_list.hpp

### DIFF
--- a/production/db/inc/core/record_list.hpp
+++ b/production/db/inc/core/record_list.hpp
@@ -13,7 +13,6 @@
 #include "gaia_internal/common/generator_iterator.hpp"
 #include "gaia_internal/common/queue.hpp"
 #include "gaia_internal/db/db_types.hpp"
-#include "gaia_internal/db/gaia_db_internal.hpp"
 
 namespace gaia
 {


### PR DESCRIPTION
While poking around I saw this redundant include.