### PR TITLE
Add dummy sanitizer option for sanitizer-free debug builds

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -136,7 +136,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInf
 
     # Explicitly list all legal values for SANITIZER.
     # (This will eventually include ASAN, MSAN, TSAN.)
-    set_property(CACHE SANITIZER PROPERTY STRINGS "ASAN")
+    set_property(CACHE SANITIZER PROPERTY STRINGS "ASAN" "NONE")
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")


### PR DESCRIPTION
This change allows disabling all sanitizers in debug builds by adding a dummy option `NONE` to the `SANITIZER` cache variable. (I originally thought that I could disable all sanitizers by just specifying `-USANITIZER` on the cmake command line, but that doesn't work.) The build will still get a useless `-fno-sanitize-recover=all` in the compile and link options, but that seems harmless.

Use case is that sometimes I need to see how an ASan/UBSan violation will manifest without any sanitizers being enabled (might be an assert, segfault, nothing). I still need a debug build to enable asserts (in LLVM), but I want to disable all sanitizers.