### PR TITLE
Fix compiler warnings for int_type_t and memory_manager_t clases

### DIFF
--- a/production/common/src/int_type.cpp
+++ b/production/common/src/int_type.cpp
@@ -12,82 +12,92 @@ namespace gaia
 namespace common
 {
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>::operator T() const
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator T_type() const
 {
     return m_value;
 }
 
-template <typename T, T default_invalid_value, typename C>
-T& int_type_t<T, default_invalid_value, C>::value_ref()
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+T_type&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::value_ref()
 {
     return m_value;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator+=(
-    const int_type_t<T, default_invalid_value, C>& other)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator+=(
+    const int_type_t<T_type, default_invalid_value, T_type_constraint>& other)
 {
     this->m_value += other.m_value;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator-=(
-    const int_type_t<T, default_invalid_value, C>& other)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator-=(
+    const int_type_t<T_type, default_invalid_value, T_type_constraint>& other)
 {
     this->m_value -= other.m_value;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator*=(
-    const int_type_t<T, default_invalid_value, C>& other)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator*=(
+    const int_type_t<T_type, default_invalid_value, T_type_constraint>& other)
 {
     this->m_value *= other.m_value;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator/=(
-    const int_type_t<T, default_invalid_value, C>& other)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator/=(
+    const int_type_t<T_type, default_invalid_value, T_type_constraint>& other)
 {
     this->m_value /= other.m_value;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator%=(
-    const int_type_t<T, default_invalid_value, C>& other)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator%=(
+    const int_type_t<T_type, default_invalid_value, T_type_constraint>& other)
 {
     this->m_value %= other.m_value;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator++()
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator++()
 {
     this->m_value += 1;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C> int_type_t<T, default_invalid_value, C>::operator++(int)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator++(int)
 {
     int_type_t pre_value = *this;
     this->m_value += 1;
     return pre_value;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C>& int_type_t<T, default_invalid_value, C>::operator--()
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>&
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator--()
 {
     this->m_value -= 1;
     return *this;
 }
 
-template <typename T, T default_invalid_value, typename C>
-int_type_t<T, default_invalid_value, C> int_type_t<T, default_invalid_value, C>::operator--(int)
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>
+int_type_t<T_type, default_invalid_value, T_type_constraint>::operator--(int)
 {
     int_type_t pre_value = *this;
     this->m_value -= 1;

--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -99,7 +99,7 @@ chunk_offset_t memory_manager_t::allocate_unused_chunk()
                 && next_chunk_offset <= c_last_chunk_offset,
             "next_chunk_offset is out of range!");
 
-        chunk_offset_t allocated_chunk_offset = static_cast<chunk_offset_t>(next_chunk_offset);
+        auto allocated_chunk_offset = static_cast<chunk_offset_t>(next_chunk_offset);
 
         // Now try to claim this chunk.
         chunk_manager_t chunk_manager;

--- a/production/inc/gaia/int_type.hpp
+++ b/production/inc/gaia/int_type.hpp
@@ -28,39 +28,39 @@ namespace common
  * @brief This class defines a base class for type-safe custom integer-based types.
  * It provides a type-safe alternative to using typedef.
  *
- * @tparam T The integer type used by this class.
+ * @tparam T_type The integer type used by this class.
  * @tparam default_invalid_value The default invalid value to be used with this type.
- * @tparam C A constraint on the types accepted for T.
+ * @tparam T_type_constraint A constraint on the types accepted for T_type.
  */
-template <typename T, T default_invalid_value, typename C = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T_type, T_type default_invalid_value, typename T_type_constraint = std::enable_if_t<std::is_integral<T_type>::value>>
 class int_type_t
 {
 public:
-    using value_type = T;
+    using value_type = T_type;
 
-    static constexpr T c_default_invalid_value = default_invalid_value;
+    static constexpr T_type c_default_invalid_value = default_invalid_value;
 
     constexpr int_type_t()
         : m_value(default_invalid_value)
     {
     }
 
-    constexpr int_type_t(T value)
+    constexpr int_type_t(T_type value)
         : m_value(value)
     {
     }
 
     // This conversion operator will enable many direct operations with integers.
-    operator T() const;
+    operator T_type() const;
 
     // For explicit retrieval of contained value.
-    constexpr T value() const
+    constexpr T_type value() const
     {
         return m_value;
     }
 
     // For direct updating of contained value.
-    T& value_ref();
+    T_type& value_ref();
 
     // For additional safety (so as to prevent the mixing of apples and oranges),
     // all these operators will only allow operations with identical types.
@@ -77,7 +77,7 @@ public:
     int_type_t operator--(int);
 
 protected:
-    T m_value;
+    T_type m_value;
 };
 
 /*@}*/


### PR DESCRIPTION
Just a few quick fixes to silence compiler warnings.