### PR TITLE
Move new fields to last

### DIFF
--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -47,7 +47,6 @@ namespace catalog
 static constexpr char c_assert_throw_and_auto_drop[]
     = "Cannot auto drop and skip on exists at the same time.";
 static constexpr char c_empty_hash[] = "";
-static constexpr char c_empty_type_name[] = "";
 
 ddl_executor_t::ddl_executor_t()
 {
@@ -87,17 +86,15 @@ void ddl_executor_t::bootstrap_catalog()
         //     is_system bool,
         //     binary_schema uint8[],
         //     serialization_template uint8[],
-        //     hash string,
-        //     type_name string,
+        //     hash string
         // );
         field_def_list_t fields;
         fields.emplace_back(make_unique<data_field_def_t>("name", data_type_t::e_string, 1));
-        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
-        fields.emplace_back(make_unique<data_field_def_t>("type_name", data_type_t::e_string, 1));
         fields.emplace_back(make_unique<data_field_def_t>("type", data_type_t::e_uint32, 1));
         fields.emplace_back(make_unique<data_field_def_t>("is_system", data_type_t::e_bool, 1));
         fields.emplace_back(make_unique<data_field_def_t>("binary_schema", data_type_t::e_uint8, 0));
         fields.emplace_back(make_unique<data_field_def_t>("serialization_template", data_type_t::e_uint8, 0));
+        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_table", fields, is_system, throw_on_exists, auto_drop,
             static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_table));
@@ -125,13 +122,13 @@ void ddl_executor_t::bootstrap_catalog()
         // );
         field_def_list_t fields;
         fields.emplace_back(make_unique<data_field_def_t>("name", data_type_t::e_string, 1));
-        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
         fields.emplace_back(make_unique<data_field_def_t>("type", data_type_t::e_uint8, 1));
         fields.emplace_back(make_unique<data_field_def_t>("repeated_count", data_type_t::e_uint16, 1));
         fields.emplace_back(make_unique<data_field_def_t>("position", data_type_t::e_uint16, 1));
         fields.emplace_back(make_unique<data_field_def_t>("deprecated", data_type_t::e_bool, 1));
         fields.emplace_back(make_unique<data_field_def_t>("active", data_type_t::e_bool, 1));
         fields.emplace_back(make_unique<data_field_def_t>("unique", data_type_t::e_bool, 1));
+        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_field", fields, is_system, throw_on_exists, auto_drop,
             static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_field));
@@ -164,7 +161,6 @@ void ddl_executor_t::bootstrap_catalog()
         // );
         field_def_list_t fields;
         fields.emplace_back(make_unique<data_field_def_t>("name", data_type_t::e_string, 1));
-        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
         fields.emplace_back(make_unique<data_field_def_t>("to_parent_link_name", data_type_t::e_string, 1));
         fields.emplace_back(make_unique<data_field_def_t>("to_child_link_name", data_type_t::e_string, 1));
         fields.emplace_back(make_unique<data_field_def_t>("cardinality", data_type_t::e_uint8, 1));
@@ -176,6 +172,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("parent_offset", data_type_t::e_uint16, 1));
         fields.emplace_back(make_unique<data_field_def_t>("parent_field_positions", data_type_t::e_uint16, 0));
         fields.emplace_back(make_unique<data_field_def_t>("child_field_positions", data_type_t::e_uint16, 0));
