### PR TITLE
Avoid leaking Gaia build options into transitively dependent targets

### DIFF
--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -28,7 +28,8 @@ endfunction()
 # gaia_build_options), so we need to set them directly on the target.
 #
 function(configure_gaia_target TARGET)
-  target_link_libraries(${TARGET} PUBLIC gaia_build_options)
+  # Keep this dependency PRIVATE to avoid leaking Gaia build options into all dependent targets.
+  target_link_libraries(${TARGET} PRIVATE gaia_build_options)
   if(NOT EXPORT_SYMBOLS)
     # See https://cmake.org/cmake/help/latest/policy/CMP0063.html.
     cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
When trying to build and run LLVM unit tests (i.e. `make check`) in a `Debug` build, I noticed that Gaia build options are incompatible with LLVM build options, and the build fails as a result. This is because all Gaia targets have a `PUBLIC` dependency on the `gaia_build_options` `INTERFACE` target, resulting in those build options being transitively propagated to any target with a dependency on a Gaia target (e.g., the `clangTooling` static lib). Changing each Gaia target's dependency on `gaia_build_options` to `PRIVATE` prevents the transitive propagation of Gaia build options.

Note: this fixes the compiler error that motivated the change, but there are still ASan-related linker errors. Those will be addressed in a future PR.