### PR TITLE
[GAIAPLAT-1635] Replace gaia_ptr_t public ctor with from_locator() method

### DIFF
--- a/production/db/core/src/db_jni_wrapper.cpp
+++ b/production/db/core/src/db_jni_wrapper.cpp
@@ -94,7 +94,7 @@ jboolean update_payload(
             return false;
         }
 
-        gaia_ptr_t t = gaia_ptr_t::open(id);
+        gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
         if (t)
         {
             t.update_payload(payload_holder.size(), payload_holder.bytes());
@@ -113,7 +113,7 @@ jboolean remove(jlong id)
 {
     try
     {
-        gaia_ptr_t t = gaia_ptr_t::open(id);
+        gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
         if (t)
         {
             gaia_ptr_t::remove(t);
@@ -144,7 +144,7 @@ jlong find_first(jlong type)
 
 jlong find_next(jlong id)
 {
-    gaia_ptr_t t = gaia_ptr_t::open(id);
+    gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
     if (!t)
     {
         return NULL;
@@ -161,7 +161,7 @@ jlong find_next(jlong id)
 
 jlong get_type(jlong id)
 {
-    gaia_ptr_t t = gaia_ptr_t::open(id);
+    gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
     if (!t)
     {
         return NULL;
@@ -172,7 +172,7 @@ jlong get_type(jlong id)
 
 jbyteArray get_payload(JNIEnv* env, jlong id)
 {
-    gaia_ptr_t t = gaia_ptr_t::open(id);
+    gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
     if (!t || t.data_size() == 0)
     {
         // NOLINTNEXTLINE(modernize-use-nullptr)

--- a/production/db/core/src/db_pybind_wrapper.cpp
+++ b/production/db/core/src/db_pybind_wrapper.cpp
@@ -112,7 +112,7 @@ PYBIND11_MODULE(gaia_db_pybind, m)
         .def_static(
             "create",
             static_cast<gaia_ptr_t (*)(gaia_id_t, gaia_type_t, reference_offset_t, size_t, const void*)>(&gaia_ptr_t::create))
-        .def_static("open", &gaia_ptr_t::open)
+        .def_static("from_gaia_id", &gaia_ptr_t::from_gaia_id)
         .def_static("find_first", &gaia_ptr_t::find_first)
         .def_static("remove", &gaia_ptr_t::remove)
         .def("is_null", &gaia_ptr_t::is_null)

--- a/production/db/core/src/gaia_ptr.cpp
+++ b/production/db/core/src/gaia_ptr.cpp
@@ -26,7 +26,13 @@ gaia_id_t gaia_ptr_t::generate_id()
     return allocate_id();
 }
 
-gaia_ptr_t gaia_ptr_t::open(
+gaia_ptr_t gaia_ptr_t::from_locator(
+    gaia_locator_t locator)
+{
+    return gaia_ptr_t(locator);
+}
+
+gaia_ptr_t gaia_ptr_t::from_gaia_id(
     common::gaia_id_t id)
 {
     return gaia_ptr_t(db_hash_map::find(id));
@@ -84,7 +90,7 @@ std::optional<gaia_ptr_t> gaia_ptr_generator_t::operator()()
     std::optional<gaia_id_t> id_opt;
     while ((id_opt = (*m_id_generator)()))
     {
-        gaia_ptr_t gaia_ptr = gaia_ptr_t::open(*id_opt);
+        gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(*id_opt);
         if (gaia_ptr)
         {
             return gaia_ptr;

--- a/production/db/core/tests/test_db_client.cpp
+++ b/production/db/core/tests/test_db_client.cpp
@@ -150,14 +150,14 @@ TEST_F(db_client_test, creation_fail_for_invalid_type)
 TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
 {
     begin_transaction();
-    gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
+    gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
     commit_transaction();
 
     // Create with existent type fail
     EXPECT_THROW(gaia_ptr_t::create(type1, 0, ""), no_open_transaction);
     EXPECT_THROW(gaia_ptr_t::create(99999, type1, 0, ""), no_open_transaction);
     EXPECT_THROW(gaia_ptr_t::create(99999, type1, 5, 0, ""), no_open_transaction);
-    EXPECT_THROW(gaia_ptr_t::open(node1_id), no_open_transaction);
+    EXPECT_THROW(gaia_ptr_t::from_gaia_id(node1_id), no_open_transaction);
     EXPECT_THROW(node1.id(), no_open_transaction);
     EXPECT_THROW(node1.type(), no_open_transaction);
     EXPECT_THROW(node1.data_size(), no_open_transaction);
@@ -179,7 +179,7 @@ TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
     //    EXPECT_THROW(gaia_ptr_t::create(type3, 0, 0), transaction_not_open);
     //    EXPECT_THROW(gaia_ptr_t::create(99999, type3, 0, 0), transaction_not_open);
     //    EXPECT_THROW(gaia_ptr_t::create(99999, type3, 5, 0, 0), transaction_not_open);
-    //    EXPECT_THROW(gaia_ptr_t::open(99999), transaction_not_open);
+    //    EXPECT_THROW(gaia_ptr_t::from_gaia_id(99999), transaction_not_open);
 }
 
 TEST_F(db_client_test, read_data)
@@ -188,10 +188,10 @@ TEST_F(db_client_test, read_data)
     {
         std::cerr << std::endl;
         std::cerr << "*** Update payload and verify" << std::endl;
-        gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
-        gaia_ptr_t node2 = gaia_ptr_t::open(node2_id);
-        gaia_ptr_t node3 = gaia_ptr_t::open(node3_id);
-        gaia_ptr_t node4 = gaia_ptr_t::open(node4_id);
+        gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
+        gaia_ptr_t node2 = gaia_ptr_t::from_gaia_id(node2_id);
+        gaia_ptr_t node3 = gaia_ptr_t::from_gaia_id(node3_id);
+        gaia_ptr_t node4 = gaia_ptr_t::from_gaia_id(node4_id);
         print_node(node1);
         print_node(node2);
         print_node(node3);
@@ -211,7 +211,7 @@ TEST_F(db_client_test, update_payload)
     {
         std::cerr << std::endl;
         std::cerr << "*** Update payload and verify" << std::endl;
-        gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
+        gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
         print_node(node1);
         node1.update_payload(strlen(payload), payload);
         print_node(node1);
@@ -223,7 +223,7 @@ TEST_F(db_client_test, update_payload)
     {
         std::cerr << std::endl;
         std::cerr << "*** Reload data and verify update" << std::endl;
-        gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
+        gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
         print_node(node1);
         EXPECT_STREQ(node1.data(), payload);
     }
@@ -237,7 +237,7 @@ TEST_F(db_client_test, update_payload_rollback)
     {
         std::cerr << std::endl;
         std::cerr << "*** Update payload and verify" << std::endl;
-        gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
+        gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
         print_node(node1);
         node1.update_payload(strlen(payload), payload);
         print_node(node1);
@@ -249,7 +249,7 @@ TEST_F(db_client_test, update_payload_rollback)
     {
         std::cerr << std::endl;
         std::cerr << "*** Reload data and verify update" << std::endl;
-        gaia_ptr_t node1 = gaia_ptr_t::open(node1_id);
+        gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);
         print_node(node1);
         EXPECT_EQ(node1.data(), nullptr);
     }

--- a/production/db/query_processor/src/index_scan.cpp
+++ b/production/db/query_processor/src/index_scan.cpp
@@ -50,13 +50,13 @@ index_scan_iterator_t::index_scan_iterator_t(gaia::common::gaia_id_t index_id, s
     else
     {
         // This will result in the index scan init() method being called.
-        auto ptr = db::gaia_ptr_t(m_scan_impl->locator());
+        auto ptr = db::gaia_ptr_t::from_locator(m_scan_impl->locator());
 
         // Advance scan to next row passing our filters.
         while (!m_scan_state.should_return_row(ptr))
         {
             m_scan_impl->next_visible_locator();
-            ptr = db::gaia_ptr_t(m_scan_impl->locator());
+            ptr = db::gaia_ptr_t::from_locator(m_scan_impl->locator());
         }
         m_gaia_ptr = ptr;
     }
@@ -71,13 +71,13 @@ index_scan_iterator_t index_scan_iterator_t::operator++()
     else
     {
         m_scan_impl->next_visible_locator();
-        auto ptr = db::gaia_ptr_t(m_scan_impl->locator());
+        auto ptr = db::gaia_ptr_t::from_locator(m_scan_impl->locator());
 
         // Advance scan to next row passing our filters.
         while (!m_scan_state.should_return_row(ptr))
         {
             m_scan_impl->next_visible_locator();
-            ptr = db::gaia_ptr_t(m_scan_impl->locator());
+            ptr = db::gaia_ptr_t::from_locator(m_scan_impl->locator());
         }
 
         m_gaia_ptr = ptr;

--- a/production/direct_access/src/dac_base.cpp
+++ b/production/direct_access/src/dac_base.cpp
@@ -95,7 +95,7 @@ bool dac_db_t::advance_iterator(std::shared_ptr<dac_base_iterator_state_t> itera
 // Otherwise, returns false.
 bool dac_db_t::get_type(gaia_id_t id, gaia_type_t& type)
 {
-    gaia_ptr_t gaia_ptr = gaia_ptr_t::open(id);
+    gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(id);
     if (gaia_ptr)
     {
         type = gaia_ptr.type();
@@ -107,7 +107,7 @@ bool dac_db_t::get_type(gaia_id_t id, gaia_type_t& type)
 
 gaia_id_t dac_db_t::get_reference(gaia_id_t id, common::reference_offset_t slot)
 {
-    gaia_ptr_t gaia_ptr = gaia_ptr_t::open(id);
+    gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(id);
     if (!gaia_ptr)
     {
         throw invalid_object_id_internal(id);
@@ -125,7 +125,7 @@ gaia_id_t dac_db_t::insert(gaia_type_t container, size_t data_size, const void* 
 
 void dac_db_t::delete_row(gaia_id_t id)
 {
-    gaia_ptr_t gaia_ptr = gaia_ptr_t::open(id);
+    gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(id);
     if (!gaia_ptr)
     {
         throw invalid_object_id_internal(id);
@@ -136,7 +136,7 @@ void dac_db_t::delete_row(gaia_id_t id)
 
 void dac_db_t::update(gaia_id_t id, size_t data_size, const void* data)
 {
-    gaia_ptr_t gaia_ptr = gaia_ptr_t::open(id);
+    gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(id);
     if (!gaia_ptr)
     {
         throw invalid_object_id_internal(id);
@@ -146,7 +146,7 @@ void dac_db_t::update(gaia_id_t id, size_t data_size, const void* data)
 
 bool dac_db_t::insert_child_reference(gaia_id_t parent_id, gaia_id_t child_id, common::reference_offset_t child_slot)
 {
-    gaia_ptr_t parent = gaia_ptr_t::open(parent_id);
+    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
     if (!parent)
     {
         throw invalid_object_id_internal(parent_id);
@@ -157,7 +157,7 @@ bool dac_db_t::insert_child_reference(gaia_id_t parent_id, gaia_id_t child_id, c
 
 bool dac_db_t::remove_child_reference(gaia_id_t parent_id, gaia_id_t child_id, common::reference_offset_t child_slot)
 {
-    gaia_ptr_t parent = gaia_ptr_t::open(parent_id);
+    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
     if (!parent)
     {
         throw invalid_object_id_internal(parent_id);
@@ -217,7 +217,7 @@ template const gaia_ptr_t* dac_base_t::to_const_ptr() const;
 
 dac_base_t::dac_base_t(gaia_id_t id)
 {
-    *(to_ptr<gaia_ptr_t>()) = gaia_ptr_t::open(id);
+    *(to_ptr<gaia_ptr_t>()) = gaia_ptr_t::from_gaia_id(id);
 }
 
 gaia_id_t dac_base_t::gaia_id() const
@@ -253,7 +253,7 @@ gaia_id_t* dac_base_t::references() const
 
 void dac_base_t::set_record(common::gaia_id_t new_id)
 {
-    *(to_ptr<gaia_ptr_t>()) = gaia_ptr_t::open(new_id);
+    *(to_ptr<gaia_ptr_t>()) = gaia_ptr_t::from_gaia_id(new_id);
 }
 
 //

--- a/production/direct_access/tests/test_references.cpp
+++ b/production/direct_access/tests/test_references.cpp
@@ -39,7 +39,7 @@ protected:
 
         for (int i = c_lower_id_range; i < c_higher_id_range; i++)
         {
-            auto invalid_obj = gaia_ptr_t::open(i);
+            auto invalid_obj = gaia_ptr_t::from_gaia_id(i);
 
             if (!invalid_obj)
             {

--- a/production/inc/gaia_internal/db/gaia_ptr.hpp
+++ b/production/inc/gaia_internal/db/gaia_ptr.hpp
@@ -31,10 +31,11 @@ class gaia_ptr_t
 public:
     gaia_ptr_t() = default;
 
-    inline explicit gaia_ptr_t(gaia_locator_t locator)
-        : m_locator(locator)
-    {
-    }
+    static gaia_ptr_t from_locator(
+        gaia_locator_t locator);
+
+    static gaia_ptr_t from_gaia_id(
+        common::gaia_id_t id);
 
     inline bool operator==(const gaia_ptr_t& other) const;
     inline bool operator!=(const gaia_ptr_t& other) const;
@@ -63,9 +64,6 @@ public:
         common::reference_offset_t num_refs,
         size_t data_size,
         const void* data);
-
-    static gaia_ptr_t open(
-        common::gaia_id_t id);
 
     // Removes the database record at the given pointer object. Throws
     // exceptions in case of referential integrity violation.
@@ -262,6 +260,11 @@ private:
 
 private:
     gaia_locator_t m_locator{c_invalid_gaia_locator};
+
+    inline explicit gaia_ptr_t(gaia_locator_t locator)
+        : m_locator(locator)
+    {
+    }
 };
 
 static_assert(

--- a/production/rules/event_manager/src/rule_checker.cpp
+++ b/production/rules/event_manager/src/rule_checker.cpp
@@ -163,6 +163,6 @@ bool rule_checker_t::is_valid_row(gaia::common::gaia_id_t row_id)
         return true;
     }
 
-    gaia::db::gaia_ptr_t row_ptr = gaia::db::gaia_ptr_t::open(row_id);
+    gaia::db::gaia_ptr_t row_ptr = gaia::db::gaia_ptr_t::from_gaia_id(row_id);
     return static_cast<bool>(row_ptr);
 }

--- a/production/sql/src/gaia_fdw_adapter.cpp
+++ b/production/sql/src/gaia_fdw_adapter.cpp
@@ -1025,7 +1025,7 @@ bool modify_state_t::modify_record(uint64_t gaia_id, modify_operation_type_t mod
         }
         else if (modify_operation_type == modify_operation_type_t::update)
         {
-            record = gaia_ptr_t::open(gaia_id);
+            record = gaia_ptr_t::from_gaia_id(gaia_id);
 
             // Only update payload if it has changed.
             if (record.data_size() != m_current_payload->size()
@@ -1153,7 +1153,7 @@ bool modify_state_t::delete_record(uint64_t gaia_id)
 {
     try
     {
-        auto record = gaia_ptr_t::open(gaia_id);
+        auto record = gaia_ptr_t::from_gaia_id(gaia_id);
         if (!record)
         {
             ereport(

--- a/production/system/tests/test_recovery.cpp
+++ b/production/system/tests/test_recovery.cpp
@@ -585,19 +585,19 @@ TEST_F(recovery_test, reference_create_delete_test_new)
         auto_transaction_t txn;
 
         // Get the parent.
-        gaia_ptr_t parent = gaia_ptr_t::open(parent_id);
+        gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
         // Make sure address cannot be deleted upon recovery.
         ASSERT_THROW(gaia_ptr_t::remove(parent), object_still_referenced);
 
         // Find the children.
-        gaia_ptr_t first_child = gaia_ptr_t::open(parent.references()[c_first_patient_offset]);
+        gaia_ptr_t first_child = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
         children_ids.push_back(first_child.id());
-        gaia_ptr_t next_child = gaia_ptr_t::open(first_child.references()[c_next_patient_offset]);
+        gaia_ptr_t next_child = gaia_ptr_t::from_gaia_id(first_child.references()[c_next_patient_offset]);
 
         while (next_child)
         {
             children_ids.push_back(next_child.id());
-            next_child = gaia_ptr_t::open(next_child.references()[c_next_patient_offset]);
+            next_child = gaia_ptr_t::from_gaia_id(next_child.references()[c_next_patient_offset]);
         }
 
         // Ensure parent has all the children
@@ -616,7 +616,7 @@ TEST_F(recovery_test, reference_create_delete_test_new)
             }
             else
             {
-                gaia_ptr_t child = gaia_ptr_t::open(child_id);
+                gaia_ptr_t child = gaia_ptr_t::from_gaia_id(child_id);
                 child.remove_parent_reference(c_parent_doctor_offset);
             }
         }
@@ -631,7 +631,7 @@ TEST_F(recovery_test, reference_create_delete_test_new)
         auto_transaction_t txn;
 
         // Get the parent.
-        gaia_ptr_t parent = gaia_ptr_t::open(parent_id);
+        gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
 
         // Ensure the parent does not have children
         ASSERT_EQ(c_invalid_gaia_id, parent.references()[c_first_patient_offset]);
@@ -682,7 +682,7 @@ TEST_F(recovery_test, reference_update_test_new)
         new_parent_id = new_parent.id();
 
         // Get the child
-        gaia_ptr_t child = gaia_ptr_t::open(child_id);
+        gaia_ptr_t child = gaia_ptr_t::from_gaia_id(child_id);
         child.update_parent_reference(new_parent_id, c_parent_doctor_offset);
 
         txn.commit();
@@ -695,9 +695,9 @@ TEST_F(recovery_test, reference_update_test_new)
     {
         auto_transaction_t txn;
 
-        gaia_ptr_t parent = gaia_ptr_t::open(parent_id);
-        gaia_ptr_t child = gaia_ptr_t::open(child_id);
-        gaia_ptr_t new_parent = gaia_ptr_t::open(new_parent_id);
+        gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
+        gaia_ptr_t child = gaia_ptr_t::from_gaia_id(child_id);
+        gaia_ptr_t new_parent = gaia_ptr_t::from_gaia_id(new_parent_id);
 
         ASSERT_EQ(c_invalid_gaia_id, parent.references()[c_first_patient_offset]);
         ASSERT_EQ(new_parent_id, child.references()[c_parent_doctor_offset]);

--- a/production/tools/gaia_db_extract/inc/table_iterator.hpp
+++ b/production/tools/gaia_db_extract/inc/table_iterator.hpp
@@ -29,7 +29,10 @@ class table_iterator_t
 
 public:
     table_iterator_t()
-        : m_table_name(nullptr), m_container_id(0), m_current_record(0), m_current_payload(nullptr)
+        : m_table_name(nullptr)
+        , m_container_id(0)
+        , m_current_record(db::gaia_ptr_t::from_locator(db::c_invalid_gaia_locator))
+        , m_current_payload(nullptr)
     {
     }
 

--- a/production/tools/gaia_db_extract/src/table_iterator.cpp
+++ b/production/tools/gaia_db_extract/src/table_iterator.cpp
@@ -46,7 +46,7 @@ bool table_iterator_t::initialize_scan(gaia_type_t container_id, gaia_id_t start
     {
         if (start_after != 0)
         {
-            m_current_record = gaia_ptr_t::open(start_after);
+            m_current_record = gaia_ptr_t::from_gaia_id(start_after);
             if (m_current_record.type() != container_id)
             {
                 fprintf(stderr, "Starting row is not correct type.\n");

--- a/production/tools/gaia_dump/src/gaia_dump.cpp
+++ b/production/tools/gaia_dump/src/gaia_dump.cpp
@@ -163,7 +163,7 @@ string gaia_dump(gaia_id_t low, gaia_id_t high, bool payload, bool references, b
     {
         try
         {
-            auto node_ptr = gaia_ptr_t::open(id);
+            auto node_ptr = gaia_ptr_t::from_gaia_id(id);
             if (node_ptr)
             {
                 // If 'catalog' is true, don't check the catalog range.


### PR DESCRIPTION
Replace `gaia_ptr_t` public ctor with `from_locator(gaia_locator_t)` method. Thanks to the recent refactoring that introduced strongly typed integer types this was no longer strictly necessary. Anyway, it provides a more coherent API.

- Repalce `gaia_ptr_t` public constructor with factory method: `from_locator(gaia_locator_t)`.
- Rename `gaia_ptr_t::open()` method with `gaia_ptr_t::from_gaia_id(gaia_id_t)`.