+        fields.emplace_back(make_unique<data_field_def_t>("hash", data_type_t::e_string, 1));
         // See gaia::db::relationship_t for more details about relationships.
         create_table_impl(
             c_catalog_db_name, "gaia_relationship", fields, is_system, throw_on_exists, auto_drop,
@@ -761,7 +758,6 @@ gaia_id_t ddl_executor_t::create_relationship(
 
     gaia_id_t relationship_id = gaia_relationship_t::insert_row(
         name.c_str(),
-        c_empty_hash,
         to_parent_link_name,
         to_child_link_name,
         static_cast<uint8_t>(cardinality),
@@ -772,7 +768,8 @@ gaia_id_t ddl_executor_t::create_relationship(
         prev_child_offset,
         parent_offset,
         *parent_field_position_values,
-        *child_field_position_values);
+        *child_field_position_values,
+        c_empty_hash);
 
     gaia_table_t::get(parent_table_id).outgoing_relationships().insert(relationship_id);
     gaia_table_t::get(child_table_id).incoming_relationships().insert(relationship_id);
@@ -1112,12 +1109,11 @@ gaia_id_t ddl_executor_t::create_table_impl(
 
     gaia_id_t table_id = gaia_table_t::insert_row(
         table_name.c_str(),
-        c_empty_hash,
-        c_empty_type_name,
         table_type,
         is_system,
         bfbs,
-        bin);
+        bin,
+        c_empty_hash);
 
     gaia_log::catalog().debug("Created table '{}', type:'{}', id:'{}'", table_name, table_type, table_id);
 
@@ -1135,13 +1131,13 @@ gaia_id_t ddl_executor_t::create_table_impl(
         const data_field_def_t* data_field = dynamic_cast<data_field_def_t*>(field.get());
         gaia_id_t field_id = gaia_field_t::insert_row(
             field->name.c_str(),
-            c_empty_hash,
             static_cast<uint8_t>(data_field->data_type),
             data_field->length,
             data_field_position,
             false,
             data_field->active,
-            data_field->unique);
+            data_field->unique,
+            c_empty_hash);
 
         // Connect the field to the table it belongs to.
         gaia_table_t::get(table_id).gaia_fields().insert(field_id);

--- a/production/catalog/src/gaia_catalog.cpp
+++ b/production/catalog/src/gaia_catalog.cpp
@@ -301,9 +301,9 @@ const char* gaia_relationship_t::gaia_typename() {
     static const char* gaia_typename = "gaia_relationship_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_relationship_t::insert_row(const char* name, const char* hash, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t prev_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions) {
+gaia::common::gaia_id_t gaia_relationship_t::insert_row(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t prev_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions, const char* hash) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
-    b.Finish(internal::Creategaia_relationshipDirect(b, name, hash, to_parent_link_name, to_child_link_name, cardinality, parent_required, deprecated, first_child_offset, next_child_offset, prev_child_offset, parent_offset, &parent_field_positions, &child_field_positions));
+    b.Finish(internal::Creategaia_relationshipDirect(b, name, to_parent_link_name, to_child_link_name, cardinality, parent_required, deprecated, first_child_offset, next_child_offset, prev_child_offset, parent_offset, &parent_field_positions, &child_field_positions, hash));
     return dac_object_t::insert_row(b);
 }
 gaia::direct_access::dac_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> gaia_relationship_t::list() {
@@ -311,9 +311,6 @@ gaia::direct_access::dac_container_t<c_gaia_type_gaia_relationship, gaia_relatio
 }
 const char* gaia_relationship_t::name() const {
     return GET_STR(name);
-}
-const char* gaia_relationship_t::hash() const {
-    return GET_STR(hash);
 }
 const char* gaia_relationship_t::to_parent_link_name() const {
     return GET_STR(to_parent_link_name);
@@ -348,6 +345,9 @@ gaia::direct_access::dac_vector_t<uint16_t> gaia_relationship_t::parent_field_po
 gaia::direct_access::dac_vector_t<uint16_t> gaia_relationship_t::child_field_positions() const {
     return GET_ARRAY(child_field_positions);
 }
+const char* gaia_relationship_t::hash() const {
+    return GET_STR(hash);
+}
 gaia_table_t gaia_relationship_t::child() const {
     gaia::common::gaia_id_t id = this->references()[c_gaia_relationship_parent_child];
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
@@ -367,9 +367,9 @@ const char* gaia_field_t::gaia_typename() {
     static const char* gaia_typename = "gaia_field_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_field_t::insert_row(const char* name, const char* hash, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique) {
+gaia::common::gaia_id_t gaia_field_t::insert_row(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique, const char* hash) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
-    b.Finish(internal::Creategaia_fieldDirect(b, name, hash, type, repeated_count, position, deprecated, active, unique));
+    b.Finish(internal::Creategaia_fieldDirect(b, name, type, repeated_count, position, deprecated, active, unique, hash));
     return dac_object_t::insert_row(b);
 }
 gaia::direct_access::dac_container_t<c_gaia_type_gaia_field, gaia_field_t> gaia_field_t::list() {
@@ -377,9 +377,6 @@ gaia::direct_access::dac_container_t<c_gaia_type_gaia_field, gaia_field_t> gaia_
 }
 const char* gaia_field_t::name() const {
     return GET_STR(name);
-}
-const char* gaia_field_t::hash() const {
-    return GET_STR(hash);
 }
 uint8_t gaia_field_t::type() const {
     return GET(type);
@@ -399,6 +396,9 @@ bool gaia_field_t::active() const {
 bool gaia_field_t::unique() const {
     return GET(unique);
 }
+const char* gaia_field_t::hash() const {
+    return GET_STR(hash);
+}
 gaia_table_t gaia_field_t::table() const {
     gaia::common::gaia_id_t id = this->references()[c_gaia_field_parent_table];
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
@@ -414,9 +414,9 @@ const char* gaia_table_t::gaia_typename() {
     static const char* gaia_typename = "gaia_table_t";
     return gaia_typename;
 }
-gaia::common::gaia_id_t gaia_table_t::insert_row(const char* name, const char* hash, const char* type_name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template) {
+gaia::common::gaia_id_t gaia_table_t::insert_row(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template, const char* hash) {
     flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
-    b.Finish(internal::Creategaia_tableDirect(b, name, hash, type_name, type, is_system, &binary_schema, &serialization_template));
+    b.Finish(internal::Creategaia_tableDirect(b, name, type, is_system, &binary_schema, &serialization_template, hash));
     return dac_object_t::insert_row(b);
 }
 gaia::direct_access::dac_container_t<c_gaia_type_gaia_table, gaia_table_t> gaia_table_t::list() {
@@ -424,12 +424,6 @@ gaia::direct_access::dac_container_t<c_gaia_type_gaia_table, gaia_table_t> gaia_
 }
 const char* gaia_table_t::name() const {
     return GET_STR(name);
-}
-const char* gaia_table_t::hash() const {
-    return GET_STR(hash);
-}
-const char* gaia_table_t::type_name() const {
-    return GET_STR(type_name);
 }
 uint32_t gaia_table_t::type() const {
     return GET(type);
@@ -442,6 +436,9 @@ gaia::direct_access::dac_vector_t<uint8_t> gaia_table_t::binary_schema() const {
 }
 gaia::direct_access::dac_vector_t<uint8_t> gaia_table_t::serialization_template() const {
     return GET_ARRAY(serialization_template);
+}
+const char* gaia_table_t::hash() const {
+    return GET_STR(hash);
 }
 gaia_database_t gaia_table_t::database() const {
     gaia::common::gaia_id_t id = this->references()[c_gaia_table_parent_database];

--- a/production/db/core/src/flatbuffers/gaia_field.fbs
+++ b/production/db/core/src/flatbuffers/gaia_field.fbs
@@ -1,12 +1,12 @@
 namespace gaia.db.catalog;
 table gaia_field {
     name:string;
-    hash:string;
     type:uint8;
     repeated_count:uint16;
     position:uint16;
     deprecated:bool;
     active:bool;
     unique:bool;
+    hash:string;
 }
 root_type gaia_field;

--- a/production/db/core/src/flatbuffers/gaia_relationship.fbs
+++ b/production/db/core/src/flatbuffers/gaia_relationship.fbs
@@ -1,7 +1,6 @@
 namespace gaia.db.catalog;
 table gaia_relationship {
     name:string;
-    hash:string;
     to_parent_link_name:string;
     to_child_link_name:string;
     cardinality:uint8;
@@ -13,5 +12,6 @@ table gaia_relationship {
     parent_offset:uint16;
     parent_field_positions:[uint16];
     child_field_positions:[uint16];
+    hash:string;
 }
 root_type gaia_relationship;

--- a/production/db/core/src/flatbuffers/gaia_table.fbs
+++ b/production/db/core/src/flatbuffers/gaia_table.fbs
@@ -1,11 +1,10 @@
 namespace gaia.db.catalog;
 table gaia_table {
     name:string;
-    hash:string;
-    type_name:string;
     type:uint32;
     is_system:bool;
     binary_schema:[uint8];
     serialization_template:[uint8];
+    hash:string;
 }
 root_type gaia_table;

--- a/production/inc/gaia_internal/catalog/catalog_generated.h
+++ b/production/inc/gaia_internal/catalog/catalog_generated.h
@@ -683,7 +683,6 @@ flatbuffers::Offset<gaia_ruleset> Creategaia_ruleset(flatbuffers::FlatBufferBuil
 struct gaia_relationshipT : public flatbuffers::NativeTable {
   typedef gaia_relationship TableType;
   gaia::direct_access::nullable_string_t name{};
-  gaia::direct_access::nullable_string_t hash{};
   gaia::direct_access::nullable_string_t to_parent_link_name{};
   gaia::direct_access::nullable_string_t to_child_link_name{};
   uint8_t cardinality = 0;
@@ -695,6 +694,7 @@ struct gaia_relationshipT : public flatbuffers::NativeTable {
   uint16_t parent_offset = 0;
   std::vector<uint16_t> parent_field_positions{};
   std::vector<uint16_t> child_field_positions{};
+  gaia::direct_access::nullable_string_t hash{};
 };
 
 struct gaia_relationship FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -702,24 +702,21 @@ struct gaia_relationship FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef gaia_relationshipBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
-    VT_HASH = 6,
-    VT_TO_PARENT_LINK_NAME = 8,
-    VT_TO_CHILD_LINK_NAME = 10,
-    VT_CARDINALITY = 12,
-    VT_PARENT_REQUIRED = 14,
-    VT_DEPRECATED = 16,
-    VT_FIRST_CHILD_OFFSET = 18,
-    VT_NEXT_CHILD_OFFSET = 20,
-    VT_PREV_CHILD_OFFSET = 22,
-    VT_PARENT_OFFSET = 24,
-    VT_PARENT_FIELD_POSITIONS = 26,
-    VT_CHILD_FIELD_POSITIONS = 28
+    VT_TO_PARENT_LINK_NAME = 6,
+    VT_TO_CHILD_LINK_NAME = 8,
+    VT_CARDINALITY = 10,
+    VT_PARENT_REQUIRED = 12,
+    VT_DEPRECATED = 14,
+    VT_FIRST_CHILD_OFFSET = 16,
+    VT_NEXT_CHILD_OFFSET = 18,
+    VT_PREV_CHILD_OFFSET = 20,
+    VT_PARENT_OFFSET = 22,
+    VT_PARENT_FIELD_POSITIONS = 24,
+    VT_CHILD_FIELD_POSITIONS = 26,
+    VT_HASH = 28
   };
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
-  }
-  const flatbuffers::String *hash() const {
-    return GetPointer<const flatbuffers::String *>(VT_HASH);
   }
   const flatbuffers::String *to_parent_link_name() const {
     return GetPointer<const flatbuffers::String *>(VT_TO_PARENT_LINK_NAME);
@@ -754,12 +751,13 @@ struct gaia_relationship FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<uint16_t> *child_field_positions() const {
     return GetPointer<const flatbuffers::Vector<uint16_t> *>(VT_CHILD_FIELD_POSITIONS);
   }
+  const flatbuffers::String *hash() const {
+    return GetPointer<const flatbuffers::String *>(VT_HASH);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
-           VerifyOffset(verifier, VT_HASH) &&
-           verifier.VerifyString(hash()) &&
            VerifyOffset(verifier, VT_TO_PARENT_LINK_NAME) &&
            verifier.VerifyString(to_parent_link_name()) &&
            VerifyOffset(verifier, VT_TO_CHILD_LINK_NAME) &&
@@ -775,6 +773,8 @@ struct gaia_relationship FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(parent_field_positions()) &&
            VerifyOffset(verifier, VT_CHILD_FIELD_POSITIONS) &&
            verifier.VerifyVector(child_field_positions()) &&
+           VerifyOffset(verifier, VT_HASH) &&
+           verifier.VerifyString(hash()) &&
            verifier.EndTable();
   }
   gaia_relationshipT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -788,9 +788,6 @@ struct gaia_relationshipBuilder {
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(gaia_relationship::VT_NAME, name);
-  }
-  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
-    fbb_.AddOffset(gaia_relationship::VT_HASH, hash);
   }
   void add_to_parent_link_name(flatbuffers::Offset<flatbuffers::String> to_parent_link_name) {
     fbb_.AddOffset(gaia_relationship::VT_TO_PARENT_LINK_NAME, to_parent_link_name);
@@ -825,6 +822,9 @@ struct gaia_relationshipBuilder {
   void add_child_field_positions(flatbuffers::Offset<flatbuffers::Vector<uint16_t>> child_field_positions) {
     fbb_.AddOffset(gaia_relationship::VT_CHILD_FIELD_POSITIONS, child_field_positions);
   }
+  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
+    fbb_.AddOffset(gaia_relationship::VT_HASH, hash);
+  }
   explicit gaia_relationshipBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -839,7 +839,6 @@ struct gaia_relationshipBuilder {
 inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
-    flatbuffers::Offset<flatbuffers::String> hash = 0,
     flatbuffers::Offset<flatbuffers::String> to_parent_link_name = 0,
     flatbuffers::Offset<flatbuffers::String> to_child_link_name = 0,
     uint8_t cardinality = 0,
@@ -850,13 +849,14 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(
     uint16_t prev_child_offset = 0,
     uint16_t parent_offset = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint16_t>> parent_field_positions = 0,
-    flatbuffers::Offset<flatbuffers::Vector<uint16_t>> child_field_positions = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint16_t>> child_field_positions = 0,
+    flatbuffers::Offset<flatbuffers::String> hash = 0) {
   gaia_relationshipBuilder builder_(_fbb);
+  builder_.add_hash(hash);
   builder_.add_child_field_positions(child_field_positions);
   builder_.add_parent_field_positions(parent_field_positions);
   builder_.add_to_child_link_name(to_child_link_name);
   builder_.add_to_parent_link_name(to_parent_link_name);
-  builder_.add_hash(hash);
   builder_.add_name(name);
   builder_.add_parent_offset(parent_offset);
   builder_.add_prev_child_offset(prev_child_offset);
@@ -871,7 +871,6 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(
 inline flatbuffers::Offset<gaia_relationship> Creategaia_relationshipDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
-    const char *hash = nullptr,
     const char *to_parent_link_name = nullptr,
     const char *to_child_link_name = nullptr,
     uint8_t cardinality = 0,
@@ -882,17 +881,17 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationshipDirect(
     uint16_t prev_child_offset = 0,
     uint16_t parent_offset = 0,
     const std::vector<uint16_t> *parent_field_positions = nullptr,
-    const std::vector<uint16_t> *child_field_positions = nullptr) {
+    const std::vector<uint16_t> *child_field_positions = nullptr,
+    const char *hash = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
-  auto hash__ = hash ? _fbb.CreateString(hash) : 0;
   auto to_parent_link_name__ = to_parent_link_name ? _fbb.CreateString(to_parent_link_name) : 0;
   auto to_child_link_name__ = to_child_link_name ? _fbb.CreateString(to_child_link_name) : 0;
   auto parent_field_positions__ = parent_field_positions ? _fbb.CreateVector<uint16_t>(*parent_field_positions) : 0;
   auto child_field_positions__ = child_field_positions ? _fbb.CreateVector<uint16_t>(*child_field_positions) : 0;
+  auto hash__ = hash ? _fbb.CreateString(hash) : 0;
   return gaia::catalog::internal::Creategaia_relationship(
       _fbb,
       name__,
-      hash__,
       to_parent_link_name__,
       to_child_link_name__,
       cardinality,
@@ -903,7 +902,8 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationshipDirect(
       prev_child_offset,
       parent_offset,
       parent_field_positions__,
-      child_field_positions__);
+      child_field_positions__,
+      hash__);
 }
 
 flatbuffers::Offset<gaia_relationship> Creategaia_relationship(flatbuffers::FlatBufferBuilder &_fbb, const gaia_relationshipT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -911,13 +911,13 @@ flatbuffers::Offset<gaia_relationship> Creategaia_relationship(flatbuffers::Flat
 struct gaia_fieldT : public flatbuffers::NativeTable {
   typedef gaia_field TableType;
   gaia::direct_access::nullable_string_t name{};
-  gaia::direct_access::nullable_string_t hash{};
   uint8_t type = 0;
   uint16_t repeated_count = 0;
   uint16_t position = 0;
   bool deprecated = false;
   bool active = false;
   bool unique = false;
+  gaia::direct_access::nullable_string_t hash{};
 };
 
 struct gaia_field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -925,19 +925,16 @@ struct gaia_field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef gaia_fieldBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
-    VT_HASH = 6,
-    VT_TYPE = 8,
-    VT_REPEATED_COUNT = 10,
-    VT_POSITION = 12,
-    VT_DEPRECATED = 14,
-    VT_ACTIVE = 16,
-    VT_UNIQUE = 18
+    VT_TYPE = 6,
+    VT_REPEATED_COUNT = 8,
+    VT_POSITION = 10,
+    VT_DEPRECATED = 12,
+    VT_ACTIVE = 14,
+    VT_UNIQUE = 16,
+    VT_HASH = 18
   };
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
-  }
-  const flatbuffers::String *hash() const {
-    return GetPointer<const flatbuffers::String *>(VT_HASH);
   }
   uint8_t type() const {
     return GetField<uint8_t>(VT_TYPE, 0);
@@ -957,18 +954,21 @@ struct gaia_field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool unique() const {
     return GetField<uint8_t>(VT_UNIQUE, 0) != 0;
   }
+  const flatbuffers::String *hash() const {
+    return GetPointer<const flatbuffers::String *>(VT_HASH);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
-           VerifyOffset(verifier, VT_HASH) &&
-           verifier.VerifyString(hash()) &&
            VerifyField<uint8_t>(verifier, VT_TYPE) &&
            VerifyField<uint16_t>(verifier, VT_REPEATED_COUNT) &&
            VerifyField<uint16_t>(verifier, VT_POSITION) &&
            VerifyField<uint8_t>(verifier, VT_DEPRECATED) &&
            VerifyField<uint8_t>(verifier, VT_ACTIVE) &&
            VerifyField<uint8_t>(verifier, VT_UNIQUE) &&
+           VerifyOffset(verifier, VT_HASH) &&
+           verifier.VerifyString(hash()) &&
            verifier.EndTable();
   }
   gaia_fieldT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -982,9 +982,6 @@ struct gaia_fieldBuilder {
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(gaia_field::VT_NAME, name);
-  }
-  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
-    fbb_.AddOffset(gaia_field::VT_HASH, hash);
   }
   void add_type(uint8_t type) {
     fbb_.AddElement<uint8_t>(gaia_field::VT_TYPE, type, 0);
@@ -1004,6 +1001,9 @@ struct gaia_fieldBuilder {
   void add_unique(bool unique) {
     fbb_.AddElement<uint8_t>(gaia_field::VT_UNIQUE, static_cast<uint8_t>(unique), 0);
   }
+  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
+    fbb_.AddOffset(gaia_field::VT_HASH, hash);
+  }
   explicit gaia_fieldBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -1018,13 +1018,13 @@ struct gaia_fieldBuilder {
 inline flatbuffers::Offset<gaia_field> Creategaia_field(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
-    flatbuffers::Offset<flatbuffers::String> hash = 0,
     uint8_t type = 0,
     uint16_t repeated_count = 0,
     uint16_t position = 0,
     bool deprecated = false,
     bool active = false,
-    bool unique = false) {
+    bool unique = false,
+    flatbuffers::Offset<flatbuffers::String> hash = 0) {
   gaia_fieldBuilder builder_(_fbb);
   builder_.add_hash(hash);
   builder_.add_name(name);
@@ -1040,25 +1040,25 @@ inline flatbuffers::Offset<gaia_field> Creategaia_field(
 inline flatbuffers::Offset<gaia_field> Creategaia_fieldDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
-    const char *hash = nullptr,
     uint8_t type = 0,
     uint16_t repeated_count = 0,
     uint16_t position = 0,
     bool deprecated = false,
     bool active = false,
-    bool unique = false) {
+    bool unique = false,
+    const char *hash = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto hash__ = hash ? _fbb.CreateString(hash) : 0;
   return gaia::catalog::internal::Creategaia_field(
       _fbb,
       name__,
-      hash__,
       type,
       repeated_count,
       position,
       deprecated,
       active,
-      unique);
+      unique,
+      hash__);
 }
 
 flatbuffers::Offset<gaia_field> Creategaia_field(flatbuffers::FlatBufferBuilder &_fbb, const gaia_fieldT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1066,12 +1066,11 @@ flatbuffers::Offset<gaia_field> Creategaia_field(flatbuffers::FlatBufferBuilder 
 struct gaia_tableT : public flatbuffers::NativeTable {
   typedef gaia_table TableType;
   gaia::direct_access::nullable_string_t name{};
-  gaia::direct_access::nullable_string_t hash{};
-  gaia::direct_access::nullable_string_t type_name{};
   uint32_t type = 0;
   bool is_system = false;
   std::vector<uint8_t> binary_schema{};
   std::vector<uint8_t> serialization_template{};
+  gaia::direct_access::nullable_string_t hash{};
 };
 
 struct gaia_table FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -1079,21 +1078,14 @@ struct gaia_table FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef gaia_tableBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
-    VT_HASH = 6,
-    VT_TYPE_NAME = 8,
-    VT_TYPE = 10,
-    VT_IS_SYSTEM = 12,
-    VT_BINARY_SCHEMA = 14,
-    VT_SERIALIZATION_TEMPLATE = 16
+    VT_TYPE = 6,
+    VT_IS_SYSTEM = 8,
+    VT_BINARY_SCHEMA = 10,
+    VT_SERIALIZATION_TEMPLATE = 12,
+    VT_HASH = 14
   };
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
-  }
-  const flatbuffers::String *hash() const {
-    return GetPointer<const flatbuffers::String *>(VT_HASH);
-  }
-  const flatbuffers::String *type_name() const {
-    return GetPointer<const flatbuffers::String *>(VT_TYPE_NAME);
   }
   uint32_t type() const {
     return GetField<uint32_t>(VT_TYPE, 0);
@@ -1107,20 +1099,21 @@ struct gaia_table FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<uint8_t> *serialization_template() const {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_SERIALIZATION_TEMPLATE);
   }
+  const flatbuffers::String *hash() const {
+    return GetPointer<const flatbuffers::String *>(VT_HASH);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
-           VerifyOffset(verifier, VT_HASH) &&
-           verifier.VerifyString(hash()) &&
-           VerifyOffset(verifier, VT_TYPE_NAME) &&
-           verifier.VerifyString(type_name()) &&
            VerifyField<uint32_t>(verifier, VT_TYPE) &&
            VerifyField<uint8_t>(verifier, VT_IS_SYSTEM) &&
            VerifyOffset(verifier, VT_BINARY_SCHEMA) &&
            verifier.VerifyVector(binary_schema()) &&
            VerifyOffset(verifier, VT_SERIALIZATION_TEMPLATE) &&
            verifier.VerifyVector(serialization_template()) &&
+           VerifyOffset(verifier, VT_HASH) &&
+           verifier.VerifyString(hash()) &&
            verifier.EndTable();
   }
   gaia_tableT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -1135,12 +1128,6 @@ struct gaia_tableBuilder {
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(gaia_table::VT_NAME, name);
   }
-  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
-    fbb_.AddOffset(gaia_table::VT_HASH, hash);
-  }
-  void add_type_name(flatbuffers::Offset<flatbuffers::String> type_name) {
-    fbb_.AddOffset(gaia_table::VT_TYPE_NAME, type_name);
-  }
   void add_type(uint32_t type) {
     fbb_.AddElement<uint32_t>(gaia_table::VT_TYPE, type, 0);
   }
@@ -1152,6 +1139,9 @@ struct gaia_tableBuilder {
   }
   void add_serialization_template(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> serialization_template) {
     fbb_.AddOffset(gaia_table::VT_SERIALIZATION_TEMPLATE, serialization_template);
+  }
+  void add_hash(flatbuffers::Offset<flatbuffers::String> hash) {
+    fbb_.AddOffset(gaia_table::VT_HASH, hash);
   }
   explicit gaia_tableBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -1167,18 +1157,16 @@ struct gaia_tableBuilder {
 inline flatbuffers::Offset<gaia_table> Creategaia_table(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
-    flatbuffers::Offset<flatbuffers::String> hash = 0,
-    flatbuffers::Offset<flatbuffers::String> type_name = 0,
     uint32_t type = 0,
     bool is_system = false,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> binary_schema = 0,
-    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> serialization_template = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> serialization_template = 0,
+    flatbuffers::Offset<flatbuffers::String> hash = 0) {
   gaia_tableBuilder builder_(_fbb);
+  builder_.add_hash(hash);
   builder_.add_serialization_template(serialization_template);
   builder_.add_binary_schema(binary_schema);
   builder_.add_type(type);
-  builder_.add_type_name(type_name);
-  builder_.add_hash(hash);
   builder_.add_name(name);
   builder_.add_is_system(is_system);
   return builder_.Finish();
@@ -1187,26 +1175,23 @@ inline flatbuffers::Offset<gaia_table> Creategaia_table(
 inline flatbuffers::Offset<gaia_table> Creategaia_tableDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
-    const char *hash = nullptr,
-    const char *type_name = nullptr,
     uint32_t type = 0,
     bool is_system = false,
     const std::vector<uint8_t> *binary_schema = nullptr,
-    const std::vector<uint8_t> *serialization_template = nullptr) {
+    const std::vector<uint8_t> *serialization_template = nullptr,
+    const char *hash = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
-  auto hash__ = hash ? _fbb.CreateString(hash) : 0;
-  auto type_name__ = type_name ? _fbb.CreateString(type_name) : 0;
   auto binary_schema__ = binary_schema ? _fbb.CreateVector<uint8_t>(*binary_schema) : 0;
   auto serialization_template__ = serialization_template ? _fbb.CreateVector<uint8_t>(*serialization_template) : 0;
+  auto hash__ = hash ? _fbb.CreateString(hash) : 0;
   return gaia::catalog::internal::Creategaia_table(
       _fbb,
       name__,
-      hash__,
-      type_name__,
       type,
       is_system,
       binary_schema__,
-      serialization_template__);
+      serialization_template__,
+      hash__);
 }
 
 flatbuffers::Offset<gaia_table> Creategaia_table(flatbuffers::FlatBufferBuilder &_fbb, const gaia_tableT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1570,7 +1555,6 @@ inline void gaia_relationship::UnPackTo(gaia_relationshipT *_o, const flatbuffer
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
-  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
   { auto _e = to_parent_link_name(); if (_e) _o->to_parent_link_name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
   { auto _e = to_child_link_name(); if (_e) _o->to_child_link_name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
   { auto _e = cardinality(); _o->cardinality = _e; }
@@ -1582,6 +1566,7 @@ inline void gaia_relationship::UnPackTo(gaia_relationshipT *_o, const flatbuffer
   { auto _e = parent_offset(); _o->parent_offset = _e; }
   { auto _e = parent_field_positions(); if (_e) { _o->parent_field_positions.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->parent_field_positions[_i] = _e->Get(_i); } } }
   { auto _e = child_field_positions(); if (_e) { _o->child_field_positions.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->child_field_positions[_i] = _e->Get(_i); } } }
+  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
 }
 
 inline flatbuffers::Offset<gaia_relationship> gaia_relationship::Pack(flatbuffers::FlatBufferBuilder &_fbb, const gaia_relationshipT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -1593,7 +1578,6 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(flatbuffer
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const gaia_relationshipT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
-  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
   auto _to_parent_link_name = _o->to_parent_link_name.empty() ? 0 : _fbb.CreateString(_o->to_parent_link_name);
   auto _to_child_link_name = _o->to_child_link_name.empty() ? 0 : _fbb.CreateString(_o->to_child_link_name);
   auto _cardinality = _o->cardinality;
@@ -1605,10 +1589,10 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(flatbuffer
   auto _parent_offset = _o->parent_offset;
   auto _parent_field_positions = _o->parent_field_positions.size() ? _fbb.CreateVector(_o->parent_field_positions) : 0;
   auto _child_field_positions = _o->child_field_positions.size() ? _fbb.CreateVector(_o->child_field_positions) : 0;
+  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
   return gaia::catalog::internal::Creategaia_relationship(
       _fbb,
       _name,
-      _hash,
       _to_parent_link_name,
       _to_child_link_name,
       _cardinality,
@@ -1619,7 +1603,8 @@ inline flatbuffers::Offset<gaia_relationship> Creategaia_relationship(flatbuffer
       _prev_child_offset,
       _parent_offset,
       _parent_field_positions,
-      _child_field_positions);
+      _child_field_positions,
+      _hash);
 }
 
 inline gaia_fieldT *gaia_field::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
@@ -1632,13 +1617,13 @@ inline void gaia_field::UnPackTo(gaia_fieldT *_o, const flatbuffers::resolver_fu
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
-  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
   { auto _e = type(); _o->type = _e; }
   { auto _e = repeated_count(); _o->repeated_count = _e; }
   { auto _e = position(); _o->position = _e; }
   { auto _e = deprecated(); _o->deprecated = _e; }
   { auto _e = active(); _o->active = _e; }
   { auto _e = unique(); _o->unique = _e; }
+  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
 }
 
 inline flatbuffers::Offset<gaia_field> gaia_field::Pack(flatbuffers::FlatBufferBuilder &_fbb, const gaia_fieldT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -1650,23 +1635,23 @@ inline flatbuffers::Offset<gaia_field> Creategaia_field(flatbuffers::FlatBufferB
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const gaia_fieldT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
-  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
   auto _type = _o->type;
   auto _repeated_count = _o->repeated_count;
   auto _position = _o->position;
   auto _deprecated = _o->deprecated;
   auto _active = _o->active;
   auto _unique = _o->unique;
+  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
   return gaia::catalog::internal::Creategaia_field(
       _fbb,
       _name,
-      _hash,
       _type,
       _repeated_count,
       _position,
       _deprecated,
       _active,
-      _unique);
+      _unique,
+      _hash);
 }
 
 inline gaia_tableT *gaia_table::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
@@ -1679,12 +1664,11 @@ inline void gaia_table::UnPackTo(gaia_tableT *_o, const flatbuffers::resolver_fu
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
-  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
-  { auto _e = type_name(); if (_e) _o->type_name = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
   { auto _e = type(); _o->type = _e; }
   { auto _e = is_system(); _o->is_system = _e; }
   { auto _e = binary_schema(); if (_e) { _o->binary_schema.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->binary_schema.begin()); } }
   { auto _e = serialization_template(); if (_e) { _o->serialization_template.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->serialization_template.begin()); } }
+  { auto _e = hash(); if (_e) _o->hash = gaia::direct_access::nullable_string_t(_e->c_str(), _e->size()); }
 }
 
 inline flatbuffers::Offset<gaia_table> gaia_table::Pack(flatbuffers::FlatBufferBuilder &_fbb, const gaia_tableT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -1696,21 +1680,19 @@ inline flatbuffers::Offset<gaia_table> Creategaia_table(flatbuffers::FlatBufferB
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const gaia_tableT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
-  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
-  auto _type_name = _o->type_name.empty() ? 0 : _fbb.CreateString(_o->type_name);
   auto _type = _o->type;
   auto _is_system = _o->is_system;
   auto _binary_schema = _o->binary_schema.size() ? _fbb.CreateVector(_o->binary_schema) : 0;
   auto _serialization_template = _o->serialization_template.size() ? _fbb.CreateVector(_o->serialization_template) : 0;
+  auto _hash = _o->hash.empty() ? 0 : _fbb.CreateString(_o->hash);
   return gaia::catalog::internal::Creategaia_table(
       _fbb,
       _name,
-      _hash,
-      _type_name,
       _type,
       _is_system,
       _binary_schema,
-      _serialization_template);
+      _serialization_template,
+      _hash);
 }
 
 inline gaia_databaseT *gaia_database::UnPack(const flatbuffers::resolver_function_t *_resolver) const {

--- a/production/inc/gaia_internal/catalog/gaia_catalog.h
+++ b/production/inc/gaia_internal/catalog/gaia_catalog.h
@@ -541,10 +541,9 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<rule_relationship_t> rule_relationships_list_t;
     gaia_relationship_t() : dac_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, const char* hash, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t prev_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions);
+    static gaia::common::gaia_id_t insert_row(const char* name, const char* to_parent_link_name, const char* to_child_link_name, uint8_t cardinality, bool parent_required, bool deprecated, uint16_t first_child_offset, uint16_t next_child_offset, uint16_t prev_child_offset, uint16_t parent_offset, const std::vector<uint16_t>& parent_field_positions, const std::vector<uint16_t>& child_field_positions, const char* hash);
     static gaia::direct_access::dac_container_t<c_gaia_type_gaia_relationship, gaia_relationship_t> list();
     const char* name() const;
-    const char* hash() const;
     const char* to_parent_link_name() const;
     const char* to_child_link_name() const;
     uint8_t cardinality() const;
@@ -556,6 +555,7 @@ public:
     uint16_t parent_offset() const;
     gaia::direct_access::dac_vector_t<uint16_t> parent_field_positions() const;
     gaia::direct_access::dac_vector_t<uint16_t> child_field_positions() const;
+    const char* hash() const;
     gaia_table_t child() const;
     gaia_table_t parent() const;
     rule_relationships_list_t rule_relationships() const;
@@ -564,7 +564,6 @@ public:
     struct expr_ {
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia::common::gaia_id_t> gaia_id;
         static gaia::direct_access::expression_t<gaia_relationship_t, const char*> name;
-        static gaia::direct_access::expression_t<gaia_relationship_t, const char*> hash;
         static gaia::direct_access::expression_t<gaia_relationship_t, const char*> to_parent_link_name;
         static gaia::direct_access::expression_t<gaia_relationship_t, const char*> to_child_link_name;
         static gaia::direct_access::expression_t<gaia_relationship_t, uint8_t> cardinality;
@@ -576,6 +575,7 @@ public:
         static gaia::direct_access::expression_t<gaia_relationship_t, uint16_t> parent_offset;
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia::direct_access::dac_vector_t<uint16_t>> parent_field_positions;
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia::direct_access::dac_vector_t<uint16_t>> child_field_positions;
+        static gaia::direct_access::expression_t<gaia_relationship_t, const char*> hash;
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia_table_t> child;
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia_table_t> parent;
         static gaia::direct_access::expression_t<gaia_relationship_t, gaia_relationship_t::rule_relationships_list_t> rule_relationships;
@@ -588,7 +588,6 @@ private:
 namespace gaia_relationship_expr {
     static auto& gaia_id = gaia_relationship_t::expr::gaia_id;
     static auto& name = gaia_relationship_t::expr::name;
-    static auto& hash = gaia_relationship_t::expr::hash;
     static auto& to_parent_link_name = gaia_relationship_t::expr::to_parent_link_name;
     static auto& to_child_link_name = gaia_relationship_t::expr::to_child_link_name;
     static auto& cardinality = gaia_relationship_t::expr::cardinality;
@@ -600,6 +599,7 @@ namespace gaia_relationship_expr {
     static auto& parent_offset = gaia_relationship_t::expr::parent_offset;
     static auto& parent_field_positions = gaia_relationship_t::expr::parent_field_positions;
     static auto& child_field_positions = gaia_relationship_t::expr::child_field_positions;
+    static auto& hash = gaia_relationship_t::expr::hash;
     static auto& child = gaia_relationship_t::expr::child;
     static auto& parent = gaia_relationship_t::expr::parent;
     static auto& rule_relationships = gaia_relationship_t::expr::rule_relationships;
@@ -607,7 +607,6 @@ namespace gaia_relationship_expr {
 
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia::common::gaia_id_t> gaia_relationship_t::expr_<unused_t>::gaia_id{&gaia_relationship_t::gaia_id};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, const char*> gaia_relationship_t::expr_<unused_t>::name{&gaia_relationship_t::name};
-template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, const char*> gaia_relationship_t::expr_<unused_t>::hash{&gaia_relationship_t::hash};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, const char*> gaia_relationship_t::expr_<unused_t>::to_parent_link_name{&gaia_relationship_t::to_parent_link_name};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, const char*> gaia_relationship_t::expr_<unused_t>::to_child_link_name{&gaia_relationship_t::to_child_link_name};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, uint8_t> gaia_relationship_t::expr_<unused_t>::cardinality{&gaia_relationship_t::cardinality};
@@ -619,6 +618,7 @@ template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, 
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, uint16_t> gaia_relationship_t::expr_<unused_t>::parent_offset{&gaia_relationship_t::parent_offset};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia::direct_access::dac_vector_t<uint16_t>> gaia_relationship_t::expr_<unused_t>::parent_field_positions{&gaia_relationship_t::parent_field_positions};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia::direct_access::dac_vector_t<uint16_t>> gaia_relationship_t::expr_<unused_t>::child_field_positions{&gaia_relationship_t::child_field_positions};
+template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, const char*> gaia_relationship_t::expr_<unused_t>::hash{&gaia_relationship_t::hash};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia_table_t> gaia_relationship_t::expr_<unused_t>::child{&gaia_relationship_t::child};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia_table_t> gaia_relationship_t::expr_<unused_t>::parent{&gaia_relationship_t::parent};
 template<class unused_t> gaia::direct_access::expression_t<gaia_relationship_t, gaia_relationship_t::rule_relationships_list_t> gaia_relationship_t::expr_<unused_t>::rule_relationships{&gaia_relationship_t::rule_relationships};
@@ -631,16 +631,16 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<rule_field_t> rule_fields_list_t;
     gaia_field_t() : dac_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, const char* hash, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique);
+    static gaia::common::gaia_id_t insert_row(const char* name, uint8_t type, uint16_t repeated_count, uint16_t position, bool deprecated, bool active, bool unique, const char* hash);
     static gaia::direct_access::dac_container_t<c_gaia_type_gaia_field, gaia_field_t> list();
     const char* name() const;
-    const char* hash() const;
     uint8_t type() const;
     uint16_t repeated_count() const;
     uint16_t position() const;
     bool deprecated() const;
     bool active() const;
     bool unique() const;
+    const char* hash() const;
     gaia_table_t table() const;
     rule_fields_list_t rule_fields() const;
 
@@ -648,13 +648,13 @@ public:
     struct expr_ {
         static gaia::direct_access::expression_t<gaia_field_t, gaia::common::gaia_id_t> gaia_id;
         static gaia::direct_access::expression_t<gaia_field_t, const char*> name;
-        static gaia::direct_access::expression_t<gaia_field_t, const char*> hash;
         static gaia::direct_access::expression_t<gaia_field_t, uint8_t> type;
         static gaia::direct_access::expression_t<gaia_field_t, uint16_t> repeated_count;
         static gaia::direct_access::expression_t<gaia_field_t, uint16_t> position;
         static gaia::direct_access::expression_t<gaia_field_t, bool> deprecated;
         static gaia::direct_access::expression_t<gaia_field_t, bool> active;
         static gaia::direct_access::expression_t<gaia_field_t, bool> unique;
+        static gaia::direct_access::expression_t<gaia_field_t, const char*> hash;
         static gaia::direct_access::expression_t<gaia_field_t, gaia_table_t> table;
         static gaia::direct_access::expression_t<gaia_field_t, gaia_field_t::rule_fields_list_t> rule_fields;
     };
@@ -666,26 +666,26 @@ private:
 namespace gaia_field_expr {
     static auto& gaia_id = gaia_field_t::expr::gaia_id;
     static auto& name = gaia_field_t::expr::name;
-    static auto& hash = gaia_field_t::expr::hash;
     static auto& type = gaia_field_t::expr::type;
     static auto& repeated_count = gaia_field_t::expr::repeated_count;
     static auto& position = gaia_field_t::expr::position;
     static auto& deprecated = gaia_field_t::expr::deprecated;
     static auto& active = gaia_field_t::expr::active;
     static auto& unique = gaia_field_t::expr::unique;
+    static auto& hash = gaia_field_t::expr::hash;
     static auto& table = gaia_field_t::expr::table;
     static auto& rule_fields = gaia_field_t::expr::rule_fields;
 } // gaia_field_expr
 
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, gaia::common::gaia_id_t> gaia_field_t::expr_<unused_t>::gaia_id{&gaia_field_t::gaia_id};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, const char*> gaia_field_t::expr_<unused_t>::name{&gaia_field_t::name};
-template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, const char*> gaia_field_t::expr_<unused_t>::hash{&gaia_field_t::hash};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, uint8_t> gaia_field_t::expr_<unused_t>::type{&gaia_field_t::type};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, uint16_t> gaia_field_t::expr_<unused_t>::repeated_count{&gaia_field_t::repeated_count};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, uint16_t> gaia_field_t::expr_<unused_t>::position{&gaia_field_t::position};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, bool> gaia_field_t::expr_<unused_t>::deprecated{&gaia_field_t::deprecated};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, bool> gaia_field_t::expr_<unused_t>::active{&gaia_field_t::active};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, bool> gaia_field_t::expr_<unused_t>::unique{&gaia_field_t::unique};
+template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, const char*> gaia_field_t::expr_<unused_t>::hash{&gaia_field_t::hash};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, gaia_table_t> gaia_field_t::expr_<unused_t>::table{&gaia_field_t::table};
 template<class unused_t> gaia::direct_access::expression_t<gaia_field_t, gaia_field_t::rule_fields_list_t> gaia_field_t::expr_<unused_t>::rule_fields{&gaia_field_t::rule_fields};
 
@@ -701,15 +701,14 @@ public:
     typedef gaia::direct_access::reference_chain_container_t<gaia_field_t> gaia_fields_list_t;
     gaia_table_t() : dac_object_t() {}
     static const char* gaia_typename();
-    static gaia::common::gaia_id_t insert_row(const char* name, const char* hash, const char* type_name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template);
+    static gaia::common::gaia_id_t insert_row(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template, const char* hash);
     static gaia::direct_access::dac_container_t<c_gaia_type_gaia_table, gaia_table_t> list();
     const char* name() const;
-    const char* hash() const;
-    const char* type_name() const;
     uint32_t type() const;
     bool is_system() const;
     gaia::direct_access::dac_vector_t<uint8_t> binary_schema() const;
     gaia::direct_access::dac_vector_t<uint8_t> serialization_template() const;
+    const char* hash() const;
     gaia_database_t database() const;
     rule_tables_list_t rule_tables() const;
     gaia_indexes_list_t gaia_indexes() const;
@@ -721,12 +720,11 @@ public:
     struct expr_ {
         static gaia::direct_access::expression_t<gaia_table_t, gaia::common::gaia_id_t> gaia_id;
         static gaia::direct_access::expression_t<gaia_table_t, const char*> name;
-        static gaia::direct_access::expression_t<gaia_table_t, const char*> hash;
-        static gaia::direct_access::expression_t<gaia_table_t, const char*> type_name;
         static gaia::direct_access::expression_t<gaia_table_t, uint32_t> type;
         static gaia::direct_access::expression_t<gaia_table_t, bool> is_system;
         static gaia::direct_access::expression_t<gaia_table_t, gaia::direct_access::dac_vector_t<uint8_t>> binary_schema;
         static gaia::direct_access::expression_t<gaia_table_t, gaia::direct_access::dac_vector_t<uint8_t>> serialization_template;
+        static gaia::direct_access::expression_t<gaia_table_t, const char*> hash;
         static gaia::direct_access::expression_t<gaia_table_t, gaia_database_t> database;
         static gaia::direct_access::expression_t<gaia_table_t, gaia_table_t::rule_tables_list_t> rule_tables;
         static gaia::direct_access::expression_t<gaia_table_t, gaia_table_t::gaia_indexes_list_t> gaia_indexes;
@@ -742,12 +740,11 @@ private:
 namespace gaia_table_expr {
     static auto& gaia_id = gaia_table_t::expr::gaia_id;
     static auto& name = gaia_table_t::expr::name;
-    static auto& hash = gaia_table_t::expr::hash;
-    static auto& type_name = gaia_table_t::expr::type_name;
     static auto& type = gaia_table_t::expr::type;
     static auto& is_system = gaia_table_t::expr::is_system;
     static auto& binary_schema = gaia_table_t::expr::binary_schema;
     static auto& serialization_template = gaia_table_t::expr::serialization_template;
+    static auto& hash = gaia_table_t::expr::hash;
     static auto& database = gaia_table_t::expr::database;
     static auto& rule_tables = gaia_table_t::expr::rule_tables;
     static auto& gaia_indexes = gaia_table_t::expr::gaia_indexes;
@@ -758,12 +755,11 @@ namespace gaia_table_expr {
 
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia::common::gaia_id_t> gaia_table_t::expr_<unused_t>::gaia_id{&gaia_table_t::gaia_id};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, const char*> gaia_table_t::expr_<unused_t>::name{&gaia_table_t::name};
-template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, const char*> gaia_table_t::expr_<unused_t>::hash{&gaia_table_t::hash};
-template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, const char*> gaia_table_t::expr_<unused_t>::type_name{&gaia_table_t::type_name};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, uint32_t> gaia_table_t::expr_<unused_t>::type{&gaia_table_t::type};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, bool> gaia_table_t::expr_<unused_t>::is_system{&gaia_table_t::is_system};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia::direct_access::dac_vector_t<uint8_t>> gaia_table_t::expr_<unused_t>::binary_schema{&gaia_table_t::binary_schema};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia::direct_access::dac_vector_t<uint8_t>> gaia_table_t::expr_<unused_t>::serialization_template{&gaia_table_t::serialization_template};
+template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, const char*> gaia_table_t::expr_<unused_t>::hash{&gaia_table_t::hash};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia_database_t> gaia_table_t::expr_<unused_t>::database{&gaia_table_t::database};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia_table_t::rule_tables_list_t> gaia_table_t::expr_<unused_t>::rule_tables{&gaia_table_t::rule_tables};
 template<class unused_t> gaia::direct_access::expression_t<gaia_table_t, gaia_table_t::gaia_indexes_list_t> gaia_table_t::expr_<unused_t>::gaia_indexes{&gaia_table_t::gaia_indexes};


### PR DESCRIPTION
Moves the new fields added to existing tables to the last. Also removes `type_name` as discussed. 