### PR TITLE
Add CMake option to disable asserts

### DIFF
--- a/production/CMakeLists.txt
+++ b/production/CMakeLists.txt
@@ -31,6 +31,8 @@ option(ENABLE_SDK_TESTS "Build and execute ruleset translation tests" ON)
 
 option(EXPORT_SYMBOLS "Export symbols by default from shared libraries" OFF)
 
+option(DISABLE_ASSERTS "Disable assertions" OFF)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   option(ENABLE_CLANG_TIDY "Enable clang tidy" ON)
 else()
@@ -89,6 +91,10 @@ add_library(gaia_build_options INTERFACE)
 target_compile_options(gaia_build_options INTERFACE -Wall -Wextra -ftime-trace)
 # Ensure Debug builds have the DEBUG macro defined.
 target_compile_definitions(gaia_build_options INTERFACE $<$<CONFIG:Debug>:DEBUG>)
+# Propagate the DISABLE_ASSERTS option to a macro definition.
+target_compile_definitions(gaia_build_options INTERFACE $<$<BOOL:${DISABLE_ASSERTS}>:DISABLE_ASSERTS>)
+# Disabling asserts will produce bogus unused variable warnings.
+target_compile_options(gaia_build_options INTERFACE $<$<BOOL:${DISABLE_ASSERTS}>:-Wno-unused-parameter -Wno-unused-lambda-capture -Wno-unused-variable -Wno-unused-but-set-variable>)
 
 # LLVM and CLANG specific options.
 if(BUILD_GAIA_RELEASE OR BUILD_GAIA_LLVM_TESTS)

--- a/production/inc/gaia_internal/common/retail_assert.hpp
+++ b/production/inc/gaia_internal/common/retail_assert.hpp
@@ -32,6 +32,12 @@ namespace common
 // A way to disable these ASSERTs (via corresponding defines) is provided mainly as a mechanism
 // for determining if they contribute any negative execution impact.
 
+#ifdef DISABLE_ASSERTS
+#define DISABLE_ASSERT_PRECONDITION
+#define DISABLE_ASSERT_INVARIANT
+#define DISABLE_ASSERT_POSTCONDITION
+#endif
+
 // ASSERT_PRECONDITION is meant for validating conditions that should hold when a function is called.
 //
 // This should be used to validate that internal functions are called with the correct parameters


### PR DESCRIPTION
I needed to disable asserts while benchmarking because of a performance bug in the retail_assert implementation (to be addressed in a later PR). We should have a convenient way of doing this anyway, so I added a new top-level CMake option `DISABLE_ASSERTS`.