### PR TITLE
Import 'Configure policy CMP0116' from LLVM

### DIFF
--- a/third_party/production/TranslationEngineLLVM/llvm/CMakeLists.txt
+++ b/third_party/production/TranslationEngineLLVM/llvm/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+# CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
 
 if(POLICY CMP0068)
   cmake_policy(SET CMP0068 NEW)


### PR DESCRIPTION
This change allows using Ninja generator without warnings. (note more PR are necessary to make Ninja work) 

https://reviews.llvm.org/D101083