### PR TITLE
[GAIAPLAT-1808] Remove VLR code from direct_access example

### DIFF
--- a/production/examples/direct_access/hospital.ddl
+++ b/production/examples/direct_access/hospital.ddl
@@ -7,7 +7,6 @@ database hospital
 
 table doctor (
     name string,
-    email string unique,
     patients references patient[]
 )
 
@@ -15,10 +14,8 @@ table patient (
     name string,
     height uint8,
     is_active bool,
-    doctor_email string,
     analysis_results float[],
-    doctor references doctor
-        where patient.doctor_email = doctor.email,
+    doctor references doctor,
     address references address
 )
 


### PR DESCRIPTION
I was checking the `direct_access` example after @daxhaw suggestion and it turns out is broken because of the latest VLR changes. 

I have removed the VLR code from the example because I believe it deserves its own example. Created follow-up task for it: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1809

- Updated `lookup_invalid_record()`