### PR TITLE
Move global compile definitions to Gaia-target-specific scope

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -45,11 +45,6 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 include(gaia_internal)
 include(GoogleTest)
 
-# Ensure Debug builds have the DEBUG macro defined.
-# REVIEW: This should really be `add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)`,
-# but that makes it harder to pass to `ExternalProject_Add()`.
-add_compile_options("$<$<CONFIG:Debug>:-DDEBUG>")
-
 # Check that PIE flags are actually passed to the linker.
 # This ensures that our executables are ASLR-compatible.
 include(CheckPIESupported)
@@ -80,6 +75,8 @@ endif(CCACHE_FOUND)
 # Default compiler/linker flags for Gaia targets.
 add_library(gaia_build_options INTERFACE)
 target_compile_options(gaia_build_options INTERFACE -Wall -Wextra -ftime-trace)
+# Ensure Debug builds have the DEBUG macro defined.
+target_compile_definitions(gaia_build_options INTERFACE $<$<CONFIG:Debug>:DEBUG>)
 
 # LLVM and CLANG specific options.
 if(BUILD_GAIA_RELEASE OR BUILD_GAIA_LLVM_TESTS)

--- a/third_party/production/flatbuffers/CMakeLists.txt
+++ b/third_party/production/flatbuffers/CMakeLists.txt
@@ -22,6 +22,13 @@ endif()
 # way to handle generator expressions. For now, we don't use add_compile_definitions() in our
 # top-level CMakeLists.txt, for just this reason.
 
+# Check that there are no COMPILE_DEFINITIONS in this scope.
+get_property(FLATBUFFERS_COMPILE_DEFINITIONS DIRECTORY PROPERTY COMPILE_DEFINITIONS)
+list(LENGTH FLATBUFFERS_COMPILE_DEFINITIONS FLATBUFFERS_COMPILE_DEFINITIONS_COUNT)
+if(FLATBUFFERS_COMPILE_DEFINITIONS_COUNT GREATER 0)
+  message(FATAL_ERROR "Global compile definitions detected, aborting configuration: ${FLATBUFFERS_COMPILE_DEFINITIONS}")
+endif()
+
 get_property(FLATBUFFERS_COMPILE_OPTIONS DIRECTORY PROPERTY COMPILE_OPTIONS)
 string(REPLACE ";" " " FLATBUFFERS_COMPILE_OPTIONS "${FLATBUFFERS_COMPILE_OPTIONS}")
 


### PR DESCRIPTION
I noticed when trying to run `make-check` on a Debug build (to run LLVM unit tests) that the build failed because the `DEBUG` macro defined in global compile options was conflicting with a `DEBUG` constant defined in an LLVM source file. This fix is necessary to avoid this sort of conflict in general, but unfortunately it's not sufficient to resolve this particular conflict, because it turns out that our LLVM fork circularly depends on Gaia targets (specifically the `gaia_system` static lib). I created https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1753 to address this issue.

I also added a check to ensure that no global compile definitions are in scope when we add the flatbuffers external target (because I haven't found a way to correctly import compile definitions with generator expressions). This will be moved to a generic function that generalizes the approach I took for the flatbuffers dependency in https://github.com/gaia-platform/GaiaPlatform/pull/1114. This work is tracked in https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1754.