### PR TITLE
Add gdev option to skip top-level build

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -58,7 +58,7 @@ echo "ASAN_OPTIONS = 'detect_leaks=0'" >> /etc/postgresql/12/main/environment
 # Default persistent store location.
 mkdir -p /var/lib/gaia/db
 
-[run]
+{enable_if_not('SkipBuild')}[run]
 cmake \
     --log-level=VERBOSE -Wno-dev \
     {enable_if('Debug')}-DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
This is a trivial change but I've found it quite useful when I want to specify build settings directly rather than let gdev choose them. Note that gdev still builds and installs all dependencies, this just skips building the CMake `production` project.