### PR TITLE
Fix an ubsan error

### DIFF
--- a/production/catalog/src/catalog_facade.cpp
+++ b/production/catalog/src/catalog_facade.cpp
@@ -311,11 +311,8 @@ std::string link_facade_t::to_table() const
 
 bool link_facade_t::is_value_linked() const
 {
-    // This should never happen unless there are some catalog or DDL parsing bugs.
-    ASSERT_INVARIANT(
-        m_relationship.parent_field_positions().size() == m_relationship.child_field_positions().size(),
-        "Invalid field settings for the value linked relationship.");
-    return m_relationship.parent_field_positions().size() > 0;
+    return (!m_relationship.parent_field_positions().is_null())
+        && m_relationship.parent_field_positions().size() > 0;
 }
 
 bool link_facade_t::is_single_cardinality() const

--- a/production/db/core/src/catalog_core.cpp
+++ b/production/db/core/src/catalog_core.cpp
@@ -118,11 +118,7 @@ namespace db
 
 [[nodiscard]] bool relationship_view_t::is_value_linked() const
 {
-    // This should never happen unless there are some catalog or DDL parsing bugs.
-    ASSERT_PRECONDITION(
-        child_field_positions()->size() == parent_field_positions()->size(),
-        "Invalid field settings for the value linked relationship.");
-    return parent_field_positions()->size() > 0;
+    return parent_field_positions() != nullptr && parent_field_positions()->size() > 0;
 }
 
 [[nodiscard]] const char* index_view_t::name() const

--- a/production/inc/gaia/direct_access/dac_array.hpp
+++ b/production/inc/gaia/direct_access/dac_array.hpp
@@ -29,12 +29,17 @@ public:
     const T_type* data() const
     {
         return m_vector->data();
-    };
+    }
 
     uint32_t size() const
     {
         return m_vector->size();
-    };
+    }
+
+    bool is_null() const
+    {
+        return m_vector == nullptr;
+    }
 
     // Normally the operator "[]" should return a reference or const reference
     // to the array element. Given we only support arrays of basic types and the


### PR DESCRIPTION
Fix for https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1815

I think this is not a real issue because we won't have null vectors in fbs payload. On missing input or nullptr input, we will insert an empty vector right now. Nevertheless, this should fix the ubsan error and probably help with the null support in the future. 