### PR TITLE
Fail with error message when incorrect options are given to gdev

### DIFF
--- a/dev_tools/gdev/gdev/dependency.py
+++ b/dev_tools/gdev/gdev/dependency.py
@@ -138,6 +138,7 @@ class Dependency:
             parser.add_argument(
                 '--base-image',
                 default=base_image_default,
+                choices=['ubuntu:18.04', 'ubuntu:20.04'],
                 help=f'Base image for build. Default: "{base_image_default}"'
             )
             cfg_enables_default = []
@@ -146,6 +147,7 @@ class Dependency:
                 default=cfg_enables_default,
                 action=Once,
                 nargs='+',
+                choices=['Debug', 'GaiaRelease', 'GaiaLLVMTests'],
                 help=(
                     f'Enable lines in gdev.cfg files gated by `enable_if`, `enable_if_any`, and'
                     f' `enable_if_all` functions. Default: "{cfg_enables_default}"'


### PR DESCRIPTION
This should have gone into the last PR, but it occurred to me after merging. We currently don't check the options given to `--cfg-enables` or `--base-image`, which means that typos will go undetected and gdev will silently fail to do the expected thing. This change makes the list of accepted choices for these options explicit and fails if the supplied value is not in the list.