### PR TITLE
GAIAPLAT-1701: Use the table type and not its gaia id when reporting invalid subscriptions

### DIFF
--- a/production/rules/event_manager/inc/rule_checker.hpp
+++ b/production/rules/event_manager/inc/rule_checker.hpp
@@ -7,6 +7,8 @@
 
 #include "gaia/rules/rules.hpp"
 
+#include "gaia_internal/catalog/gaia_catalog.h"
+
 namespace gaia
 {
 namespace rules
@@ -48,7 +50,7 @@ public:
     bool is_valid_row(common::gaia_id_t row_id);
 
 private:
-    void check_fields(common::gaia_id_t id, const common::field_position_list_t& field_list);
+    void check_fields(const catalog::gaia_table_t& table, const common::field_position_list_t& field_list);
 
 private:
     bool m_enable_catalog_checks;

--- a/production/rules/event_manager/tests/test_rule_checker.cpp
+++ b/production/rules/event_manager/tests/test_rule_checker.cpp
@@ -143,8 +143,13 @@ TEST_F(rule_checker_test, field_not_found)
     rule_checker_t rule_checker;
     field_position_list_t fields;
     fields.emplace_back(field);
-    const char* message = "Field (position: 1000) was not found in table";
-    verify_exception(message, [&]() { rule_checker.check_catalog(g_table_type, fields); });
+
+    // Verify the entire message
+    std::stringstream message;
+    message << "Field (position: " << field << ") was not found in table 'Sensors' (type: '"
+            << g_table_type << "').";
+
+    verify_exception(message.str().c_str(), [&]() { rule_checker.check_catalog(g_table_type, fields); });
 }
 
 TEST_F(rule_checker_test, active_field)
@@ -172,10 +177,14 @@ TEST_F(rule_checker_test, deprecated_field)
 {
     rule_checker_t rule_checker;
     field_position_list_t fields;
-    fields.emplace_back(g_field_positions["deprecated"]);
-    const char* message = "deprecated";
+    field_position_t position = g_field_positions["deprecated"];
+    fields.emplace_back(position);
 
-    verify_exception(message, [&]() { rule_checker.check_catalog(g_table_type, fields); });
+    // Verify the entire message
+    std::stringstream message;
+    message << "Field 'deprecated' (position: " << position << ") in table 'Sensors' (type: '"
+            << g_table_type << "') is deprecated.";
+    verify_exception(message.str().c_str(), [&]() { rule_checker.check_catalog(g_table_type, fields); });
 }
 
 TEST_F(rule_checker_test, multiple_valid_fields)


### PR DESCRIPTION
@LaurentiuCristofor found this issue when working on changes to `gaia_id_t`.  The rule checker was reporting the `gaia_id` instead of the `gaia_type` when throwing an `invalid_subscription` exception.  This code was left over from the days when the type used to be the row in the catalog `gaia_table_t`.

Updated the code and added tests to verify that the type is indeed correct.