### PR TITLE
Replace ref chain with ref anchor chain

### DIFF
--- a/production/catalog/inc/gaiac_catalog_facade.hpp
+++ b/production/catalog/inc/gaiac_catalog_facade.hpp
@@ -38,6 +38,8 @@ public:
 
     std::string first_offset() const;
     uint16_t first_offset_value() const;
+    std::string parent_offset() const;
+    uint16_t parent_offset_value() const;
     std::string next_offset() const;
     std::string prev_offset() const;
 };

--- a/production/catalog/src/dac_generator.cpp
+++ b/production/catalog/src/dac_generator.cpp
@@ -171,15 +171,6 @@ std::string dac_compilation_unit_writer_t::generate_constants()
             const_code.SetValue("NEXT_OFFSET_VALUE", std::to_string(link.next_offset_value()));
             const_code += "constexpr common::reference_offset_t {{NEXT_OFFSET}} = {{NEXT_OFFSET_VALUE}};\\";
             table_constants.insert({link.next_offset_value(), const_code.ToString()});
-
-            if (incoming_link.is_value_linked())
-            {
-                const_code.Clear();
-                const_code.SetValue("PREV_OFFSET", link.prev_offset());
-                const_code.SetValue("PREV_OFFSET_VALUE", std::to_string(link.prev_offset_value()));
-                const_code += "constexpr common::reference_offset_t {{PREV_OFFSET}} = {{PREV_OFFSET_VALUE}};\\";
-                table_constants.insert({link.prev_offset_value(), const_code.ToString()});
-            }
         }
 
         for (const auto& outgoing_link : table.outgoing_links())
@@ -327,12 +318,12 @@ std::string class_writer_t::generate_list_types()
         {
             if (link.is_value_linked())
             {
-                code += "typedef gaia::direct_access::reference_anchor_chain_container_t<{{CHILD_TABLE}}_t> "
+                code += "typedef gaia::direct_access::value_linked_reference_container_t<{{CHILD_TABLE}}_t> "
                         "{{FIELD_NAME}}_list_t;";
             }
             else
             {
-                code += "typedef gaia::direct_access::reference_chain_container_t<{{CHILD_TABLE}}_t> "
+                code += "typedef gaia::direct_access::reference_container_t<{{CHILD_TABLE}}_t> "
                         "{{FIELD_NAME}}_list_t;";
             }
         }
@@ -506,7 +497,13 @@ std::string class_writer_t::generate_incoming_links_accessors_cpp()
         }
         else
         {
-            code += "gaia::common::gaia_id_t id = this->references()[{{PARENT_OFFSET}}];";
+            code += "gaia::common::gaia_id_t anchor_id = this->references()[{{PARENT_OFFSET}}];";
+            code += "if (anchor_id == gaia::common::c_invalid_gaia_id) {";
+            code.IncrementIdentLevel();
+            code += "return {{PARENT_TABLE}}_t();";
+            code.DecrementIdentLevel();
+            code += "}";
+            code += "gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);";
         }
         code += "return (id == gaia::common::c_invalid_gaia_id) ? {{PARENT_TABLE}}_t() : {{PARENT_TABLE}}_t::get(id);";
         code.DecrementIdentLevel();
@@ -554,8 +551,8 @@ std::string class_writer_t::generate_outgoing_links_accessors_cpp()
         code.SetValue("CHILD_TABLE", link.to_table());
         code.SetValue("FIELD_NAME", link.field_name());
         code.SetValue("FIRST_OFFSET", link.first_offset());
+        code.SetValue("PARENT_OFFSET", link.parent_offset());
         code.SetValue("NEXT_OFFSET", link.next_offset());
-        code.SetValue("PREV_OFFSET", link.prev_offset());
 
         if (link.is_multiple_cardinality())
         {
@@ -563,7 +560,7 @@ std::string class_writer_t::generate_outgoing_links_accessors_cpp()
             {
                 code += "{{TABLE_NAME}}_t::{{FIELD_NAME}}_list_t {{TABLE_NAME}}_t::{{FIELD_NAME}}() const {";
                 code.IncrementIdentLevel();
-                code += "return {{TABLE_NAME}}_t::{{FIELD_NAME}}_list_t(this->references()[{{FIRST_OFFSET}}], {{NEXT_OFFSET}}, {{PREV_OFFSET}});";
+                code += "return {{TABLE_NAME}}_t::{{FIELD_NAME}}_list_t(this->references()[{{FIRST_OFFSET}}], {{PARENT_OFFSET}});";
                 code.DecrementIdentLevel();
                 code += "}";
             }
@@ -580,7 +577,9 @@ std::string class_writer_t::generate_outgoing_links_accessors_cpp()
         {
             code += "{{CHILD_TABLE}}_ref_t {{TABLE_NAME}}_t::{{FIELD_NAME}}() const {";
             code.IncrementIdentLevel();
-            code += "return {{CHILD_TABLE}}_ref_t(gaia_id(), this->references()[{{FIRST_OFFSET}}], {{FIRST_OFFSET}});";
+            code += "gaia::common::gaia_id_t anchor_id = this->references()[{{FIRST_OFFSET}}];";
+            code += "gaia::common::gaia_id_t child_id = (anchor_id == gaia::common::c_invalid_gaia_id) ? gaia::common::c_invalid_gaia_id : dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_first_child_offset);";
+            code += "return {{CHILD_TABLE}}_ref_t(gaia_id(), child_id, {{FIRST_OFFSET}});";
             code.DecrementIdentLevel();
             code += "}";
         }

--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -72,7 +72,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("name", data_type_t::e_string, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_database", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_database));
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_database));
     }
     {
         // create table gaia_table (
@@ -90,7 +90,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("serialization_template", data_type_t::e_uint8, 0));
         create_table_impl(
             c_catalog_db_name, "gaia_table", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_table));
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_table));
         // create relationship gaia_catalog_database_table (
         //     catalog.gaia_database.gaia_tables -> catalog.gaia_table[],
         //     catalog.gaia_table.database -> catalog.gaia_database
@@ -122,7 +122,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("unique", data_type_t::e_bool, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_field", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_field));
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_field));
         // create relationship gaia_catalog_table_field (
         //     catalog.gaia_table.gaia_fields -> catalog.gaia_field[],
         //     catalog.gaia_field.table -> catalog.gaia_table
@@ -164,7 +164,7 @@ void ddl_executor_t::bootstrap_catalog()
         // See gaia::db::relationship_t for more details about relationships.
         create_table_impl(
             c_catalog_db_name, "gaia_relationship", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_relationship));
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_relationship));
         // create relationship gaia_catalog_relationship_parent (
         //     catalog.gaia_table.outgoing_relationships -> catalog.gaia_relationship[],
         //     catalog.gaia_relationship.parent -> catalog.gaia_table
@@ -202,7 +202,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("serial_stream", data_type_t::e_string, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_ruleset", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_ruleset));
+            static_cast<gaia_type_t::value_type>(system_table_type_t::gaia_ruleset));
     }
     {
         // create table gaia_rule (
@@ -212,7 +212,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("name", data_type_t::e_string, 1));
         create_table_impl(
             c_catalog_db_name, "gaia_rule", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_rule));
+            static_cast<gaia_type_t::value_type>(system_table_type_t::gaia_rule));
         // create relationship gaia_catalog_ruleset_rule (
         //     catalog.gaia_ruleset.rules -> catalog.gaia_rule[],
         //     catalog.gaia_rule.ruleset -> catalog.gaia_ruleset
@@ -238,7 +238,7 @@ void ddl_executor_t::bootstrap_catalog()
         fields.emplace_back(make_unique<data_field_def_t>("fields", data_type_t::e_uint64, 0));
         create_table_impl(
             "catalog", "gaia_index", fields, is_system, throw_on_exists, auto_drop,
-            static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_index));
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_index));
 
         create_relationship(
             "gaia_catalog_table_index",
@@ -246,6 +246,12 @@ void ddl_executor_t::bootstrap_catalog()
             {c_catalog_db_name, "gaia_index", "table", "catalog", "gaia_table", relationship_cardinality_t::one},
             std::nullopt,
             false);
+    }
+    {
+        field_def_list_t fields;
+        create_table_impl(
+            "catalog", "gaia_ref_anchor", fields, is_system, throw_on_exists, auto_drop,
+            static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_ref_anchor));
     }
 
     create_database(c_event_log_db_name, false);
@@ -439,9 +445,10 @@ gaia_id_t ddl_executor_t::create_relationship(
     reference_offset_t first_child_offset = parent_available_offset;
 
     reference_offset_t parent_offset = child_available_offset;
-    reference_offset_t next_child_offset = child_available_offset + 1;
+    reference_offset_t next_child_offset = parent_offset + 1;
     validate_new_reference_offset(next_child_offset);
-    reference_offset_t prev_child_offset = c_invalid_reference_offset;
+    reference_offset_t prev_child_offset = next_child_offset + 1;
+    validate_new_reference_offset(prev_child_offset);
 
     bool is_parent_required = false;
     bool is_deprecated = false;
@@ -548,9 +555,6 @@ gaia_id_t ddl_executor_t::create_relationship(
         {
             child_field_positions.push_back(gaia_field_t::get(field_id).position());
         }
-
-        prev_child_offset = next_child_offset + 1;
-        validate_new_reference_offset(prev_child_offset);
     }
 
     // These casts works because a field_position_t is a thin wrapper over uint16_t,
@@ -587,7 +591,7 @@ void ddl_executor_t::drop_relationship_no_ri(gaia_relationship_t& relationship)
     // this by disconnecting all child records from their parent.
     for (auto record : gaia_ptr_t::find_all_range(relationship.child().type()))
     {
-        record.remove_parent_reference(relationship.parent_offset());
+        gaia_ptr::remove_from_reference_container(record, relationship.parent_offset());
     }
 
     // Unlink parent.
@@ -804,7 +808,7 @@ reference_offset_t ddl_executor_t::find_child_available_offset(const gaia_table_
     {
         max_offset = std::max(
             {max_offset.value(),
-             relationship.prev_child_offset() == c_invalid_reference_offset ? relationship.next_child_offset() : relationship.prev_child_offset(),
+             relationship.prev_child_offset(),
              relationship.parent_offset()});
 
         ASSERT_INVARIANT(max_offset != c_invalid_reference_offset, "Invalid reference offset detected!");

--- a/production/catalog/src/gaia_catalog.cpp
+++ b/production/catalog/src/gaia_catalog.cpp
@@ -12,6 +12,22 @@ namespace gaia {
 namespace catalog {
 
 //
+// Implementation of class gaia_ref_anchor_t.
+//
+
+const char* gaia_ref_anchor_t::gaia_typename() {
+    static const char* gaia_typename = "gaia_ref_anchor_t";
+    return gaia_typename;
+}
+gaia::common::gaia_id_t gaia_ref_anchor_t::insert_row() {
+    flatbuffers::FlatBufferBuilder b(c_flatbuffer_builder_size);
+    b.Finish(internal::Creategaia_ref_anchor(b));
+    return dac_object_t::insert_row(b);
+}
+gaia::direct_access::dac_container_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t> gaia_ref_anchor_t::list() {
+    return gaia::direct_access::dac_container_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t>();
+}
+//
 // Implementation of class gaia_index_t.
 //
 
@@ -40,7 +56,11 @@ gaia::direct_access::dac_vector_t<uint64_t> gaia_index_t::fields() const {
     return GET_ARRAY(fields);
 }
 gaia_table_t gaia_index_t::table() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_index_parent_table];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_index_parent_table];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_table_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
 }
 //
@@ -63,7 +83,11 @@ const char* gaia_rule_t::name() const {
     return GET_STR(name);
 }
 gaia_ruleset_t gaia_rule_t::ruleset() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_rule_parent_ruleset];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_rule_parent_ruleset];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_ruleset_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_ruleset_t() : gaia_ruleset_t::get(id);
 }
 //
@@ -153,11 +177,19 @@ gaia::direct_access::dac_vector_t<uint16_t> gaia_relationship_t::child_field_pos
     return GET_ARRAY(child_field_positions);
 }
 gaia_table_t gaia_relationship_t::child() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_relationship_parent_child];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_relationship_parent_child];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_table_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
 }
 gaia_table_t gaia_relationship_t::parent() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_relationship_parent_parent];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_relationship_parent_parent];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_table_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
 }
 //
@@ -198,7 +230,11 @@ bool gaia_field_t::unique() const {
     return GET(unique);
 }
 gaia_table_t gaia_field_t::table() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_field_parent_table];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_field_parent_table];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_table_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_table_t() : gaia_table_t::get(id);
 }
 //
@@ -233,7 +269,11 @@ gaia::direct_access::dac_vector_t<uint8_t> gaia_table_t::serialization_template(
     return GET_ARRAY(serialization_template);
 }
 gaia_database_t gaia_table_t::database() const {
-    gaia::common::gaia_id_t id = this->references()[c_gaia_table_parent_database];
+    gaia::common::gaia_id_t anchor_id = this->references()[c_gaia_table_parent_database];
+    if (anchor_id == gaia::common::c_invalid_gaia_id) {
+        return gaia_database_t();
+    }
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_parent_offset);
     return (id == gaia::common::c_invalid_gaia_id) ? gaia_database_t() : gaia_database_t::get(id);
 }
 gaia_table_t::gaia_indexes_list_t gaia_table_t::gaia_indexes() const {

--- a/production/catalog/src/gaiac_catalog_facade.cpp
+++ b/production/catalog/src/gaiac_catalog_facade.cpp
@@ -67,6 +67,16 @@ uint16_t gaiac_outgoing_link_facade_t::first_offset_value() const
     return m_relationship.first_child_offset();
 }
 
+std::string gaiac_outgoing_link_facade_t::parent_offset() const
+{
+    return "c_" + to_table() + "_parent_" + m_relationship.to_parent_link_name();
+}
+
+uint16_t gaiac_outgoing_link_facade_t::parent_offset_value() const
+{
+    return m_relationship.parent_offset();
+}
+
 std::string gaiac_outgoing_link_facade_t::next_offset() const
 {
     return "c_" + to_table() + "_next_" + m_relationship.to_parent_link_name();

--- a/production/catalog/tests/test_ddl_executor.cpp
+++ b/production/catalog/tests/test_ddl_executor.cpp
@@ -439,6 +439,7 @@ TEST_F(ddl_executor_test, create_relationships)
     ASSERT_EQ(uint8_t{0}, clinic_to_doctor_relationship.first_child_offset()); // clinic
     ASSERT_EQ(uint8_t{0}, clinic_to_doctor_relationship.parent_offset()); // doctor
     ASSERT_EQ(uint8_t{1}, clinic_to_doctor_relationship.next_child_offset()); // doctor
+    ASSERT_EQ(uint8_t{2}, clinic_to_doctor_relationship.prev_child_offset()); // doctor
 
     // check
     // (doctor) 1 -[patients]-> N (patient)
@@ -454,9 +455,10 @@ TEST_F(ddl_executor_test, create_relationships)
 
     ASSERT_STREQ("patients", doctor_to_patient_relationship.to_child_link_name());
     ASSERT_STREQ("doctor", doctor_to_patient_relationship.to_parent_link_name());
-    ASSERT_EQ(uint8_t{2}, doctor_to_patient_relationship.first_child_offset()); // doctor
+    ASSERT_EQ(uint8_t{3}, doctor_to_patient_relationship.first_child_offset()); // doctor
     ASSERT_EQ(uint8_t{0}, doctor_to_patient_relationship.parent_offset()); // patient
     ASSERT_EQ(uint8_t{1}, doctor_to_patient_relationship.next_child_offset()); // patient
+    ASSERT_EQ(uint8_t{2}, doctor_to_patient_relationship.prev_child_offset()); // patient
 
     // check
     // (clinic) 1 -[patients]-> (patient)
@@ -473,8 +475,9 @@ TEST_F(ddl_executor_test, create_relationships)
     ASSERT_STREQ("patients", clinic_to_patient_relationship.to_child_link_name());
     ASSERT_STREQ("clinic", clinic_to_patient_relationship.to_parent_link_name());
     ASSERT_EQ(uint8_t{1}, clinic_to_patient_relationship.first_child_offset()); // clinic
-    ASSERT_EQ(uint8_t{2}, clinic_to_patient_relationship.parent_offset()); // patient
-    ASSERT_EQ(uint8_t{3}, clinic_to_patient_relationship.next_child_offset()); // patient
+    ASSERT_EQ(uint8_t{3}, clinic_to_patient_relationship.parent_offset()); // patient
+    ASSERT_EQ(uint8_t{4}, clinic_to_patient_relationship.next_child_offset()); // patient
+    ASSERT_EQ(uint8_t{5}, clinic_to_patient_relationship.prev_child_offset()); // patient
     txn.commit();
 }
 

--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(gaia_db_client STATIC
   src/db_client_api.cpp
   src/gaia_ptr.cpp
   src/gaia_ptr_client.cpp
+  src/gaia_ptr_api.cpp
   src/payload_diff.cpp
   src/client_messenger.cpp
   src/mapped_data.cpp

--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -17,6 +17,7 @@
 #include "gaia_internal/common/retail_assert.hpp"
 #include "gaia_internal/common/system_table_types.hpp"
 #include "gaia_internal/db/db_client_config.hpp"
+#include "gaia_internal/db/gaia_ptr.hpp"
 #include "gaia_internal/db/triggers.hpp"
 #include "gaia_internal/exceptions.hpp"
 
@@ -40,6 +41,9 @@ class db_client_proxy_t;
 class client_t
 {
     friend class gaia_ptr_t;
+
+    friend void gaia_ptr::update_payload(gaia_ptr_t& obj, size_t data_size, const void* data);
+    friend gaia_ptr_t gaia_ptr::create(common::gaia_id_t id, common::gaia_type_t type, size_t data_size, const void* data);
 
     /**
      * @throws no_open_transaction_internal if there is no open transaction.

--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -25,7 +25,7 @@ inline int client_t::get_session_socket_for_txn()
 
 inline bool client_t::is_valid_event(common::gaia_type_t type)
 {
-    return (s_txn_commit_trigger && type < common::c_system_table_reserved_range_start);
+    return (s_txn_commit_trigger && !is_system_object(type));
 }
 
 inline void client_t::verify_txn_active()

--- a/production/db/core/inc/db_object_helpers.hpp
+++ b/production/db/core/inc/db_object_helpers.hpp
@@ -43,7 +43,10 @@ inline db_object_t* create_object(
     {
         memcpy(obj_ptr->payload, reinterpret_cast<const uint8_t*>(refs), ref_len);
     }
-    memcpy(obj_ptr->payload + ref_len, obj_data, obj_data_size);
+    if (obj_data_size > 0)
+    {
+        memcpy(obj_ptr->payload + ref_len, obj_data, obj_data_size);
+    }
     return obj_ptr;
 }
 
@@ -60,7 +63,10 @@ inline db_object_t* create_object(
     obj_ptr->type = type;
     obj_ptr->num_references = num_refs;
     obj_ptr->payload_size = obj_data_size;
-    memcpy(obj_ptr->payload, obj_data, obj_data_size);
+    if (obj_data_size > 0)
+    {
+        memcpy(obj_ptr->payload, obj_data, obj_data_size);
+    }
     return obj_ptr;
 }
 

--- a/production/db/core/src/catalog_core.cpp
+++ b/production/db/core/src/catalog_core.cpp
@@ -98,12 +98,16 @@ namespace db
 
 [[nodiscard]] gaia_id_t relationship_view_t::parent_table_id() const
 {
-    return m_obj_ptr->references()[c_parent_gaia_table_ref_offset];
+    gaia_id_t anchor_id = m_obj_ptr->references()[c_parent_gaia_table_ref_offset];
+    auto anchor_ptr = id_to_ptr(anchor_id);
+    return anchor_ptr->references()[c_ref_anchor_parent_offset];
 }
 
 [[nodiscard]] gaia_id_t relationship_view_t::child_table_id() const
 {
-    return m_obj_ptr->references()[c_child_gaia_table_ref_offset];
+    gaia_id_t anchor_id = m_obj_ptr->references()[c_child_gaia_table_ref_offset];
+    auto anchor_ptr = id_to_ptr(anchor_id);
+    return anchor_ptr->references()[c_ref_anchor_parent_offset];
 }
 
 [[nodiscard]] const flatbuffers::Vector<uint16_t>* relationship_view_t::parent_field_positions() const
@@ -148,7 +152,9 @@ namespace db
 
 [[nodiscard]] gaia_id_t index_view_t::table_id() const
 {
-    return m_obj_ptr->references()[c_parent_table_ref_offset];
+    gaia_id_t anchor_id = m_obj_ptr->references()[c_parent_table_ref_offset];
+    auto anchor_ptr = id_to_ptr(anchor_id);
+    return anchor_ptr->references()[c_ref_anchor_parent_offset];
 }
 
 table_view_t catalog_core_t::get_table(gaia_id_t table_id)
@@ -179,7 +185,7 @@ table_list_t
 catalog_core_t::list_tables()
 {
     auto gaia_ptr_iterator = table_generator_t(gaia_ptr_t::find_all_iterator(
-        static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_table)));
+        static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_table)));
     return range_from_generator(gaia_ptr_iterator);
 }
 
@@ -188,10 +194,15 @@ generator_range_t<T_catalog_obj_view>
 list_catalog_obj_reference_chain(gaia_id_t table_id, uint16_t first_offset, uint16_t next_offset)
 {
     auto obj_ptr = id_to_ptr(table_id);
-    const gaia_id_t* references = obj_ptr->references();
-    gaia_id_t first_obj_id = references[first_offset];
-    auto generator = [id = first_obj_id, next_offset]() mutable -> std::optional<T_catalog_obj_view>
+    gaia_id_t anchor_id = obj_ptr->references()[first_offset];
+    if (anchor_id == c_invalid_gaia_id)
     {
+        return generator_range_t<T_catalog_obj_view>();
+    }
+    auto anchor_ptr = id_to_ptr(anchor_id);
+    gaia_id_t first_obj_id = anchor_ptr->references()[c_ref_anchor_first_child_offset];
+
+    auto generator = [id = first_obj_id, next_offset]() mutable -> std::optional<T_catalog_obj_view> {
         if (id == c_invalid_gaia_id)
         {
             return std::nullopt;

--- a/production/db/core/src/db_jni_wrapper.cpp
+++ b/production/db/core/src/db_jni_wrapper.cpp
@@ -116,7 +116,7 @@ jboolean remove(jlong id)
         gaia_ptr_t t = gaia_ptr_t::from_gaia_id(id);
         if (t)
         {
-            gaia_ptr_t::remove(t);
+            t.reset();
         }
         else
         {
@@ -234,7 +234,7 @@ JNIEXPORT jlong JNICALL Java_com_gaiaplatform_database_GaiaDatabase_createNode(
     try
     {
         node = gaia_ptr_t::create(
-            id, type, payload_holder.size(), payload_holder.bytes());
+            id, type, 0, payload_holder.size(), payload_holder.bytes());
     }
     catch (const std::exception& e)
     {

--- a/production/db/core/src/db_pybind_wrapper.cpp
+++ b/production/db/core/src/db_pybind_wrapper.cpp
@@ -105,16 +105,10 @@ PYBIND11_MODULE(gaia_db_pybind, m)
     class_<gaia_ptr_t>(m, "gaia_ptr")
         .def_static(
             "create",
-            static_cast<gaia_ptr_t (*)(gaia_type_t, size_t, const void*)>(&gaia_ptr_t::create))
-        .def_static(
-            "create",
-            static_cast<gaia_ptr_t (*)(gaia_id_t, gaia_type_t, size_t, const void*)>(&gaia_ptr_t::create))
-        .def_static(
-            "create",
             static_cast<gaia_ptr_t (*)(gaia_id_t, gaia_type_t, reference_offset_t, size_t, const void*)>(&gaia_ptr_t::create))
         .def_static("from_gaia_id", &gaia_ptr_t::from_gaia_id)
         .def_static("find_first", &gaia_ptr_t::find_first)
-        .def_static("remove", &gaia_ptr_t::remove)
+        .def("remove", &gaia_ptr_t::reset)
         .def("is_null", &gaia_ptr_t::is_null)
         .def("id", &gaia_ptr_t::id)
         .def("type", &gaia_ptr_t::type)

--- a/production/db/core/src/gaia_ptr_api.cpp
+++ b/production/db/core/src/gaia_ptr_api.cpp
@@ -1,0 +1,752 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#include "gaia_internal/db/gaia_ptr_api.hpp"
+
+#include "gaia_internal/common/system_table_types.hpp"
+#include "gaia_internal/db/catalog_core.hpp"
+#include "gaia_internal/db/gaia_ptr.hpp"
+#include "gaia_internal/db/type_metadata.hpp"
+#include "gaia_internal/exceptions.hpp"
+
+#include "db_client.hpp"
+#include "db_helpers.hpp"
+#include "field_access.hpp"
+#include "index_key.hpp"
+#include "index_scan.hpp"
+#include "payload_diff.hpp"
+#include "type_id_mapping.hpp"
+
+using namespace gaia::common;
+using namespace gaia::db;
+
+namespace gaia
+{
+namespace db
+{
+
+namespace gaia_ptr
+{
+
+namespace
+{
+
+gaia_id_t find_using_index(
+    const uint8_t* payload,
+    field_position_t field_position,
+    gaia_type_t type,
+    gaia_id_t type_id,
+    gaia_id_t indexed_table_id,
+    field_position_t indexed_field_position)
+{
+    gaia_type_t indexed_table_type = catalog_core_t::get_table(indexed_table_id).table_type();
+    gaia_id_t indexed_table_type_id = type_id_mapping_t::instance().get_record_id(indexed_table_type);
+
+    gaia_id_t index_id = catalog_core_t::find_index(indexed_table_type_id, indexed_field_position);
+    // Callers need to ensure the table has an index on the field to search.
+    ASSERT_PRECONDITION(index_id != c_invalid_gaia_id, "Cannot find value index for the table.");
+
+    auto schema = catalog_core_t::get_table(type_id).binary_schema();
+    auto field_value = payload_types::get_field_value(
+        type,
+        payload,
+        schema->data(),
+        schema->size(),
+        field_position);
+
+    index::index_key_t key;
+    key.insert(field_value);
+    for (const auto& scan : query_processor::scan::index_scan_t(
+             index_id,
+             std::make_shared<query_processor::scan::index_point_read_predicate_t>(key)))
+    {
+        return scan.id();
+    }
+    return c_invalid_gaia_id;
+}
+
+void parent_side_auto_connect(
+    gaia_id_t id,
+    gaia_type_t type,
+    gaia_id_t type_id,
+    gaia_id_t* references,
+    const uint8_t* payload,
+    field_position_t field_position)
+{
+    // Check if the given field is used in establishing a relationship where the
+    // field's table is on the parent side.
+    for (auto relationship_view : catalog_core_t::list_relationship_from(type_id))
+    {
+        if (relationship_view.parent_field_positions()->size() != 1
+            || relationship_view.parent_field_positions()->Get(0) != field_position)
+        {
+            continue;
+        }
+
+        // At this point, we have found the value-linked relationship the
+        // node participated in on the parent side.
+        //
+        // If the node already has some child nodes, disconnect all existing
+        // children by detaching the children's reference anchor.
+        if (references[relationship_view.first_child_offset()] != c_invalid_gaia_id)
+        {
+            auto parent_anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.first_child_offset()]);
+            if (parent_anchor.references()[c_ref_anchor_first_child_offset] != c_invalid_gaia_id)
+            {
+                parent_anchor.set_reference(c_ref_anchor_parent_offset, c_invalid_gaia_id);
+                references[relationship_view.first_child_offset()] = c_invalid_gaia_id;
+            }
+        }
+
+        // Check if the field value exists in any child node using the index on the child table.
+        gaia_id_t child_id = find_using_index(
+            payload,
+            field_position,
+            type,
+            type_id,
+            relationship_view.child_table_id(),
+            relationship_view.child_field_positions()->Get(0));
+
+        if (child_id != c_invalid_gaia_id)
+        {
+            // We have found the child with the field value. Link the child
+            // node(s) to the parent node by connecting the child's
+            // reference anchor to the parent.
+            auto child = gaia_ptr_t::from_gaia_id(child_id);
+            gaia_id_t anchor_id = child.references()[relationship_view.parent_offset()];
+            references[relationship_view.first_child_offset()] = anchor_id;
+
+            auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
+            anchor.set_reference(c_ref_anchor_parent_offset, id);
+        }
+
+        // Create an anchor node for the parent node if it does not already
+        // exist for the field's value.
+        if (references[relationship_view.first_child_offset()] == c_invalid_gaia_id)
+        {
+            gaia_ptr_t anchor = gaia_ptr_t::create_ref_anchor(id, c_invalid_gaia_id);
+            references[relationship_view.first_child_offset()] = anchor.id();
+        }
+    }
+}
+
+void child_side_auto_connect(
+    gaia_id_t id,
+    gaia_type_t type,
+    gaia_id_t type_id,
+    gaia_id_t* references,
+    const uint8_t* payload,
+    field_position_t field_position)
+{
+
+    // Check if the given field is used in establishing a relationship where the
+    // field's table is on the child side.
+    for (auto relationship_view : catalog_core_t::list_relationship_to(type_id))
+    {
+        if (relationship_view.child_field_positions()->size() != 1
+            || relationship_view.child_field_positions()->Get(0) != field_position)
+        {
+            continue;
+        }
+
+        // At this point, we have found the value-linked relationship the
+        // node participated in on the child side.
+        //
+        // Disconnect the node from its existing reference chain.
+        if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
+        {
+            // Update the next child if exists.
+            auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
+            next_child.set_reference(relationship_view.prev_child_offset(), references[relationship_view.prev_child_offset()]);
+        }
+        if (references[relationship_view.prev_child_offset()] != c_invalid_gaia_id)
+        {
+            // Update the previous child if exists.
+            auto prev_child = gaia_ptr_t::from_gaia_id(references[relationship_view.prev_child_offset()]);
+            prev_child.set_reference(relationship_view.next_child_offset(), references[relationship_view.next_child_offset()]);
+        }
+        else if (references[relationship_view.parent_offset()] != c_invalid_gaia_id)
+        {
+            // This is the first child because previous node does not exist.
+            bool anchor_deleted = false;
+            if (references[relationship_view.next_child_offset()] == c_invalid_gaia_id)
+            {
+                // This is the only child because next node does not exist.
+                auto anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.parent_offset()]);
+                if (anchor.references()[c_ref_anchor_parent_offset] == c_invalid_gaia_id)
+                {
+                    // Delete the anchor node if it is not connected to some parent node.
+                    anchor.reset();
+                    anchor_deleted = true;
+                }
+            }
+
+            // Disconnect the (first) child from the anchor if it is not deleted in previous step.
+            if (!anchor_deleted)
+            {
+                auto anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.parent_offset()]);
+                anchor.set_reference(c_ref_anchor_first_child_offset, references[relationship_view.next_child_offset()]);
+            }
+        }
+        references[relationship_view.prev_child_offset()] = c_invalid_gaia_id;
+        references[relationship_view.next_child_offset()] = c_invalid_gaia_id;
+        references[relationship_view.parent_offset()] = c_invalid_gaia_id;
+
+        // Check if the field value exists in any parent node using the index on the parent table.
+        gaia_id_t parent_id = find_using_index(
+            payload,
+            field_position,
+            type,
+            type_id,
+            relationship_view.parent_table_id(),
+            relationship_view.parent_field_positions()->Get(0));
+
+        if (parent_id != c_invalid_gaia_id)
+        {
+            // We have found the parent node with the field value. Link the
+            // child node to the parent node by connecting the child to the
+            // parent's child anchor node.
+            auto parent = gaia_ptr_t::from_gaia_id(parent_id);
+            gaia_id_t anchor_id = parent.references()[relationship_view.first_child_offset()];
+            auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
+            references[relationship_view.parent_offset()] = anchor_id;
+            references[relationship_view.next_child_offset()] = anchor.references()[c_ref_anchor_first_child_offset];
+
+            anchor.set_reference(c_ref_anchor_first_child_offset, id);
+
+            if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
+            {
+                auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
+                next_child.set_reference(relationship_view.prev_child_offset(), id);
+            }
+        }
+        else
+        {
+            // Check if the field value exists in any child node using the index on the child table (this table).
+            gaia_id_t child_id = find_using_index(
+                payload,
+                field_position,
+                type,
+                type_id,
+                relationship_view.child_table_id(),
+                relationship_view.child_field_positions()->Get(0));
+            if (child_id != c_invalid_gaia_id)
+            {
+                // We have found some child node with the same linked field
+                // value. Insert the node to the existing anchor chain.
+                auto child = gaia_ptr_t::from_gaia_id(child_id);
+                gaia_id_t anchor_id = child.references()[relationship_view.parent_offset()];
+                auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
+                references[relationship_view.parent_offset()] = anchor_id;
+                references[relationship_view.next_child_offset()] = anchor.references()[c_ref_anchor_first_child_offset];
+
+                anchor.set_reference(c_ref_anchor_first_child_offset, id);
+
+                if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
+                {
+                    auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
+                    next_child.set_reference(relationship_view.prev_child_offset(), id);
+                }
+            }
+            else if (references[relationship_view.parent_offset()] == c_invalid_gaia_id)
+            {
+                // This child has no matching parent or other child of the
+                // same field value. Create an anchor node for the child to
+                // form an anchor chain of itself.
+                gaia_ptr_t anchor = gaia_ptr_t::create_ref_anchor(c_invalid_gaia_id, id);
+                references[relationship_view.parent_offset()] = anchor.id();
+            }
+        }
+    }
+}
+
+void auto_connect(
+    gaia_id_t id,
+    gaia_type_t type,
+    gaia_id_t type_id,
+    gaia_id_t* references,
+    const uint8_t* payload,
+    const field_position_list_t& candidate_fields)
+{
+    // Skip catalog core tables. See notes in the other method of the same name.
+    if (is_catalog_core_object(type))
+    {
+        return;
+    }
+
+    for (auto field_position : candidate_fields)
+    {
+        parent_side_auto_connect(id, type, type_id, references, payload, field_position);
+        child_side_auto_connect(id, type, type_id, references, payload, field_position);
+    }
+}
+
+void auto_connect(
+    gaia_id_t id,
+    gaia_type_t type,
+    gaia_id_t* references,
+    const uint8_t* payload)
+{
+    // Skip catalog core tables.
+    //
+    // This implementation relies on the following catalog tables in place to work:
+    //   - gaia_table
+    //   - gaia_field
+    //   - gaia_relationship
+    //
+    // These tables will not be available during bootstrap when they are being
+    // populated themselves. We can skip all system tables safely as no system
+    // tables use the auto connection feature.
+    if (is_catalog_core_object(type))
+    {
+        return;
+    }
+    field_position_list_t candidate_fields;
+    gaia_id_t table_id = type_id_mapping_t::instance().get_record_id(type);
+    for (auto field_view : catalog_core_t::list_fields(table_id))
+    {
+        candidate_fields.push_back(field_view.position());
+    }
+    auto_connect(id, type, table_id, references, payload, candidate_fields);
+}
+
+} // namespace
+
+gaia_ptr_t create(
+    common::gaia_type_t type,
+    size_t data_size,
+    const void* data)
+{
+    gaia_id_t id = gaia_ptr_t::generate_id();
+    return create(id, type, data_size, data);
+}
+
+gaia_ptr_t create(
+    common::gaia_id_t id,
+    common::gaia_type_t type,
+    size_t data_size,
+    const void* data)
+{
+    client_t::verify_txn_active();
+
+    const type_metadata_t& metadata = type_registry_t::instance().get(type);
+    reference_offset_t num_references = metadata.num_references();
+
+    gaia_ptr_t obj = gaia_ptr_t::create_no_txn(id, type, num_references, data_size, data);
+    db_object_t* obj_ptr = obj.to_ptr();
+    auto_connect(
+        id,
+        type,
+        // NOLINTNEXTLINE: cppcoreguidelines-pro-type-const-cast
+        const_cast<gaia_id_t*>(obj_ptr->references()),
+        reinterpret_cast<const uint8_t*>(obj_ptr->data()));
+
+    obj.finalize_create();
+
+    if (client_t::is_valid_event(type))
+    {
+        client_t::s_events.emplace_back(triggers::event_type_t::row_insert, type, id, triggers::c_empty_position_list, get_current_txn_id());
+    }
+    return obj;
+}
+
+void update_payload(gaia_id_t id, size_t data_size, const void* data)
+{
+    gaia_ptr_t obj = gaia_ptr_t::from_gaia_id(id);
+    if (!obj)
+    {
+        throw invalid_object_id_internal(id);
+    }
+    update_payload(obj, data_size, data);
+}
+
+void update_payload(gaia_ptr_t& obj, size_t data_size, const void* data)
+{
+    db_object_t* old_this = obj.to_ptr();
+    gaia_offset_t old_offset = obj.to_offset();
+    size_t references_size = old_this->num_references * sizeof(gaia_id_t);
+
+    obj.update_payload_no_txn(data_size, data);
+
+    auto new_data = reinterpret_cast<const uint8_t*>(data);
+    auto old_data = reinterpret_cast<const uint8_t*>(old_this->payload);
+    const uint8_t* old_data_payload = old_data + references_size;
+    field_position_list_t changed_fields = compute_payload_diff(obj.type(), old_data_payload, new_data);
+
+    auto_connect(
+        obj.id(),
+        obj.type(),
+        type_id_mapping_t::instance().get_record_id(obj.type()),
+        obj.references(),
+        new_data,
+        changed_fields);
+
+    obj.finalize_update(old_offset);
+
+    if (client_t::is_valid_event(obj.type()))
+    {
+        client_t::s_events.emplace_back(triggers::event_type_t::row_update, obj.type(), obj.id(), changed_fields, get_current_txn_id());
+    }
+}
+
+void remove(gaia_ptr_t& object)
+{
+    if (!object)
+    {
+        return;
+    }
+
+    const gaia_id_t* references = object.references();
+
+    for (reference_offset_t i = 0; i < object.num_references(); i++)
+    {
+        if (references[i] == c_invalid_gaia_id)
+        {
+            continue;
+        }
+
+        auto other_obj = gaia_ptr_t::from_gaia_id(references[i]);
+
+        gaia_id_t referenced_obj_id = other_obj.id();
+
+        if (other_obj.is_ref_anchor())
+        {
+            if (other_obj.references()[c_ref_anchor_parent_offset] == object.id())
+            {
+                // This is a parent node in the relationship because its
+                // anchor's parent reference is pointing to itself.
+                if (other_obj.references()[c_ref_anchor_first_child_offset] == c_invalid_gaia_id)
+                {
+                    // There is no child. We can delete the parent.
+                    continue;
+                }
+                referenced_obj_id = other_obj.references()[c_ref_anchor_first_child_offset];
+            }
+            else
+            {
+                // This is a child node in the relationship because its
+                // anchor node's parent reference is not pointing to itself.
+                if (other_obj.references()[c_ref_anchor_parent_offset] == c_invalid_gaia_id)
+                {
+                    // There is no parent. We can delete the child.
+                    //
+                    // Skip checking the next two reference slots.
+                    i += 2;
+                    continue;
+                }
+                referenced_obj_id = other_obj.references()[c_ref_anchor_parent_offset];
+            }
+        }
+
+        throw object_still_referenced_internal(object.id(), object.type(), referenced_obj_id, gaia_ptr_t::from_gaia_id(referenced_obj_id).type());
+    }
+
+    // Make necessary changes to the anchor chain before deleting the node.
+    for (reference_offset_t i = 0; i < object.num_references(); i++)
+    {
+        if (references[i] != c_invalid_gaia_id)
+        {
+            auto anchor = gaia_ptr_t::from_gaia_id(references[i]);
+            if (!anchor.is_ref_anchor())
+            {
+                continue;
+            }
+
+            if (anchor.references()[c_ref_anchor_parent_offset] == object.id())
+            {
+                // The anchor node connected to the parent can be safely deleted.
+                anchor.reset();
+                continue;
+            }
+
+            reference_offset_t next_offset = i + 1;
+
+            if (anchor.references()[c_ref_anchor_first_child_offset] == object.id()
+                && object.references()[next_offset] == c_invalid_gaia_id)
+            {
+                // This is the only child in the anchor chain. We can delete the
+                // anchor node safely.
+                anchor.reset();
+                continue;
+            }
+
+            reference_offset_t prev_offset = next_offset + 1;
+
+            // Disconnect the node from its existing anchor chain.
+            if (object.references()[next_offset] != c_invalid_gaia_id)
+            {
+                auto next = gaia_ptr_t::from_gaia_id(object.references()[next_offset]);
+                next.set_reference(prev_offset, object.references()[prev_offset]);
+            }
+            if (object.references()[prev_offset] != c_invalid_gaia_id)
+            {
+                auto prev = gaia_ptr_t::from_gaia_id(object.references()[prev_offset]);
+                prev.set_reference(next_offset, object.references()[next_offset]);
+            }
+            if (anchor.references()[c_ref_anchor_first_child_offset] == object.id())
+            {
+                anchor.set_reference(c_ref_anchor_first_child_offset, object.references()[next_offset]);
+            }
+        }
+    }
+
+    object.reset();
+}
+
+bool insert_into_reference_container(gaia_ptr_t& parent, gaia_id_t child_id, reference_offset_t parent_anchor_slot)
+{
+    gaia_type_t parent_type = parent.type();
+    const type_metadata_t& parent_metadata = type_registry_t::instance().get(parent_type);
+    std::optional<relationship_t> relationship = parent_metadata.find_parent_relationship(parent_anchor_slot);
+    if (!relationship)
+    {
+        throw invalid_reference_offset_internal(parent_type, parent_anchor_slot);
+    }
+
+    auto child = gaia_ptr_t::from_gaia_id(child_id);
+    if (!child)
+    {
+        throw invalid_object_id_internal(child_id);
+    }
+
+    if (relationship->parent_type != parent_type)
+    {
+        throw invalid_relationship_type_internal(parent_anchor_slot, relationship->parent_type, parent_type);
+    }
+    if (relationship->child_type != child.type())
+    {
+        throw invalid_relationship_type_internal(parent_anchor_slot, relationship->child_type, child.type());
+    }
+
+    gaia_ptr_t anchor;
+    gaia_id_t anchor_id = parent.references()[parent_anchor_slot];
+    if (anchor_id != c_invalid_gaia_id)
+    {
+        anchor = gaia_ptr_t::from_gaia_id(anchor_id);
+
+        if (relationship->cardinality == cardinality_t::one
+            && anchor.references()[c_ref_anchor_first_child_offset] != c_invalid_gaia_id)
+        {
+            throw single_cardinality_violation_internal(parent_type, parent_anchor_slot);
+        }
+
+        if (child.references()[relationship->parent_offset] == anchor_id)
+        {
+            // Users try to insert a child that is already in the anchor chain. We
+            // have nothing to do. Return false as the child is not inserted.
+            return false;
+        }
+    }
+    if (child.references()[relationship->parent_offset] != c_invalid_gaia_id)
+    {
+        // Do not allow inserting a child that is already in some other chain.
+        throw child_already_referenced_internal(child.type(), parent_anchor_slot);
+    }
+
+    if (anchor_id == c_invalid_gaia_id)
+    {
+        anchor = gaia_ptr_t::create_ref_anchor(parent.id(), child_id);
+        anchor_id = anchor.id();
+        parent.set_reference(parent_anchor_slot, anchor_id);
+        child.set_references(
+            relationship->parent_offset,
+            anchor_id,
+            relationship->next_child_offset,
+            c_invalid_gaia_id,
+            relationship->prev_child_offset,
+            c_invalid_gaia_id);
+    }
+    else
+    {
+        child.set_references(
+            relationship->parent_offset,
+            anchor_id,
+            relationship->next_child_offset,
+            anchor.references()[c_ref_anchor_first_child_offset],
+            relationship->prev_child_offset,
+            c_invalid_gaia_id);
+        anchor.set_reference(c_ref_anchor_first_child_offset, child_id);
+    }
+
+    if (child.references()[relationship->next_child_offset] != c_invalid_gaia_id)
+    {
+        auto next_child = gaia_ptr_t::from_gaia_id(child.references()[relationship->next_child_offset]);
+        next_child.set_reference(relationship->prev_child_offset, child_id);
+    }
+
+    return true;
+}
+
+bool insert_into_reference_container(gaia_id_t parent_id, gaia_id_t child_id, reference_offset_t parent_anchor_slot)
+{
+    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
+    if (!parent)
+    {
+        throw invalid_object_id_internal(parent_id);
+    }
+    return insert_into_reference_container(parent, child_id, parent_anchor_slot);
+}
+
+bool remove_from_reference_container(gaia_ptr_t& parent, gaia_id_t child_id, reference_offset_t parent_anchor_slot)
+{
+    gaia_type_t parent_type = parent.type();
+    const type_metadata_t& parent_metadata = type_registry_t::instance().get(parent_type);
+    std::optional<relationship_t> relationship = parent_metadata.find_parent_relationship(parent_anchor_slot);
+
+    if (!relationship)
+    {
+        throw invalid_reference_offset_internal(parent_type, parent_anchor_slot);
+    }
+
+    // Check types.
+    // TODO: Note that this check could be removed or the failure could be gracefully handled.
+    //   We prefer to fail because calling this method with wrong arguments means there
+    //   is something seriously ill in the caller code.
+
+    auto child = gaia_ptr_t::from_gaia_id(child_id);
+
+    if (!child)
+    {
+        throw invalid_object_id_internal(child_id);
+    }
+
+    if (relationship->parent_type != parent_type)
+    {
+        throw invalid_relationship_type_internal(parent_anchor_slot, parent_type, relationship->parent_type);
+    }
+
+    if (relationship->child_type != child.type())
+    {
+        throw invalid_relationship_type_internal(parent_anchor_slot, child.type(), relationship->child_type);
+    }
+
+    if (child.references()[relationship->parent_offset] == c_invalid_gaia_id)
+    {
+        return false;
+    }
+
+    if (child.references()[relationship->parent_offset] != parent.references()[parent_anchor_slot])
+    {
+        throw invalid_child_reference_internal(child.type(), child_id, parent_type, parent.id());
+    }
+
+    return remove_from_reference_container(child, relationship->parent_offset);
+}
+
+bool remove_from_reference_container(gaia_id_t parent_id, gaia_id_t child_id, reference_offset_t parent_anchor_slot)
+{
+    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
+    if (!parent)
+    {
+        throw invalid_object_id_internal(parent_id);
+    }
+    return remove_from_reference_container(parent, child_id, parent_anchor_slot);
+}
+
+bool remove_from_reference_container(gaia_ptr_t& child, reference_offset_t child_anchor_slot)
+{
+    reference_offset_t next_child_offset = child_anchor_slot + 1;
+    reference_offset_t prev_child_offset = next_child_offset + 1;
+
+    if (child.references()[next_child_offset] != c_invalid_gaia_id)
+    {
+        // Update the next child if exists.
+        auto next_child = gaia_ptr_t::from_gaia_id(child.references()[next_child_offset]);
+        next_child.set_reference(prev_child_offset, child.references()[prev_child_offset]);
+    }
+    if (child.references()[prev_child_offset] != c_invalid_gaia_id)
+    {
+        // Update the previous child if exists.
+        auto prev_child = gaia_ptr_t::from_gaia_id(child.references()[prev_child_offset]);
+        prev_child.set_reference(next_child_offset, child.references()[next_child_offset]);
+    }
+    else if (child.references()[child_anchor_slot] != c_invalid_gaia_id)
+    {
+        // This is the first child because previous node does not exist.
+        if (child.references()[next_child_offset] == c_invalid_gaia_id)
+        {
+            // This is the only child because next node does not exist.
+            // Delete the anchor node and reset the parent node's anchor slot.
+            auto anchor = gaia_ptr_t::from_gaia_id(child.references()[child_anchor_slot]);
+            auto parent = gaia_ptr_t::from_gaia_id(anchor.references()[c_ref_anchor_parent_offset]);
+            const type_metadata_t& metadata = type_registry_t::instance().get(child.type());
+            std::optional<relationship_t> relationship = metadata.find_child_relationship(child_anchor_slot);
+            parent.set_reference(relationship->first_child_offset, c_invalid_gaia_id);
+            anchor.reset();
+        }
+        else
+        {
+            // Disconnect the (first) child from the anchor if it is not the only child.
+            auto anchor = gaia_ptr_t::from_gaia_id(child.references()[child_anchor_slot]);
+            anchor.set_reference(c_ref_anchor_first_child_offset, child.references()[next_child_offset]);
+        }
+    }
+    child.set_references(
+        child_anchor_slot,
+        c_invalid_gaia_id,
+        next_child_offset,
+        c_invalid_gaia_id,
+        prev_child_offset,
+        c_invalid_gaia_id);
+    return true;
+}
+
+bool remove_from_reference_container(gaia_id_t child_id, reference_offset_t child_anchor_slot)
+{
+    gaia_ptr_t child = gaia_ptr_t::from_gaia_id(child_id);
+    return remove_from_reference_container(child, child_anchor_slot);
+}
+
+bool update_parent_reference(gaia_ptr_t& child, gaia_id_t new_parent_id, reference_offset_t parent_offset)
+{
+    const type_metadata_t& child_metadata = type_registry_t::instance().get(child.type());
+    std::optional<relationship_t> relationship = child_metadata.find_child_relationship(parent_offset);
+
+    if (!relationship)
+    {
+        throw invalid_reference_offset_internal(child.type(), parent_offset);
+    }
+
+    auto new_parent = gaia_ptr_t::from_gaia_id(new_parent_id);
+
+    if (!new_parent)
+    {
+        throw invalid_object_id_internal(new_parent_id);
+    }
+
+    // TODO: this implementation will produce more garbage than necessary. Also, many of the RI methods
+    //  perform redundant checks. Created JIRA to improve RI performance/api:
+    //  https://gaiaplatform.atlassian.net/browse/GAIAPLAT-435
+
+    // Check cardinality.
+    if (new_parent.references()[relationship->first_child_offset] != c_invalid_gaia_id)
+    {
+        // This parent already has a child for this relationship.
+        // If the relationship is one-to-one we fail.
+        if (relationship->cardinality == cardinality_t::one)
+        {
+            throw single_cardinality_violation_internal(new_parent.type(), relationship->first_child_offset);
+        }
+    }
+
+    if (child.references()[parent_offset] != c_invalid_gaia_id)
+    {
+        auto anchor = gaia_ptr_t::from_gaia_id(child.references()[parent_offset]);
+        auto old_parent = gaia_ptr_t::from_gaia_id(anchor.references()[c_ref_anchor_parent_offset]);
+        remove_from_reference_container(old_parent.id(), child.id(), relationship->first_child_offset);
+    }
+
+    return insert_into_reference_container(new_parent_id, child.id(), relationship->first_child_offset);
+}
+
+bool update_parent_reference(gaia_id_t child_id, gaia_id_t new_parent_id, reference_offset_t parent_offset)
+{
+    gaia_ptr_t child = gaia_ptr_t::from_gaia_id(child_id);
+    return update_parent_reference(child, new_parent_id, parent_offset);
+}
+} // namespace gaia_ptr
+
+} // namespace db
+} // namespace gaia

--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -4,36 +4,26 @@
 /////////////////////////////////////////////
 
 #include "gaia/common.hpp"
+#include "gaia/exceptions.hpp"
 
 #include "gaia_internal/common/retail_assert.hpp"
-#include "gaia_internal/common/system_table_types.hpp"
-#include "gaia_internal/db/catalog_core.hpp"
 #include "gaia_internal/db/gaia_ptr.hpp"
-#include "gaia_internal/db/triggers.hpp"
+#include "gaia_internal/exceptions.hpp"
 
 #include "db_client.hpp"
 #include "db_hash_map.hpp"
 #include "db_helpers.hpp"
-#include "db_internal_types.hpp"
-#include "field_access.hpp"
-#include "index_key.hpp"
-#include "index_scan.hpp"
+
+#ifdef DEBUG
 #include "memory_helpers.hpp"
-#include "memory_types.hpp"
-#include "payload_diff.hpp"
-#include "type_id_mapping.hpp"
+#define WRITE_PROTECT(o) memory_manager::write_protect_allocation_page_for_offset((o))
+#else
+#define WRITE_PROTECT(o) ((void)0)
+#endif
 
 using namespace gaia::common;
 using namespace gaia::common::iterators;
 using namespace gaia::db;
-using namespace gaia::db::triggers;
-using namespace gaia::db::memory_manager;
-
-#ifdef DEBUG
-#define WRITE_PROTECT(o) write_protect_allocation_page_for_offset((o))
-#else
-#define WRITE_PROTECT(o) ((void)0)
-#endif
 
 namespace gaia
 {
@@ -66,293 +56,6 @@ gaia_ptr_t::get_id_generator_for_type(gaia_type_t type)
     return client_t::get_id_generator_for_type(type);
 }
 
-bool gaia_ptr_t::add_child_reference(gaia_id_t child_id, reference_offset_t first_child_offset)
-{
-    gaia_type_t parent_type = type();
-    const type_metadata_t& parent_metadata = type_registry_t::instance().get(parent_type);
-    std::optional<relationship_t> relationship = parent_metadata.find_parent_relationship(first_child_offset);
-
-    if (!relationship)
-    {
-        throw invalid_reference_offset_internal(parent_type, first_child_offset);
-    }
-
-    // Check types.
-
-    auto child_ptr = gaia_ptr_t::from_gaia_id(child_id);
-
-    if (!child_ptr)
-    {
-        throw invalid_object_id_internal(child_id);
-    }
-
-    if (relationship->parent_type != parent_type)
-    {
-        throw invalid_relationship_type_internal(first_child_offset, relationship->parent_type, parent_type);
-    }
-
-    if (relationship->child_type != child_ptr.type())
-    {
-        throw invalid_relationship_type_internal(first_child_offset, relationship->child_type, child_ptr.type());
-    }
-
-    // Check cardinality.
-
-    if (references()[first_child_offset] != c_invalid_gaia_id)
-    {
-        // This parent already has a child for this relationship.
-        // If the relationship is one-to-one, we fail.
-        if (relationship->cardinality == cardinality_t::one)
-        {
-            throw single_cardinality_violation_internal(parent_type, first_child_offset);
-        }
-    }
-
-    // Note: we check only for parent under the assumption that the relational integrity
-    // is preserved, thus if there are no parent references there are no next_child_offset values either.
-    if (child_ptr.references()[relationship->parent_offset] != c_invalid_gaia_id)
-    {
-        // If the child already has a reference to this parent, handle gracefully.
-        // Otherwise throw an exception.
-        if (child_ptr.references()[relationship->parent_offset] == id())
-        {
-            return false;
-        }
-        throw child_already_referenced_internal(child_ptr.type(), relationship->parent_offset);
-    }
-
-    // Clone parent and child objects for CoW updates.
-    // TODO (Mihir): if the parent/child have been created in the same txn, the clone may not be necessary.
-    gaia_offset_t old_parent_offset = to_offset();
-    WRITE_PROTECT(old_parent_offset);
-    clone_no_txn();
-
-    gaia_offset_t old_child_offset = child_ptr.to_offset();
-
-    // Need to handle self-references.
-    if (*this != child_ptr)
-    {
-        WRITE_PROTECT(old_child_offset);
-        child_ptr.clone_no_txn();
-    }
-
-    child_ptr.references()[relationship->next_child_offset] = references()[first_child_offset];
-    references()[first_child_offset] = child_ptr.id();
-    child_ptr.references()[relationship->parent_offset] = id();
-
-    // Need to handle self-references.
-    if (*this != child_ptr)
-    {
-        WRITE_PROTECT(child_ptr.to_offset());
-        client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset());
-    }
-
-    WRITE_PROTECT(to_offset());
-    client_t::txn_log(m_locator, old_parent_offset, to_offset());
-    return true;
-}
-
-bool gaia_ptr_t::add_parent_reference(gaia_id_t parent_id, reference_offset_t parent_offset)
-{
-    gaia_type_t child_type = type();
-
-    const type_metadata_t& child_metadata = type_registry_t::instance().get(child_type);
-    std::optional<relationship_t> child_relationship = child_metadata.find_child_relationship(parent_offset);
-
-    if (!child_relationship)
-    {
-        throw invalid_reference_offset_internal(child_type, parent_offset);
-    }
-
-    auto parent_ptr = gaia_ptr_t::from_gaia_id(parent_id);
-
-    if (!parent_ptr)
-    {
-        throw invalid_object_id_internal(parent_id);
-    }
-
-    return parent_ptr.add_child_reference(id(), child_relationship->first_child_offset);
-}
-
-bool gaia_ptr_t::remove_child_reference(gaia_id_t child_id, reference_offset_t first_child_offset)
-{
-    gaia_type_t parent_type = type();
-    const type_metadata_t& parent_metadata = type_registry_t::instance().get(parent_type);
-    std::optional<relationship_t> relationship = parent_metadata.find_parent_relationship(first_child_offset);
-
-    if (!relationship)
-    {
-        throw invalid_reference_offset_internal(parent_type, first_child_offset);
-    }
-
-    // Check types.
-    // TODO: Note that this check could be removed or the failure could be gracefully handled.
-    //   We prefer to fail because calling this method with wrong arguments means there
-    //   is something seriously ill in the caller code.
-
-    auto child_ptr = gaia_ptr_t::from_gaia_id(child_id);
-
-    if (!child_ptr)
-    {
-        throw invalid_object_id_internal(child_id);
-    }
-
-    if (relationship->parent_type != parent_type)
-    {
-        throw invalid_relationship_type_internal(first_child_offset, parent_type, relationship->parent_type);
-    }
-
-    if (relationship->child_type != child_ptr.type())
-    {
-        throw invalid_relationship_type_internal(first_child_offset, child_ptr.type(), relationship->child_type);
-    }
-
-    if (child_ptr.references()[relationship->parent_offset] == c_invalid_gaia_id)
-    {
-        return false;
-    }
-
-    if (child_ptr.references()[relationship->parent_offset] != id())
-    {
-        throw invalid_child_reference_internal(child_ptr.type(), child_id, type(), id());
-    }
-
-    // Clone parent and child objects for CoW updates.
-    gaia_offset_t old_parent_offset = to_offset();
-    WRITE_PROTECT(old_parent_offset);
-    clone_no_txn();
-
-    gaia_offset_t old_child_offset = child_ptr.to_offset();
-
-    // Need to handle self-references.
-    if (*this != child_ptr)
-    {
-        WRITE_PROTECT(old_child_offset);
-        child_ptr.clone_no_txn();
-    }
-
-    gaia_id_t prev_child = c_invalid_gaia_id;
-    gaia_id_t curr_child = references()[first_child_offset];
-
-    while (curr_child != child_id && curr_child != c_invalid_gaia_id)
-    {
-        prev_child = curr_child;
-        curr_child = gaia_ptr_t::from_gaia_id(prev_child).references()[relationship->next_child_offset];
-    }
-
-    // Match found.
-    if (curr_child == child_id)
-    {
-        auto curr_ptr = gaia_ptr_t::from_gaia_id(curr_child);
-
-        if (!prev_child)
-        {
-            // First child in the linked list, need to update the parent.
-            references()[first_child_offset] = curr_ptr.references()[relationship->next_child_offset];
-        }
-        else
-        {
-            // Non-first child in the linked list, update the previous child.
-            auto prev_ptr = gaia_ptr_t::from_gaia_id(prev_child);
-            gaia_offset_t old_prev_offset = prev_ptr.to_offset();
-            WRITE_PROTECT(old_prev_offset);
-            prev_ptr.clone_no_txn();
-            prev_ptr.references()[relationship->next_child_offset]
-                = curr_ptr.references()[relationship->next_child_offset];
-            WRITE_PROTECT(prev_ptr.to_offset());
-            client_t::txn_log(prev_ptr.m_locator, old_prev_offset, prev_ptr.to_offset());
-        }
-
-        curr_ptr.references()[relationship->parent_offset] = c_invalid_gaia_id;
-        curr_ptr.references()[relationship->next_child_offset] = c_invalid_gaia_id;
-    }
-
-    // Need to handle self-references.
-    if (*this != child_ptr)
-    {
-        WRITE_PROTECT(child_ptr.to_offset());
-        client_t::txn_log(child_ptr.m_locator, old_child_offset, child_ptr.to_offset());
-    }
-
-    WRITE_PROTECT(to_offset());
-    client_t::txn_log(m_locator, old_parent_offset, to_offset());
-    return true;
-}
-
-bool gaia_ptr_t::remove_parent_reference(reference_offset_t parent_offset)
-{
-    gaia_type_t child_type = type();
-
-    const type_metadata_t& child_metadata = type_registry_t::instance().get(child_type);
-    std::optional<relationship_t> relationship = child_metadata.find_child_relationship(parent_offset);
-
-    if (!relationship)
-    {
-        throw invalid_reference_offset_internal(child_type, parent_offset);
-    }
-
-    auto parent_ptr = gaia_ptr_t::from_gaia_id(this->references()[parent_offset]);
-
-    if (!parent_ptr)
-    {
-        return false;
-    }
-
-    // Remove reference.
-    return parent_ptr.remove_child_reference(id(), relationship->first_child_offset);
-}
-
-bool gaia_ptr_t::update_parent_reference(
-    gaia_id_t child_id,
-    gaia_type_t child_type,
-    gaia_id_t* child_references,
-    gaia_id_t new_parent_id,
-    reference_offset_t parent_offset)
-{
-    const type_metadata_t& child_metadata = type_registry_t::instance().get(child_type);
-    std::optional<relationship_t> relationship = child_metadata.find_child_relationship(parent_offset);
-
-    if (!relationship)
-    {
-        throw invalid_reference_offset_internal(child_type, parent_offset);
-    }
-
-    auto new_parent_ptr = gaia_ptr_t::from_gaia_id(new_parent_id);
-
-    if (!new_parent_ptr)
-    {
-        throw invalid_object_id_internal(new_parent_id);
-    }
-
-    // TODO: this implementation will produce more garbage than necessary. Also, many of the RI methods
-    //  perform redundant checks. Created JIRA to improve RI performance/api:
-    //  https://gaiaplatform.atlassian.net/browse/GAIAPLAT-435
-
-    // Check cardinality.
-    if (new_parent_ptr.references()[relationship->first_child_offset] != c_invalid_gaia_id)
-    {
-        // This parent already has a child for this relationship.
-        // If the relationship is one-to-one we fail.
-        if (relationship->cardinality == cardinality_t::one)
-        {
-            throw single_cardinality_violation_internal(new_parent_ptr.type(), relationship->first_child_offset);
-        }
-    }
-
-    if (child_references[parent_offset])
-    {
-        auto old_parent_ptr = gaia_ptr_t::from_gaia_id(child_references[parent_offset]);
-        old_parent_ptr.remove_child_reference(child_id, relationship->first_child_offset);
-    }
-
-    return new_parent_ptr.add_child_reference(child_id, relationship->first_child_offset);
-}
-
-bool gaia_ptr_t::update_parent_reference(gaia_id_t new_parent_id, reference_offset_t parent_offset)
-{
-    return update_parent_reference(id(), type(), references(), new_parent_id, parent_offset);
-}
-
 db_object_t* gaia_ptr_t::to_ptr() const
 {
     client_t::verify_txn_active();
@@ -365,49 +68,30 @@ gaia_offset_t gaia_ptr_t::to_offset() const
     return locator_to_offset(m_locator);
 }
 
-void gaia_ptr_t::create_insert_trigger(gaia_type_t type, gaia_id_t id)
+void gaia_ptr_t::finalize_create()
 {
-    if (client_t::is_valid_event(type))
-    {
-        client_t::s_events.emplace_back(event_type_t::row_insert, type, id, empty_position_list, get_current_txn_id());
-    }
+    WRITE_PROTECT(to_offset());
+    client_t::txn_log(m_locator, c_invalid_gaia_offset, to_offset());
 }
 
-gaia_ptr_t gaia_ptr_t::create(gaia_type_t type, size_t data_size, const void* data)
+void gaia_ptr_t::finalize_update(gaia_offset_t old_offset)
 {
-    gaia_id_t id = gaia_ptr_t::generate_id();
-
-    const type_metadata_t& metadata = type_registry_t::instance().get(type);
-    reference_offset_t num_references = metadata.num_references();
-
-    return create(id, type, num_references, data_size, data);
-}
-
-gaia_ptr_t gaia_ptr_t::create(gaia_id_t id, gaia_type_t type, size_t data_size, const void* data)
-{
-    const type_metadata_t& metadata = type_registry_t::instance().get(type);
-    reference_offset_t num_references = metadata.num_references();
-
-    return create(id, type, num_references, data_size, data);
+    WRITE_PROTECT(to_offset());
+    client_t::txn_log(m_locator, old_offset, to_offset());
 }
 
 gaia_ptr_t gaia_ptr_t::create(gaia_id_t id, gaia_type_t type, reference_offset_t num_references, size_t data_size, const void* data)
 {
     gaia_ptr_t obj = create_no_txn(id, type, num_references, data_size, data);
-    db_object_t* obj_ptr = obj.to_ptr();
-
-    auto_connect(
-        id,
-        type,
-        // NOLINTNEXTLINE: cppcoreguidelines-pro-type-const-cast
-        const_cast<gaia_id_t*>(obj_ptr->references()),
-        reinterpret_cast<const uint8_t*>(obj_ptr->data()));
-
-    WRITE_PROTECT(obj.to_offset());
-    client_t::txn_log(obj.m_locator, c_invalid_gaia_offset, obj.to_offset());
-
-    obj.create_insert_trigger(type, id);
+    obj.finalize_create();
     return obj;
+}
+
+void gaia_ptr_t::update_payload(size_t data_size, const void* data)
+{
+    gaia_offset_t old_offset = to_offset();
+    update_payload_no_txn(data_size, data);
+    finalize_update(old_offset);
 }
 
 gaia_ptr_t gaia_ptr_t::create_ref_anchor(gaia_id_t parent_id, gaia_id_t first_child_id)
@@ -420,8 +104,8 @@ gaia_ptr_t gaia_ptr_t::create_ref_anchor(gaia_id_t parent_id, gaia_id_t first_ch
         nullptr);
     obj.references()[c_ref_anchor_parent_offset] = parent_id;
     obj.references()[c_ref_anchor_first_child_offset] = first_child_id;
-    WRITE_PROTECT(obj.to_offset());
-    client_t::txn_log(obj.m_locator, c_invalid_gaia_offset, obj.to_offset());
+
+    obj.finalize_create();
     return obj;
 }
 
@@ -463,107 +147,6 @@ gaia_ptr_t gaia_ptr_t::create_no_txn(gaia_id_t id, gaia_type_t type, reference_o
     return obj;
 }
 
-void gaia_ptr_t::remove(gaia_ptr_t& object)
-{
-    if (!object)
-    {
-        return;
-    }
-
-    const gaia_id_t* references = object.references();
-
-    for (reference_offset_t i = 0; i < object.num_references(); i++)
-    {
-        if (references[i] != c_invalid_gaia_id)
-        {
-            auto other_obj = gaia_ptr_t::from_gaia_id(references[i]);
-
-            gaia_id_t referenced_obj_id = other_obj.id();
-
-            if (other_obj.type() == static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_ref_anchor))
-            {
-                if (other_obj.references()[c_ref_anchor_parent_offset] == object.id())
-                {
-                    // This is a parent node in the relationship because its
-                    // anchor's parent reference is pointing to itself.
-                    if (other_obj.references()[c_ref_anchor_first_child_offset] == c_invalid_gaia_id)
-                    {
-                        // There is no child. We can delete the parent.
-                        continue;
-                    }
-                    referenced_obj_id = other_obj.references()[c_ref_anchor_first_child_offset];
-                }
-                else
-                {
-                    // This is a child node in the relationship because its
-                    // anchor node's parent reference is not pointing to itself.
-                    if (other_obj.references()[c_ref_anchor_parent_offset] == c_invalid_gaia_id)
-                    {
-                        // There is no parent. We can delete the child.
-                        //
-                        // Skip checking the next two reference slots.
-                        i += 2;
-                        continue;
-                    }
-                    referenced_obj_id = other_obj.references()[c_ref_anchor_parent_offset];
-                }
-            }
-
-            throw object_still_referenced_internal(object.id(), object.type(), referenced_obj_id, gaia_ptr_t::from_gaia_id(referenced_obj_id).type());
-        }
-    }
-
-    // Make necessary changes to the anchor chain before deleting the node.
-    for (reference_offset_t i = 0; i < object.num_references(); i++)
-    {
-        if (references[i] != c_invalid_gaia_id)
-        {
-            auto anchor = gaia_ptr_t::from_gaia_id(references[i]);
-            if (anchor.type() != static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_ref_anchor))
-            {
-                continue;
-            }
-
-            if (anchor.references()[c_ref_anchor_parent_offset] == object.id())
-            {
-                // The anchor node connected to the parent can be safely deleted.
-                anchor.reset();
-                continue;
-            }
-
-            reference_offset_t next_offset = i + 1;
-
-            if (anchor.references()[c_ref_anchor_first_child_offset] == object.id()
-                && object.references()[next_offset] == c_invalid_gaia_id)
-            {
-                // This is the only child in the anchor chain. We can delete the
-                // anchor node safely.
-                anchor.reset();
-                continue;
-            }
-
-            reference_offset_t prev_offset = next_offset + 1;
-
-            // Disconnect the node from its existing anchor chain.
-            if (object.references()[next_offset] != c_invalid_gaia_id)
-            {
-                auto next = gaia_ptr_t::from_gaia_id(object.references()[next_offset]);
-                next.set_reference(prev_offset, object.references()[prev_offset]);
-            }
-            if (object.references()[prev_offset] != c_invalid_gaia_id)
-            {
-                auto prev = gaia_ptr_t::from_gaia_id(object.references()[prev_offset]);
-                prev.set_reference(next_offset, object.references()[next_offset]);
-            }
-            if (anchor.references()[c_ref_anchor_first_child_offset] == object.id())
-            {
-                anchor.set_reference(c_ref_anchor_first_child_offset, object.references()[next_offset]);
-            }
-        }
-    }
-    object.reset();
-}
-
 void gaia_ptr_t::clone_no_txn()
 {
     db_object_t* old_this = to_ptr();
@@ -574,299 +157,9 @@ void gaia_ptr_t::clone_no_txn()
     memcpy(new_this, old_this, total_object_size);
 }
 
-void gaia_ptr_t::auto_connect(
-    gaia_id_t id,
-    gaia_type_t type,
-    gaia_id_t* references,
-    const uint8_t* payload)
-{
-    // Skip system tables.
-    //
-    // This implementation relies on the following catalog tables in place to work:
-    //   - gaia_table
-    //   - gaia_field
-    //   - gaia_relationship
-    //
-    // These tables will not be available during bootstrap when they are being
-    // populated themselves. We can skip all system tables safely as no system
-    // tables use the auto connection feature.
-    if (type >= c_system_table_reserved_range_start)
-    {
-        return;
-    }
-    field_position_list_t candidate_fields;
-    gaia_id_t table_id = type_id_mapping_t::instance().get_record_id(type);
-    for (auto field_view : catalog_core_t::list_fields(table_id))
-    {
-        candidate_fields.push_back(field_view.position());
-    }
-    auto_connect(id, type, table_id, references, payload, candidate_fields);
-}
-
-void gaia_ptr_t::parent_side_auto_connect(
-    gaia_id_t id,
-    gaia_type_t type,
-    gaia_id_t type_id,
-    gaia_id_t* references,
-    const uint8_t* payload,
-    field_position_t field_position)
-{
-    // Check if the given field is used in establishing a relationship where the
-    // field's table is on the parent side.
-    for (auto relationship_view : catalog_core_t::list_relationship_from(type_id))
-    {
-        if (relationship_view.parent_field_positions()->size() != 1
-            || relationship_view.parent_field_positions()->Get(0) != field_position)
-        {
-            continue;
-        }
-
-        // At this point, we have found the value-linked relationship the
-        // node participated in on the parent side.
-        //
-        // If the node already has some child nodes, disconnect all existing
-        // children by detaching the children's reference anchor.
-        if (references[relationship_view.first_child_offset()] != c_invalid_gaia_id)
-        {
-            auto parent_anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.first_child_offset()]);
-            if (parent_anchor.references()[c_ref_anchor_first_child_offset] != c_invalid_gaia_id)
-            {
-                parent_anchor.set_reference(c_ref_anchor_parent_offset, c_invalid_gaia_id);
-                references[relationship_view.first_child_offset()] = c_invalid_gaia_id;
-            }
-        }
-
-        // Check if the field value exists in any child node using the index on the child table.
-        gaia_id_t child_id = find_using_index(
-            payload,
-            field_position,
-            type,
-            type_id,
-            relationship_view.child_table_id(),
-            relationship_view.child_field_positions()->Get(0));
-
-        if (child_id != c_invalid_gaia_id)
-        {
-            // We have found the child with the field value. Link the child
-            // node(s) to the parent node by connecting the child's
-            // reference anchor to the parent.
-            auto child = gaia_ptr_t::from_gaia_id(child_id);
-            gaia_id_t anchor_id = child.references()[relationship_view.parent_offset()];
-            references[relationship_view.first_child_offset()] = anchor_id;
-
-            auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
-            anchor.set_reference(c_ref_anchor_parent_offset, id);
-        }
-
-        // Create an anchor node for the parent node if it does not already
-        // exist for the field's value.
-        if (references[relationship_view.first_child_offset()] == c_invalid_gaia_id)
-        {
-            gaia_ptr_t anchor = gaia_ptr_t::create_ref_anchor(id, c_invalid_gaia_id);
-            references[relationship_view.first_child_offset()] = anchor.id();
-        }
-    }
-}
-
-void gaia_ptr_t::child_side_auto_connect(
-    gaia_id_t id,
-    gaia_type_t type,
-    gaia_id_t type_id,
-    gaia_id_t* references,
-    const uint8_t* payload,
-    field_position_t field_position)
-{
-
-    // Check if the given field is used in establishing a relationship where the
-    // field's table is on the child side.
-    for (auto relationship_view : catalog_core_t::list_relationship_to(type_id))
-    {
-        if (relationship_view.child_field_positions()->size() != 1
-            || relationship_view.child_field_positions()->Get(0) != field_position)
-        {
-            continue;
-        }
-
-        // At this point, we have found the value-linked relationship the
-        // node participated in on the child side.
-        //
-        // Disconnect the node from its existing reference chain.
-        if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
-        {
-            // Update the next child if exists.
-            auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
-            next_child.set_reference(relationship_view.prev_child_offset(), references[relationship_view.prev_child_offset()]);
-        }
-        if (references[relationship_view.prev_child_offset()] != c_invalid_gaia_id)
-        {
-            // Update the previous child if exists.
-            auto prev_child = gaia_ptr_t::from_gaia_id(references[relationship_view.prev_child_offset()]);
-            prev_child.set_reference(relationship_view.next_child_offset(), references[relationship_view.next_child_offset()]);
-        }
-        else if (references[relationship_view.parent_offset()] != c_invalid_gaia_id)
-        {
-            // This is the first child because previous node does not exist.
-            bool anchor_deleted = false;
-            if (references[relationship_view.next_child_offset()] == c_invalid_gaia_id)
-            {
-                // This is the only child because next node does not exist.
-                auto anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.parent_offset()]);
-                if (anchor.references()[c_ref_anchor_parent_offset] == c_invalid_gaia_id)
-                {
-                    // Delete the anchor node if it is not connected to some parent node.
-                    anchor.reset();
-                    anchor_deleted = true;
-                }
-            }
-
-            // Disconnect the (first) child from the anchor if it is not deleted in previous step.
-            if (!anchor_deleted)
-            {
-                auto anchor = gaia_ptr_t::from_gaia_id(references[relationship_view.parent_offset()]);
-                anchor.set_reference(c_ref_anchor_first_child_offset, references[relationship_view.next_child_offset()]);
-            }
-        }
-        references[relationship_view.prev_child_offset()] = c_invalid_gaia_id;
-        references[relationship_view.next_child_offset()] = c_invalid_gaia_id;
-        references[relationship_view.parent_offset()] = c_invalid_gaia_id;
-
-        // Check if the field value exists in any parent node using the index on the parent table.
-        gaia_id_t parent_id = find_using_index(
-            payload,
-            field_position,
-            type,
-            type_id,
-            relationship_view.parent_table_id(),
-            relationship_view.parent_field_positions()->Get(0));
-
-        if (parent_id != c_invalid_gaia_id)
-        {
-            // We have found the parent node with the field value. Link the
-            // child node to the parent node by connecting the child to the
-            // parent's child anchor node.
-            auto parent = gaia_ptr_t::from_gaia_id(parent_id);
-            gaia_id_t anchor_id = parent.references()[relationship_view.first_child_offset()];
-            auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
-            references[relationship_view.parent_offset()] = anchor_id;
-            references[relationship_view.next_child_offset()] = anchor.references()[c_ref_anchor_first_child_offset];
-
-            anchor.set_reference(c_ref_anchor_first_child_offset, id);
-
-            if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
-            {
-                auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
-                next_child.set_reference(relationship_view.prev_child_offset(), id);
-            }
-        }
-        else
-        {
-            // Check if the field value exists in any child node using the index on the child table (this table).
-            gaia_id_t child_id = find_using_index(
-                payload,
-                field_position,
-                type,
-                type_id,
-                relationship_view.child_table_id(),
-                relationship_view.child_field_positions()->Get(0));
-            if (child_id != c_invalid_gaia_id)
-            {
-                // We have found some child node with the same linked field
-                // value. Insert the node to the existing anchor chain.
-                auto child = gaia_ptr_t::from_gaia_id(child_id);
-                gaia_id_t anchor_id = child.references()[relationship_view.parent_offset()];
-                auto anchor = gaia_ptr_t::from_gaia_id(anchor_id);
-                references[relationship_view.parent_offset()] = anchor_id;
-                references[relationship_view.next_child_offset()] = anchor.references()[c_ref_anchor_first_child_offset];
-
-                anchor.set_reference(c_ref_anchor_first_child_offset, id);
-
-                if (references[relationship_view.next_child_offset()] != c_invalid_gaia_id)
-                {
-                    auto next_child = gaia_ptr_t::from_gaia_id(references[relationship_view.next_child_offset()]);
-                    next_child.set_reference(relationship_view.prev_child_offset(), id);
-                }
-            }
-            else if (references[relationship_view.parent_offset()] == c_invalid_gaia_id)
-            {
-                // This child has no matching parent or other child of the
-                // same field value. Create an anchor node for the child to
-                // form an anchor chain of itself.
-                gaia_ptr_t anchor = gaia_ptr_t::create_ref_anchor(c_invalid_gaia_id, id);
-                references[relationship_view.parent_offset()] = anchor.id();
-            }
-        }
-    }
-}
-
-void gaia_ptr_t::auto_connect(
-    gaia_id_t id,
-    gaia_type_t type,
-    gaia_id_t type_id,
-    gaia_id_t* references,
-    const uint8_t* payload,
-    const field_position_list_t& candidate_fields)
-{
-    // Skip system tables. See notes in the other method of the same name.
-    if (type >= c_system_table_reserved_range_start)
-    {
-        return;
-    }
-
-    for (auto field_position : candidate_fields)
-    {
-        parent_side_auto_connect(id, type, type_id, references, payload, field_position);
-        child_side_auto_connect(id, type, type_id, references, payload, field_position);
-    }
-}
-
-gaia_ptr_t gaia_ptr_t::set_reference(reference_offset_t offset, gaia_id_t id)
-{
-    gaia_offset_t old_offset = to_offset();
-    clone_no_txn();
-    references()[offset] = id;
-    WRITE_PROTECT(to_offset());
-    client_t::txn_log(m_locator, old_offset, to_offset());
-    return *this;
-}
-
-gaia_id_t gaia_ptr_t::find_using_index(
-    const uint8_t* payload,
-    field_position_t field_position,
-    gaia_type_t type,
-    gaia_id_t type_id,
-    gaia_id_t indexed_table_id,
-    field_position_t indexed_field_position)
-{
-    gaia_type_t indexed_table_type = catalog_core_t::get_table(indexed_table_id).table_type();
-    gaia_id_t indexed_table_type_id = type_id_mapping_t::instance().get_record_id(indexed_table_type);
-
-    gaia_id_t index_id = catalog_core_t::find_index(indexed_table_type_id, indexed_field_position);
-    // Callers need to ensure the table has an index on the field to search.
-    ASSERT_PRECONDITION(index_id != c_invalid_gaia_id, "Cannot find value index for the table.");
-
-    auto schema = catalog_core_t::get_table(type_id).binary_schema();
-    auto field_value = payload_types::get_field_value(
-        type,
-        payload,
-        schema->data(),
-        schema->size(),
-        field_position);
-
-    index::index_key_t key;
-    key.insert(field_value);
-    for (const auto& scan : query_processor::scan::index_scan_t(
-             index_id,
-             std::make_shared<query_processor::scan::index_point_read_predicate_t>(key)))
-    {
-        return scan.id();
-    }
-    return c_invalid_gaia_id;
-}
-
-gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
+void gaia_ptr_t::update_payload_no_txn(size_t data_size, const void* data)
 {
     db_object_t* old_this = to_ptr();
-    gaia_offset_t old_offset = to_offset();
 
     size_t references_size = old_this->num_references * sizeof(gaia_id_t);
     size_t total_payload_size = data_size + references_size;
@@ -888,28 +181,33 @@ gaia_ptr_t& gaia_ptr_t::update_payload(size_t data_size, const void* data)
     }
     new_this->num_references = old_this->num_references;
     memcpy(new_this->payload + references_size, data, data_size);
+}
 
-    auto new_data = reinterpret_cast<const uint8_t*>(data);
-    auto old_data = reinterpret_cast<const uint8_t*>(old_this->payload);
-    const uint8_t* old_data_payload = old_data + references_size;
-    field_position_list_t changed_fields = compute_payload_diff(new_this->type, old_data_payload, new_data);
+gaia_ptr_t gaia_ptr_t::set_reference(reference_offset_t offset, gaia_id_t id)
+{
+    gaia_offset_t old_offset = to_offset();
+    clone_no_txn();
+    references()[offset] = id;
+    finalize_update(old_offset);
+    return *this;
+}
 
-    auto_connect(
-        id(),
-        type(),
-        type_id_mapping_t::instance().get_record_id(type()),
-        references(),
-        new_data,
-        changed_fields);
-
-    WRITE_PROTECT(to_offset());
-    client_t::txn_log(m_locator, old_offset, to_offset());
-
-    if (client_t::is_valid_event(new_this->type))
+gaia_ptr_t gaia_ptr_t::set_references(
+    reference_offset_t offset1, gaia_id_t id1,
+    reference_offset_t offset2, gaia_id_t id2,
+    reference_offset_t offset3, gaia_id_t id3)
+{
+    ASSERT_PRECONDITION(offset1 != c_invalid_reference_offset, "Unexpected invalid reference offset.");
+    ASSERT_PRECONDITION(offset2 != c_invalid_reference_offset, "Unexpected invalid reference offset.");
+    gaia_offset_t old_offset = to_offset();
+    clone_no_txn();
+    references()[offset1] = id1;
+    references()[offset2] = id2;
+    if (offset3 != c_invalid_reference_offset)
     {
-        client_t::s_events.emplace_back(event_type_t::row_update, new_this->type, new_this->id, changed_fields, get_current_txn_id());
+        references()[offset3] = id3;
     }
-
+    finalize_update(old_offset);
     return *this;
 }
 

--- a/production/db/core/src/index_builder.cpp
+++ b/production/db/core/src/index_builder.cpp
@@ -408,7 +408,7 @@ void index_builder_t::update_indexes_from_txn_log(
         }
 
         // Maintenance on the in-memory index data structures.
-        if (obj->type == static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_index))
+        if (obj->type == static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_index))
         {
             auto index_view = index_view_t(obj);
 

--- a/production/db/core/src/persistent_store_manager.cpp
+++ b/production/db/core/src/persistent_store_manager.cpp
@@ -178,7 +178,7 @@ void persistent_store_manager::recover()
     for (it->SeekToFirst(); it->Valid(); it->Next())
     {
         db_object_t* recovered_object = decode_object(it->key(), it->value());
-        if (recovered_object->type > max_type_id && recovered_object->type < c_system_table_reserved_range_start)
+        if (recovered_object->type > max_type_id && !is_catalog_core_object(recovered_object->type))
         {
             max_type_id = recovered_object->type;
         }

--- a/production/db/core/src/rdb_object_converter.cpp
+++ b/production/db/core/src/rdb_object_converter.cpp
@@ -81,7 +81,6 @@ db_object_t* gaia::db::persistence::decode_object(
 
     auto data_size = size - num_references * sizeof(gaia_id_t);
     auto payload = value_reader.read(data_size);
-    ASSERT_POSTCONDITION(payload, "Read object shouldn't be null");
 
     // Create object.
     db_object_t* db_object = create_object(id, type, num_references, refs, data_size, payload);

--- a/production/db/core/tests/db_test_util.hpp
+++ b/production/db/core/tests/db_test_util.hpp
@@ -16,8 +16,9 @@ namespace gaia::db::test
 // Doctor --> Patient
 // This relationship is used in most relationship/references tests.
 constexpr common::reference_offset_t c_first_patient_offset = 0;
-constexpr common::reference_offset_t c_next_patient_offset = 0;
-constexpr common::reference_offset_t c_parent_doctor_offset = 1;
+constexpr common::reference_offset_t c_parent_doctor_offset = 0;
+constexpr common::reference_offset_t c_next_patient_offset = 1;
+constexpr common::reference_offset_t c_prev_patient_offset = 2;
 constexpr common::reference_offset_t c_non_existent_offset = 1024;
 
 /**
@@ -66,6 +67,12 @@ public:
         return *this;
     }
 
+    relationship_builder_t prev_child_offset(common::reference_offset_t prev_child_offset)
+    {
+        this->m_prev_child_offset = prev_child_offset;
+        return *this;
+    }
+
     relationship_builder_t parent_offset(common::reference_offset_t parent_offset)
     {
         this->m_parent_offset = parent_offset;
@@ -96,6 +103,7 @@ public:
             .child_type = this->m_child_type,
             .first_child_offset = this->m_first_child_offset,
             .next_child_offset = this->m_next_child_offset,
+            .prev_child_offset = this->m_prev_child_offset,
             .parent_offset = this->m_parent_offset,
             .cardinality = this->m_cardinality,
             .parent_required = this->m_parent_required});
@@ -119,12 +127,13 @@ private:
     bool m_parent_required = false;
     common::reference_offset_t m_first_child_offset = c_first_patient_offset;
     common::reference_offset_t m_next_child_offset = c_next_patient_offset;
+    common::reference_offset_t m_prev_child_offset = c_prev_patient_offset;
     common::reference_offset_t m_parent_offset = c_parent_doctor_offset;
 };
 
 gaia_ptr_t create_object(common::gaia_type_t type, std::string payload)
 {
-    return gaia_ptr_t::create(type, payload.size(), payload.data());
+    return gaia_ptr::create(type, payload.size(), payload.data());
 }
 
 void clean_type_registry()

--- a/production/db/core/tests/test_catalog_core.cpp
+++ b/production/db/core/tests/test_catalog_core.cpp
@@ -38,11 +38,8 @@ TEST_F(catalog_core_test, list_tables)
     std::set<gaia_type_t> system_table_ids{
         static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_field),
         static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_table),
-        static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_rule),
-        static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_ruleset),
         static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_database),
         static_cast<gaia_type_t::value_type>(system_table_type_t::catalog_gaia_relationship),
-        static_cast<gaia_type_t::value_type>(system_table_type_t::event_log),
     };
 
     gaia::catalog::initialize_catalog();

--- a/production/db/core/tests/test_db_client.cpp
+++ b/production/db/core/tests/test_db_client.cpp
@@ -99,13 +99,13 @@ private:
 
             std::cerr << std::endl;
             std::cerr << "*** create test nodes" << std::endl;
-            gaia_ptr_t node1 = gaia_ptr_t::create(node1_id, type1, 0, nullptr);
+            gaia_ptr_t node1 = gaia_ptr_t::create(node1_id, type1, 0, 0, nullptr);
             print_node(node1);
-            gaia_ptr_t node2 = gaia_ptr_t::create(node2_id, type1, 0, nullptr);
+            gaia_ptr_t node2 = gaia_ptr_t::create(node2_id, type1, 0, 0, nullptr);
             print_node(node2);
-            gaia_ptr_t node3 = gaia_ptr_t::create(node3_id, type2, 0, nullptr);
+            gaia_ptr_t node3 = gaia_ptr_t::create(node3_id, type2, 0, 0, nullptr);
             print_node(node3);
-            gaia_ptr_t node4 = gaia_ptr_t::create(node4_id, type2, 0, nullptr);
+            gaia_ptr_t node4 = gaia_ptr_t::create(node4_id, type2, 0, 0, nullptr);
             print_node(node4);
         }
         commit_transaction();
@@ -137,16 +137,6 @@ TEST_F(db_client_test, early_session_termination)
     rollback_transaction();
 }
 
-TEST_F(db_client_test, creation_fail_for_invalid_type)
-{
-    begin_transaction();
-    {
-        const gaia_type_t c_invalid_type = 8888;
-        EXPECT_THROW(gaia_ptr_t::create(c_invalid_type, 0, 0), invalid_object_type);
-    }
-    commit_transaction();
-}
-
 TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
 {
     begin_transaction();
@@ -154,8 +144,6 @@ TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
     commit_transaction();
 
     // Create with existent type fail
-    EXPECT_THROW(gaia_ptr_t::create(type1, 0, ""), no_open_transaction);
-    EXPECT_THROW(gaia_ptr_t::create(99999, type1, 0, ""), no_open_transaction);
     EXPECT_THROW(gaia_ptr_t::create(99999, type1, 5, 0, ""), no_open_transaction);
     EXPECT_THROW(gaia_ptr_t::from_gaia_id(node1_id), no_open_transaction);
     EXPECT_THROW(node1.id(), no_open_transaction);
@@ -164,22 +152,6 @@ TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
     EXPECT_THROW(node1.references(), no_open_transaction);
     EXPECT_THROW(node1.find_next(), no_open_transaction);
     EXPECT_THROW(node1.update_payload(0, ""), no_open_transaction);
-    EXPECT_THROW(node1.add_child_reference(1, 2), no_open_transaction);
-    EXPECT_THROW(node1.add_parent_reference(1, 2), no_open_transaction);
-    EXPECT_THROW(node1.remove_child_reference(1, 2), no_open_transaction);
-    EXPECT_THROW(node1.remove_parent_reference(2), no_open_transaction);
-    EXPECT_THROW(node1.update_parent_reference(1, 2), no_open_transaction);
-    EXPECT_THROW(gaia_ptr_t::remove(node1), no_open_transaction);
-
-    // Test with non existent type
-    // TODO there is a bug in GNU libstdc that will the type_id_mapping hang if the initialization
-    //  throws an exception and call_once is called again. Disabling the tests for now.
-    //  see type_id_mapping_t for more details.
-    //    gaia_type_t type3 = 3;
-    //    EXPECT_THROW(gaia_ptr_t::create(type3, 0, 0), transaction_not_open);
-    //    EXPECT_THROW(gaia_ptr_t::create(99999, type3, 0, 0), transaction_not_open);
-    //    EXPECT_THROW(gaia_ptr_t::create(99999, type3, 5, 0, 0), transaction_not_open);
-    //    EXPECT_THROW(gaia_ptr_t::from_gaia_id(99999), transaction_not_open);
 }
 
 TEST_F(db_client_test, read_data)
@@ -322,41 +294,41 @@ void iterate_test_create_nodes()
 
     // Create objects for iterator test.
     // "One node" test.
-    gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+    gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
 
     test_type_index++;
     // "Exact buffer size" test.
     for (size_t i = 0; i < c_buffer_size_exact; i++)
     {
-        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
     }
 
     test_type_index++;
     // "Exact multiple of buffer size" test
     for (size_t i = 0; i < c_buffer_size_exact_multiple; i++)
     {
-        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
     }
 
     test_type_index++;
     // "Inexact multiple of buffer size" test
     for (size_t i = 0; i < c_buffer_size_inexact_multiple; i++)
     {
-        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
     }
 
     test_type_index++;
     // "One less than buffer size" test
     for (size_t i = 0; i < c_buffer_size_minus_one; i++)
     {
-        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
     }
 
     test_type_index++;
     // "One more than buffer size" test
     for (size_t i = 0; i < c_buffer_size_plus_one; i++)
     {
-        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, nullptr);
+        gaia_ptr_t::create(gaia_ptr_t::generate_id(), g_test_types[test_type_index], 0, 0, nullptr);
     }
     commit_transaction();
 }
@@ -489,7 +461,7 @@ TEST_F(db_client_test, iterate_type_delete)
         EXPECT_EQ(node_iter.id(), node1_id);
         std::cerr << std::endl;
         std::cerr << "*** Preparing to delete first node of type 1:" << std::endl;
-        gaia_ptr_t::remove(node_iter);
+        node_iter.reset();
         std::cerr << "*** Iterating over nodes of type 1 after delete:" << std::endl;
         node_iter = gaia_ptr_t::find_first(type1);
         print_node(node_iter);

--- a/production/db/core/tests/test_db_references.cpp
+++ b/production/db/core/tests/test_db_references.cpp
@@ -5,9 +5,12 @@
 
 #include <gtest/gtest.h>
 
+#include <gaia/common.hpp>
+
 #include "gaia_internal/catalog/catalog.hpp"
 #include "gaia_internal/catalog/gaia_catalog.h"
 #include "gaia_internal/db/db_test_base.hpp"
+#include "gaia_internal/db/gaia_ptr.hpp"
 #include "gaia_internal/db/type_metadata.hpp"
 
 #include "db_test_util.hpp"
@@ -51,8 +54,31 @@ protected:
     gaia_type_t address_type;
 };
 
-// The add_parent_reference API ends up calling the add_child API. What
-// is covered by the add_child API is not tested again in add_parent.
+TEST_F(gaia_db_references_test, no_txn_fail)
+{
+    begin_transaction();
+    gaia_ptr_t node = gaia_ptr::create(doctor_type, 0, nullptr);
+    commit_transaction();
+
+    EXPECT_THROW(gaia_ptr::create(doctor_type, 0, ""), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::create(99999, doctor_type, 0, ""), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::remove(node), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::update_payload(node.id(), 0, ""), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::insert_into_reference_container(node.id(), 1, 2), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::remove_from_reference_container(node.id(), 1, 2), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::remove_from_reference_container(node.id(), 1), no_open_transaction);
+    EXPECT_THROW(gaia_ptr::update_parent_reference(node.id(), 1, 2), no_open_transaction);
+}
+
+TEST_F(gaia_db_references_test, creation_fail_for_invalid_type)
+{
+    begin_transaction();
+    {
+        const gaia_type_t c_invalid_type = 8888;
+        EXPECT_THROW(gaia_ptr::create(c_invalid_type, 0, nullptr), invalid_object_type);
+    }
+    commit_transaction();
+}
 
 TEST_F(gaia_db_references_test, add_child_reference__one_to_one)
 {
@@ -66,11 +92,15 @@ TEST_F(gaia_db_references_test, add_child_reference__one_to_one)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], parent.id());
+    ASSERT_EQ(child.references()[c_parent_doctor_offset], anchor.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -88,14 +118,19 @@ TEST_F(gaia_db_references_test, add_child_reference__one_to_many)
     gaia_ptr_t child = create_object(patient_type, "John Doe");
     gaia_ptr_t child2 = create_object(patient_type, "Jane Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
-    parent.add_child_reference(child2.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child2.id(), c_first_patient_offset);
 
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child2.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child2.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], parent.id());
+    ASSERT_EQ(child.references()[c_parent_doctor_offset], anchor.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
-    ASSERT_EQ(child2.references()[c_parent_doctor_offset], parent.id());
+    ASSERT_EQ(child.references()[c_prev_patient_offset], child2.id());
+    ASSERT_EQ(child2.references()[c_parent_doctor_offset], anchor.id());
     ASSERT_EQ(child2.references()[c_next_patient_offset], child.id());
+    ASSERT_EQ(child2.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -113,10 +148,10 @@ TEST_F(gaia_db_references_test, add_child_reference__single_cardinality_violatio
     gaia_ptr_t child = create_object(patient_type, "John Doe");
     gaia_ptr_t child2 = create_object(patient_type, "Jane Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     EXPECT_THROW(
-        parent.add_child_reference(child2.id(), c_first_patient_offset),
+        gaia_ptr::insert_into_reference_container(parent, child2.id(), c_first_patient_offset),
         single_cardinality_violation);
 
     commit_transaction();
@@ -135,7 +170,7 @@ TEST_F(gaia_db_references_test, add_child_reference__invalid_relation_offset)
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
     EXPECT_THROW(
-        parent.add_child_reference(child.id(), c_non_existent_offset),
+        gaia_ptr::insert_into_reference_container(parent, child.id(), c_non_existent_offset),
         invalid_reference_offset);
 
     commit_transaction();
@@ -168,7 +203,7 @@ TEST_F(gaia_db_references_test, add_child_reference__invalid_relation_type_paren
     gaia_ptr_t patient = create_object(patient_type, "Jane Doe");
 
     EXPECT_THROW(
-        patient.add_child_reference(doctor.id(), c_first_address_offset),
+        gaia_ptr::insert_into_reference_container(patient, doctor.id(), c_first_address_offset),
         invalid_relationship_type);
 
     commit_transaction();
@@ -183,11 +218,11 @@ TEST_F(gaia_db_references_test, add_child_reference__invalid_relation_type_child
         .child(patient_type)
         .create_relationship();
 
-    gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
+    gaia_ptr_t doctor = create_object(doctor_type, "Dr. House");
     gaia_ptr_t clinic = create_object(clinic_type, "Buena Vista Urgent Care");
 
     EXPECT_THROW(
-        parent.add_child_reference(clinic.id(), c_first_patient_offset),
+        gaia_ptr::insert_into_reference_container(doctor, clinic.id(), c_first_patient_offset),
         invalid_relationship_type);
 
     commit_transaction();
@@ -205,60 +240,20 @@ TEST_F(gaia_db_references_test, add_child_reference__child_already_in_relation)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     // doesn't fail if the same child is added to the same parent
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     gaia_ptr_t parent2 = create_object(doctor_type, "JD");
     gaia_ptr_t child2 = create_object(patient_type, "Jane Doe");
 
-    parent2.add_child_reference(child2.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent2, child2.id(), c_first_patient_offset);
 
     // fails if a child that is already part of a relationship is added to a different parent
     EXPECT_THROW(
-        parent.add_child_reference(child2.id(), c_first_patient_offset),
+        gaia_ptr::insert_into_reference_container(parent, child2.id(), c_first_patient_offset),
         child_already_referenced);
-
-    commit_transaction();
-}
-
-TEST_F(gaia_db_references_test, add_parent_reference__one_to_many)
-{
-    begin_transaction();
-
-    relationship_builder_t::one_to_many()
-        .parent(doctor_type)
-        .child(patient_type)
-        .create_relationship();
-
-    gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
-    gaia_ptr_t child = create_object(patient_type, "John Doe");
-
-    child.add_parent_reference(parent.id(), c_parent_doctor_offset);
-
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
-    ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
-
-    commit_transaction();
-}
-
-TEST_F(gaia_db_references_test, add_parent_reference__fail_on_wrong_offset)
-{
-    begin_transaction();
-
-    relationship_builder_t::one_to_many()
-        .parent(doctor_type)
-        .child(patient_type)
-        .create_relationship();
-
-    gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
-    gaia_ptr_t child = create_object(patient_type, "John Doe");
-
-    EXPECT_THROW(
-        child.add_parent_reference(parent.id(), c_next_patient_offset),
-        invalid_reference_offset);
 
     commit_transaction();
 }
@@ -275,25 +270,7 @@ TEST_F(gaia_db_references_test, add_child_reference__invalid_object_id)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
 
     EXPECT_THROW(
-        parent.add_child_reference(c_non_existent_id, c_next_patient_offset),
-        invalid_object_id);
-
-    commit_transaction();
-}
-
-TEST_F(gaia_db_references_test, add_parent_reference__invalid_object_id)
-{
-    begin_transaction();
-
-    relationship_builder_t::one_to_many()
-        .parent(doctor_type)
-        .child(patient_type)
-        .create_relationship();
-
-    gaia_ptr_t child = create_object(patient_type, "John Doe");
-
-    EXPECT_THROW(
-        child.add_parent_reference(c_non_existent_id, c_parent_doctor_offset),
+        gaia_ptr::insert_into_reference_container(parent, c_non_existent_id, c_first_patient_offset),
         invalid_object_id);
 
     commit_transaction();
@@ -313,17 +290,18 @@ TEST_F(gaia_db_references_test, remove_child_reference__one_to_one)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     // WHEN
 
-    parent.remove_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::remove_from_reference_container(parent, child.id(), c_first_patient_offset);
 
     // THEN
 
     ASSERT_EQ(parent.references()[c_first_patient_offset], c_invalid_gaia_id);
     ASSERT_EQ(child.references()[c_parent_doctor_offset], c_invalid_gaia_id);
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -346,7 +324,7 @@ TEST_F(gaia_db_references_test, remove_child_reference__many_to_many_from_back)
     for (auto patient_name : {"Jhon Doe", "Jane Doe", "Foo", "Bar"})
     {
         gaia_ptr_t child = create_object(patient_type, patient_name);
-        parent.add_child_reference(child.id(), c_first_patient_offset);
+        gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
         children.push_back(child);
     }
 
@@ -356,15 +334,17 @@ TEST_F(gaia_db_references_test, remove_child_reference__many_to_many_from_back)
         auto child = children[i];
 
         // WHEN
-        parent.remove_child_reference(child.id(), c_first_patient_offset);
+        gaia_ptr::remove_from_reference_container(parent, child.id(), c_first_patient_offset);
 
         // THEN
         if (i > 0)
         {
-            ASSERT_EQ(parent.references()[c_first_patient_offset], children[i - 1].id());
+            gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+            ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], children[i - 1].id());
         }
         ASSERT_EQ(child.references()[c_parent_doctor_offset], c_invalid_gaia_id);
         ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+        ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
     }
 
     // when the last child is removed the parent needs to be updated as well.
@@ -391,7 +371,7 @@ TEST_F(gaia_db_references_test, remove_child_reference__many_to_many_from_head)
     for (auto patient_name : {"Jhon Doe", "Jane Doe", "Foo", "Bar"})
     {
         gaia_ptr_t child = create_object(patient_type, patient_name);
-        parent.add_child_reference(child.id(), c_first_patient_offset);
+        gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
         children.push_back(child);
     }
 
@@ -399,12 +379,13 @@ TEST_F(gaia_db_references_test, remove_child_reference__many_to_many_from_head)
     for (const auto& child : children)
     {
         // WHEN
-        parent.remove_child_reference(child.id(), c_first_patient_offset);
+        gaia_ptr::remove_from_reference_container(parent, child.id(), c_first_patient_offset);
 
         // THEN
         if (child.id() != children.back().id())
         {
-            ASSERT_EQ(parent.references()[c_first_patient_offset], children.back().id());
+            gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+            ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], children.back().id());
         }
         ASSERT_EQ(child.references()[c_parent_doctor_offset], c_invalid_gaia_id);
         ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
@@ -427,15 +408,18 @@ TEST_F(gaia_db_references_test, remove_child_reference__different_child)
 
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     gaia_ptr_t child2 = create_object(patient_type, "Jane Doe");
 
-    ASSERT_FALSE(parent.remove_child_reference(child2.id(), c_next_patient_offset));
+    ASSERT_FALSE(gaia_ptr::remove_from_reference_container(parent, child2.id(), c_first_patient_offset));
 
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], parent.id());
+    ASSERT_EQ(child.references()[c_parent_doctor_offset], anchor.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -451,18 +435,21 @@ TEST_F(gaia_db_references_test, remove_child_reference__different_parent)
 
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     gaia_ptr_t parent2 = create_object(doctor_type, "Jane Doe");
 
     // nothing should happen
     ASSERT_THROW(
-        parent2.remove_child_reference(child.id(), c_next_patient_offset),
+        gaia_ptr::remove_from_reference_container(parent2, child.id(), c_first_patient_offset),
         invalid_child_reference);
 
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], parent.id());
+    ASSERT_EQ(child.references()[c_parent_doctor_offset], anchor.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -478,10 +465,10 @@ TEST_F(gaia_db_references_test, remove_child_reference__invalid_relation_offset)
 
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::remove_from_reference_container(parent, child.id(), c_first_patient_offset);
 
     EXPECT_THROW(
-        parent.remove_child_reference(child.id(), c_non_existent_offset),
+        gaia_ptr::remove_from_reference_container(parent, child.id(), c_non_existent_offset),
         invalid_reference_offset);
 
     commit_transaction();
@@ -499,7 +486,7 @@ TEST_F(gaia_db_references_test, remove_child_reference__invalid_object_id)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
 
     EXPECT_THROW(
-        parent.remove_child_reference(c_non_existent_id, c_next_patient_offset),
+        gaia_ptr::remove_from_reference_container(parent, c_non_existent_id, c_first_patient_offset),
         invalid_object_id);
 
     commit_transaction();
@@ -532,7 +519,7 @@ TEST_F(gaia_db_references_test, remove_child_reference__invalid_relation_type_pa
     gaia_ptr_t patient = create_object(patient_type, "Jane Doe");
 
     EXPECT_THROW(
-        patient.remove_child_reference(doctor.id(), c_first_address_offset),
+        gaia_ptr::remove_from_reference_container(patient, doctor.id(), c_first_address_offset),
         invalid_relationship_type);
 
     commit_transaction();
@@ -547,11 +534,11 @@ TEST_F(gaia_db_references_test, remove_child_reference__invalid_relation_type_ch
         .child(patient_type)
         .create_relationship();
 
-    gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
+    gaia_ptr_t doctor = create_object(doctor_type, "Dr. House");
     gaia_ptr_t clinic = create_object(clinic_type, "Buena Vista Urgent Care");
 
     EXPECT_THROW(
-        parent.remove_child_reference(clinic.id(), c_first_patient_offset),
+        gaia_ptr::remove_from_reference_container(doctor, clinic.id(), c_first_patient_offset),
         invalid_relationship_type);
 
     commit_transaction();
@@ -571,17 +558,18 @@ TEST_F(gaia_db_references_test, remove_parent_reference__one_to_one)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     // WHEN
 
-    child.remove_parent_reference(c_parent_doctor_offset);
+    gaia_ptr::remove_from_reference_container(child, c_parent_doctor_offset);
 
     // THEN
 
     ASSERT_EQ(parent.references()[c_first_patient_offset], c_invalid_gaia_id);
     ASSERT_EQ(child.references()[c_parent_doctor_offset], c_invalid_gaia_id);
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
 
     commit_transaction();
 }
@@ -598,15 +586,19 @@ TEST_F(gaia_db_references_test, update_parent_reference__parent_exists)
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     gaia_ptr_t new_parent = create_object(doctor_type, "Dr. Cox");
-    child.update_parent_reference(new_parent.id(), c_parent_doctor_offset);
+    gaia_ptr::update_parent_reference(child, new_parent.id(), c_parent_doctor_offset);
 
     ASSERT_EQ(parent.references()[c_first_patient_offset], c_invalid_gaia_id);
-    ASSERT_EQ(new_parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], new_parent.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(new_parent.references()[c_first_patient_offset], child.references()[c_parent_doctor_offset]);
+
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(new_parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], new_parent.id());
 
     commit_transaction();
 }
@@ -623,11 +615,15 @@ TEST_F(gaia_db_references_test, update_parent_reference__parent_not_exists)
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
     gaia_ptr_t new_parent = create_object(doctor_type, "JD");
-    child.update_parent_reference(new_parent.id(), c_parent_doctor_offset);
+    gaia_ptr::update_parent_reference(child, new_parent.id(), c_parent_doctor_offset);
 
-    ASSERT_EQ(new_parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], new_parent.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(new_parent.references()[c_first_patient_offset], child.references()[c_parent_doctor_offset]);
+
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(new_parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], new_parent.id());
 
     commit_transaction();
 }
@@ -644,21 +640,30 @@ TEST_F(gaia_db_references_test, update_parent_reference__single_cardinality_viol
     gaia_ptr_t parent = create_object(doctor_type, "Dr. House");
     gaia_ptr_t child = create_object(patient_type, "John Doe");
 
-    parent.add_child_reference(child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(parent, child.id(), c_first_patient_offset);
 
     gaia_ptr_t new_parent = create_object(doctor_type, "Dr. Cox");
     gaia_ptr_t new_child = create_object(patient_type, "Jane Doe");
 
-    new_parent.add_child_reference(new_child.id(), c_first_patient_offset);
+    gaia_ptr::insert_into_reference_container(new_parent, new_child.id(), c_first_patient_offset);
 
     EXPECT_THROW(
-        child.update_parent_reference(new_parent.id(), c_parent_doctor_offset),
+        gaia_ptr::update_parent_reference(child, new_parent.id(), c_parent_doctor_offset),
         single_cardinality_violation);
 
-    ASSERT_EQ(parent.references()[c_first_patient_offset], child.id());
-    ASSERT_EQ(new_parent.references()[c_first_patient_offset], new_child.id());
-    ASSERT_EQ(child.references()[c_parent_doctor_offset], parent.id());
     ASSERT_EQ(child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(child.references()[c_prev_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(new_child.references()[c_next_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(new_child.references()[c_prev_patient_offset], c_invalid_gaia_id);
+    ASSERT_EQ(parent.references()[c_first_patient_offset], child.references()[c_parent_doctor_offset]);
+    ASSERT_EQ(new_parent.references()[c_first_patient_offset], new_child.references()[c_parent_doctor_offset]);
 
+    gaia_ptr_t anchor = gaia_ptr_t::from_gaia_id(parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(anchor.references()[c_ref_anchor_first_child_offset], child.id());
+    ASSERT_EQ(anchor.references()[c_ref_anchor_parent_offset], parent.id());
+
+    gaia_ptr_t new_anchor = gaia_ptr_t::from_gaia_id(new_parent.references()[c_first_patient_offset]);
+    ASSERT_EQ(new_anchor.references()[c_ref_anchor_first_child_offset], new_child.id());
+    ASSERT_EQ(new_anchor.references()[c_ref_anchor_parent_offset], new_parent.id());
     commit_transaction();
 }

--- a/production/db/core/tests/test_relationships.cpp
+++ b/production/db/core/tests/test_relationships.cpp
@@ -77,8 +77,9 @@ TEST_F(gaia_relationships_test, metadata_init)
     // Expected pointers layout for employee type.
     const reference_offset_t c_employee_first_employee = 0;
     const reference_offset_t c_employee_parent_employee = 1;
-    const reference_offset_t c_employee_child_employee = 2;
-    const reference_offset_t c_employee_first_address = 3;
+    const reference_offset_t c_employee_next_child_employee = 2;
+    const reference_offset_t c_employee_prev_child_employee = 3;
+    const reference_offset_t c_employee_first_address = 4;
 
     gaia_id_t address_table_id = gaia::catalog::create_table(db, address_table, {});
 
@@ -106,13 +107,15 @@ TEST_F(gaia_relationships_test, metadata_init)
     ASSERT_TRUE(employee_employee_relationship1.has_value());
     ASSERT_EQ(c_employee_first_employee, employee_employee_relationship1->first_child_offset);
     ASSERT_EQ(c_employee_parent_employee, employee_employee_relationship1->parent_offset);
-    ASSERT_EQ(c_employee_child_employee, employee_employee_relationship1->next_child_offset);
+    ASSERT_EQ(c_employee_next_child_employee, employee_employee_relationship1->next_child_offset);
+    ASSERT_EQ(c_employee_prev_child_employee, employee_employee_relationship1->prev_child_offset);
 
     optional<relationship_t> employee_employee_relationship2 = employee_meta.find_parent_relationship(c_employee_first_employee);
     ASSERT_TRUE(employee_employee_relationship2.has_value());
     ASSERT_EQ(c_employee_first_employee, employee_employee_relationship2->first_child_offset);
     ASSERT_EQ(c_employee_parent_employee, employee_employee_relationship2->parent_offset);
-    ASSERT_EQ(c_employee_child_employee, employee_employee_relationship2->next_child_offset);
+    ASSERT_EQ(c_employee_next_child_employee, employee_employee_relationship2->next_child_offset);
+    ASSERT_EQ(c_employee_prev_child_employee, employee_employee_relationship2->prev_child_offset);
 
     // employee -[address]-> address
     optional<relationship_t> employee_address_relationship1 = employee_meta.find_parent_relationship(c_employee_first_address);
@@ -161,7 +164,7 @@ TEST_F(gaia_relationships_test, metadata_one_to_many)
     ASSERT_EQ(child.get_type(), patient_table_type);
 
     ASSERT_EQ(parent.num_references(), 1);
-    ASSERT_EQ(child.num_references(), 2);
+    ASSERT_EQ(child.num_references(), 3);
 
     auto parent_rel = parent.find_parent_relationship(c_first_patient_offset);
     ASSERT_TRUE(parent_rel.has_value());
@@ -197,7 +200,7 @@ TEST_F(gaia_relationships_test, metadata_one_to_one)
     ASSERT_EQ(child.get_type(), patient_table_type);
 
     ASSERT_EQ(parent.num_references(), 1);
-    ASSERT_EQ(child.num_references(), 2);
+    ASSERT_EQ(child.num_references(), 3);
 
     auto parent_rel = parent.find_parent_relationship(c_first_patient_offset);
     ASSERT_TRUE(parent_rel.has_value());

--- a/production/direct_access/src/dac_base.cpp
+++ b/production/direct_access/src/dac_base.cpp
@@ -5,6 +5,7 @@
 
 #include "gaia/direct_access/dac_base.hpp"
 
+#include "gaia/common.hpp"
 #include "gaia/db/db.hpp"
 
 #include "gaia_internal/common/generator_iterator.hpp"
@@ -119,7 +120,7 @@ gaia_id_t dac_db_t::get_reference(gaia_id_t id, common::reference_offset_t slot)
 gaia_id_t dac_db_t::insert(gaia_type_t container, size_t data_size, const void* data)
 {
     gaia_id_t id = gaia_ptr_t::generate_id();
-    gaia_ptr_t::create(id, container, data_size, data);
+    gaia_ptr::create(id, container, data_size, data);
     return id;
 }
 
@@ -131,39 +132,22 @@ void dac_db_t::delete_row(gaia_id_t id)
         throw invalid_object_id_internal(id);
     }
 
-    gaia_ptr_t::remove(gaia_ptr);
+    gaia_ptr::remove(gaia_ptr);
 }
 
 void dac_db_t::update(gaia_id_t id, size_t data_size, const void* data)
 {
-    gaia_ptr_t gaia_ptr = gaia_ptr_t::from_gaia_id(id);
-    if (!gaia_ptr)
-    {
-        throw invalid_object_id_internal(id);
-    }
-    gaia_ptr.update_payload(data_size, data);
+    gaia_ptr::update_payload(id, data_size, data);
 }
 
-bool dac_db_t::insert_child_reference(gaia_id_t parent_id, gaia_id_t child_id, common::reference_offset_t child_slot)
+bool dac_db_t::insert_into_anchor_chain(gaia_id_t parent_id, gaia_id_t id, common::reference_offset_t anchor_slot)
 {
-    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
-    if (!parent)
-    {
-        throw invalid_object_id_internal(parent_id);
-    }
-
-    return parent.add_child_reference(child_id, child_slot);
+    return gaia_ptr::insert_into_reference_container(parent_id, id, anchor_slot);
 }
 
-bool dac_db_t::remove_child_reference(gaia_id_t parent_id, gaia_id_t child_id, common::reference_offset_t child_slot)
+bool dac_db_t::remove_from_anchor_chain(gaia_id_t parent_id, gaia_id_t id, common::reference_offset_t anchor_slot)
 {
-    gaia_ptr_t parent = gaia_ptr_t::from_gaia_id(parent_id);
-    if (!parent)
-    {
-        throw invalid_object_id_internal(parent_id);
-    }
-
-    return parent.remove_child_reference(child_id, child_slot);
+    return gaia_ptr::remove_from_reference_container(parent_id, id, anchor_slot);
 }
 
 //
@@ -271,7 +255,7 @@ bool dac_base_reference_t::connect(gaia_id_t old_id, gaia::common::gaia_id_t new
         return false;
     }
     dac_base_reference_t::disconnect(old_id);
-    dac_db_t::insert_child_reference(m_parent_id, new_id, m_child_offset);
+    dac_db_t::insert_into_anchor_chain(m_parent_id, new_id, m_child_offset);
     return true;
 }
 
@@ -281,7 +265,7 @@ bool dac_base_reference_t::disconnect(gaia_id_t id)
     {
         return false;
     }
-    dac_db_t::remove_child_reference(m_parent_id, id, m_child_offset);
+    dac_db_t::remove_from_anchor_chain(m_parent_id, id, m_child_offset);
     return true;
 }
 

--- a/production/direct_access/tests/test_references.cpp
+++ b/production/direct_access/tests/test_references.cpp
@@ -613,7 +613,7 @@ void insert_object(bool committed, employee_t e1, address_t a1)
         else
         {
             // Nothing is committed yet.
-            EXPECT_THROW(e1.addresses().insert(a1), invalid_object_state);
+            EXPECT_THROW(e1.addresses().insert(a1), invalid_object_id);
         }
     }
     commit_transaction();

--- a/production/inc/gaia/direct_access/dac_base.hpp
+++ b/production/inc/gaia/direct_access/dac_base.hpp
@@ -55,10 +55,11 @@ protected:
     static common::gaia_id_t get_reference(common::gaia_id_t id, common::reference_offset_t slot);
     static common::gaia_id_t insert(common::gaia_type_t container, size_t data_size, const void* data);
     static void update(common::gaia_id_t id, size_t data_size, const void* data);
-    static bool insert_child_reference(common::gaia_id_t parent_id, common::gaia_id_t child_id, common::reference_offset_t child_slot);
-    static bool remove_child_reference(common::gaia_id_t parent_id, common::gaia_id_t child_id, common::reference_offset_t child_slot);
     static void delete_row(common::gaia_id_t id);
     static bool get_type(common::gaia_id_t id, common::gaia_type_t& type);
+
+    static bool insert_into_anchor_chain(common::gaia_id_t parent_id, common::gaia_id_t id, common::reference_offset_t anchor_slot);
+    static bool remove_from_anchor_chain(common::gaia_id_t parent_id, common::gaia_id_t id, common::reference_offset_t anchor_slot);
 };
 
 /**

--- a/production/inc/gaia/direct_access/dac_iterators.hpp
+++ b/production/inc/gaia/direct_access/dac_iterators.hpp
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "gaia/common.hpp"
 #include "gaia/direct_access/dac_base.hpp"
 #include "gaia/exceptions.hpp"
 
@@ -132,39 +133,65 @@ private:
     common::reference_offset_t m_next_offset;
 };
 
-// A reference_chain_container_t is defined within each DAC that is a parent in
-// a "set" relationship. The relationship is represented by a chain of pointers.
-// The parent points to the first child, and each child points to the next
-// child, where a null pointer indicates the end of the chain. Each DAC contains
-// a fixed number of reference slots of type gaia::common::gaia_id_t, to form the chains it is
-// a member of. Any DAC may be parent of any number of sets, and a member of any
-// number of sets. The catalog is aware of each set relationship and determines
-// the number of slots required to be stored in an DAC instance in order to
-// hold the pointers. One reference slot is needed for each set owned by this
-// DAC, and two slots are needed for each set of which this DAC is a member.
-// Constants have been generated to identify the particular slot assigned for
-// its role in a set.
-//
-// @tparam T_child the Direct Access Class that is in the child position in the set
 template <typename T_child>
-class reference_chain_container_t : protected dac_db_t
+class value_linked_reference_container_t : protected dac_db_t
 {
 public:
-    // This constructor will be used by the where() method to create a filtered container.
-    explicit reference_chain_container_t(gaia::common::gaia_id_t parent, std::function<bool(const T_child&)> filter_function, common::reference_offset_t child_offset, common::reference_offset_t next_offset)
+    explicit value_linked_reference_container_t(
+        gaia::common::gaia_id_t anchor_id,
+        common::reference_offset_t anchor_offset,
+        std::function<bool(const T_child&)> filter_function)
+        : m_anchor_id(anchor_id), m_anchor_offset(anchor_offset), m_filter_fn(filter_function)
+    {
+    }
+
+    explicit value_linked_reference_container_t(
+        gaia::common::gaia_id_t anchor_id,
+        common::reference_offset_t anchor_offset)
+        : m_anchor_id(anchor_id), m_anchor_offset(anchor_offset)
+    {
+    }
+
+    value_linked_reference_container_t(const value_linked_reference_container_t&) = default;
+    value_linked_reference_container_t& operator=(const value_linked_reference_container_t&) = default;
+
+    dac_set_iterator_t<T_child> begin() const;
+    dac_set_iterator_t<T_child> end() const;
+
+    size_t size() const;
+
+    value_linked_reference_container_t<T_child> where(std::function<bool(const T_child&)> filter_function) const;
+
+private:
+    gaia::common::gaia_id_t m_anchor_id{gaia::common::c_invalid_gaia_id};
+    common::reference_offset_t m_anchor_offset;
+    std::function<bool(const T_child&)> m_filter_fn{};
+};
+
+template <typename T_child>
+class reference_container_t : protected dac_db_t
+{
+public:
+    explicit reference_container_t(
+        gaia::common::gaia_id_t parent,
+        std::function<bool(const T_child&)> filter_function,
+        common::reference_offset_t child_offset,
+        common::reference_offset_t next_offset)
         : m_parent_id(parent)
         , m_filter_fn(filter_function)
         , m_child_offset(child_offset)
         , m_next_offset(next_offset){};
 
-    explicit reference_chain_container_t(gaia::common::gaia_id_t parent, common::reference_offset_t child_offset, common::reference_offset_t next_offset)
+    explicit reference_container_t(
+        gaia::common::gaia_id_t parent,
+        common::reference_offset_t child_offset,
+        common::reference_offset_t next_offset)
         : m_parent_id(parent)
         , m_child_offset(child_offset)
         , m_next_offset(next_offset){};
 
-    // reference_chain_container_t is copied from the DAC list methods.
-    reference_chain_container_t(const reference_chain_container_t&) = default;
-    reference_chain_container_t& operator=(const reference_chain_container_t&) = default;
+    reference_container_t(const reference_container_t&) = default;
+    reference_container_t& operator=(const reference_container_t&) = default;
 
     dac_set_iterator_t<T_child> begin() const;
     dac_set_iterator_t<T_child> end() const;
@@ -183,63 +210,18 @@ public:
     bool disconnect(const T_child& child_edc);
     void clear();
 
-    reference_chain_container_t<T_child> where(std::function<bool(const T_child&)>) const;
+    reference_container_t<T_child> where(std::function<bool(const T_child&)>) const;
 
 private:
     gaia::common::gaia_id_t m_parent_id{gaia::common::c_invalid_gaia_id};
     std::function<bool(const T_child&)> m_filter_fn{};
     common::reference_offset_t m_child_offset;
     common::reference_offset_t m_next_offset;
-};
 
-// The reference chain container used in value-linked relationships. It differs
-// from the reference chain container above in the following ways:
-//
-// - The front of the child list is an anchor node that points to the parent node.
-//
-// - Each child node has a link to the anchor node instead of the parent node.
-//
-// - Each child node has a back link to the previous node.
-//
-// - No manual connection methods like 'connect()' or 'disconnect()'.
-//
-template <typename T_child>
-class reference_anchor_chain_container_t : protected dac_db_t
-{
-public:
-    explicit reference_anchor_chain_container_t(
-        gaia::common::gaia_id_t anchor,
-        std::function<bool(const T_child&)> filter_function,
-        common::reference_offset_t next_offset,
-        common::reference_offset_t prev_offset)
-        : m_anchor_id(anchor)
-        , m_filter_fn(filter_function)
-        , m_next_offset(next_offset)
-        , m_prev_offset(prev_offset){};
-
-    explicit reference_anchor_chain_container_t(
-        gaia::common::gaia_id_t anchor,
-        common::reference_offset_t next_offset,
-        common::reference_offset_t prev_offset)
-        : m_anchor_id(anchor)
-        , m_next_offset(next_offset)
-        , m_prev_offset(prev_offset){};
-
-    reference_anchor_chain_container_t(const reference_anchor_chain_container_t&) = default;
-    reference_anchor_chain_container_t& operator=(const reference_anchor_chain_container_t&) = default;
-
-    dac_set_iterator_t<T_child> begin() const;
-    dac_set_iterator_t<T_child> end() const;
-
-    size_t size() const;
-
-    reference_anchor_chain_container_t<T_child> where(std::function<bool(const T_child&)>) const;
-
-private:
-    gaia::common::gaia_id_t m_anchor_id{gaia::common::c_invalid_gaia_id};
-    std::function<bool(const T_child&)> m_filter_fn{};
-    common::reference_offset_t m_next_offset;
-    common::reference_offset_t m_prev_offset;
+    inline dac_set_iterator_t<T_child> end_dac_set_iterator() const
+    {
+        return dac_set_iterator_t<T_child>(gaia::common::c_invalid_gaia_id, common::c_invalid_reference_offset);
+    }
 };
 
 // Pick up our template implementation. These still need to be in the header so

--- a/production/inc/gaia/direct_access/dac_iterators.inc
+++ b/production/inc/gaia/direct_access/dac_iterators.inc
@@ -6,6 +6,7 @@
 //
 // Implementation for dac_iterator_t.
 //
+#include "gaia/common.hpp"
 template <typename T_class>
 dac_iterator_t<T_class>::dac_iterator_t(std::shared_ptr<dac_base_iterator_state_t> iterator_state)
     : m_iterator_state(std::move(iterator_state))
@@ -227,141 +228,13 @@ bool dac_set_iterator_t<T_child>::operator!=(const dac_set_iterator_t& rhs) cons
 }
 
 //
-// Implementation for reference_chain_container_t.
+// Implementation for value_linked_reference_container_t.
 //
 template <typename T_child>
-dac_set_iterator_t<T_child> reference_chain_container_t<T_child>::begin() const
-{
-    gaia::common::gaia_id_t id = gaia::common::c_invalid_gaia_id;
-
-    if (m_parent_id != gaia::common::c_invalid_gaia_id)
-    {
-        id = dac_db_t::get_reference(m_parent_id, m_child_offset);
-        while (id != gaia::common::c_invalid_gaia_id)
-        {
-            if (m_filter_fn)
-            {
-                if (m_filter_fn(T_child::get(id)))
-                {
-                    break;
-                }
-                id = dac_db_t::get_reference(id, m_next_offset);
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-
-    return dac_set_iterator_t<T_child>(id, m_filter_fn, m_next_offset);
-}
-
-// The where() method saves the address of the std::function, to be called for each candidate return value.
-template <typename T_child>
-reference_chain_container_t<T_child>
-reference_chain_container_t<T_child>::where(std::function<bool(const T_child&)> filter_function) const
-{
-    return reference_chain_container_t<T_child>(m_parent_id, filter_function, m_child_offset, m_next_offset);
-}
-
-template <typename T_child>
-dac_set_iterator_t<T_child> reference_chain_container_t<T_child>::end() const
-{
-    return dac_set_iterator_t<T_child>(gaia::common::c_invalid_gaia_id, common::c_invalid_reference_offset);
-}
-
-template <typename T_child>
-void reference_chain_container_t<T_child>::insert(gaia::common::gaia_id_t child_id)
-{
-    // The gaia_id() will be zero if the row hasn't been inserted into the SE.
-    if (child_id == gaia::common::c_invalid_gaia_id || m_parent_id == gaia::common::c_invalid_gaia_id)
-    {
-        report_invalid_object_state(m_parent_id, child_id, T_child::gaia_typename());
-    }
-
-    dac_db_t::insert_child_reference(m_parent_id, child_id, m_child_offset);
-}
-
-template <typename T_child>
-void reference_chain_container_t<T_child>::insert(const T_child& child_edc)
-{
-    insert(child_edc.gaia_id());
-}
-
-template <typename T_child>
-bool reference_chain_container_t<T_child>::connect(gaia::common::gaia_id_t child_id)
-{
-    // The gaia_id() will be zero if the row hasn't been inserted into the SE.
-    if (child_id == gaia::common::c_invalid_gaia_id || m_parent_id == gaia::common::c_invalid_gaia_id)
-    {
-        report_invalid_object_state(m_parent_id, child_id, T_child::gaia_typename());
-    }
-
-    return dac_db_t::insert_child_reference(m_parent_id, child_id, m_child_offset);
-}
-
-template <typename T_child>
-bool reference_chain_container_t<T_child>::connect(const T_child& child_edc)
-{
-    return connect(child_edc.gaia_id());
-}
-
-template <typename T_child>
-void reference_chain_container_t<T_child>::remove(gaia::common::gaia_id_t child_id)
-{
-    dac_db_t::remove_child_reference(m_parent_id, child_id, m_child_offset);
-}
-
-template <typename T_child>
-void reference_chain_container_t<T_child>::remove(const T_child& child_edc)
-{
-    remove(child_edc.gaia_id());
-}
-
-template <typename T_child>
-bool reference_chain_container_t<T_child>::disconnect(gaia::common::gaia_id_t child_id)
-{
-    return dac_db_t::remove_child_reference(m_parent_id, child_id, m_child_offset);
-}
-
-template <typename T_child>
-bool reference_chain_container_t<T_child>::disconnect(const T_child& child_edc)
-{
-    return disconnect(child_edc.gaia_id());
-}
-
-template <typename T_child>
-dac_set_iterator_t<T_child> reference_chain_container_t<T_child>::erase(dac_set_iterator_t<T_child> position)
-{
-    auto current = *position;
-    position++;
-    remove(current);
-    return position;
-}
-
-template <typename T_child>
-void reference_chain_container_t<T_child>::clear()
-{
-    for (auto it = begin(); it != end();)
-    {
-        it = erase(it);
-    }
-}
-
-template <typename T_child>
-size_t reference_chain_container_t<T_child>::size() const
-{
-    return std::distance(begin(), end());
-}
-
-//
-// Implementation for reference_anchor_chain_container_t.
-//
-template <typename T_child>
-dac_set_iterator_t<T_child> reference_anchor_chain_container_t<T_child>::begin() const
+dac_set_iterator_t<T_child> value_linked_reference_container_t<T_child>::begin() const
 {
     gaia::common::gaia_id_t id = dac_db_t::get_reference(m_anchor_id, gaia::common::c_ref_anchor_first_child_offset);
+    gaia::common::reference_offset_t next_offset = m_anchor_offset + 1;
     while (id != gaia::common::c_invalid_gaia_id)
     {
         if (m_filter_fn)
@@ -370,31 +243,155 @@ dac_set_iterator_t<T_child> reference_anchor_chain_container_t<T_child>::begin()
             {
                 break;
             }
-            id = dac_db_t::get_reference(id, m_next_offset);
+            id = dac_db_t::get_reference(id, next_offset);
         }
         else
         {
             break;
         }
     }
-    return dac_set_iterator_t<T_child>(id, m_filter_fn, m_next_offset);
+    return dac_set_iterator_t<T_child>(id, m_filter_fn, next_offset);
 }
 
 template <typename T_child>
-reference_anchor_chain_container_t<T_child>
-reference_anchor_chain_container_t<T_child>::where(std::function<bool(const T_child&)> filter_function) const
+value_linked_reference_container_t<T_child>
+value_linked_reference_container_t<T_child>::where(std::function<bool(const T_child&)> filter_function) const
 {
-    return reference_anchor_chain_container_t<T_child>(m_anchor_id, filter_function, m_next_offset, m_prev_offset);
+    return value_linked_reference_container_t<T_child>(m_anchor_id, m_anchor_offset, filter_function);
 }
 
 template <typename T_child>
-dac_set_iterator_t<T_child> reference_anchor_chain_container_t<T_child>::end() const
+dac_set_iterator_t<T_child> value_linked_reference_container_t<T_child>::end() const
 {
     return dac_set_iterator_t<T_child>(gaia::common::c_invalid_gaia_id, common::c_invalid_reference_offset);
 }
 
 template <typename T_child>
-size_t reference_anchor_chain_container_t<T_child>::size() const
+size_t value_linked_reference_container_t<T_child>::size() const
+{
+    return std::distance(begin(), end());
+}
+
+//
+// Implementation for reference_container_t.
+//
+template <typename T_child>
+dac_set_iterator_t<T_child> reference_container_t<T_child>::begin() const
+{
+    if (m_parent_id == gaia::common::c_invalid_gaia_id)
+    {
+        return end_dac_set_iterator();
+    }
+
+    gaia::common::gaia_id_t anchor_id = dac_db_t::get_reference(m_parent_id, m_child_offset);
+    if (anchor_id == gaia::common::c_invalid_gaia_id)
+    {
+        return end_dac_set_iterator();
+    }
+
+    gaia::common::gaia_id_t id = dac_db_t::get_reference(anchor_id, gaia::common::c_ref_anchor_first_child_offset);
+    if (!m_filter_fn)
+    {
+        return dac_set_iterator_t<T_child>(id, m_next_offset);
+    }
+
+    while (id != gaia::common::c_invalid_gaia_id)
+    {
+        if (m_filter_fn(T_child::get(id)))
+        {
+            break;
+        }
+        id = dac_db_t::get_reference(id, m_next_offset);
+    }
+
+    return dac_set_iterator_t<T_child>(id, m_filter_fn, m_next_offset);
+}
+
+template <typename T_child>
+reference_container_t<T_child>
+reference_container_t<T_child>::where(std::function<bool(const T_child&)> filter_function) const
+{
+    return reference_container_t<T_child>(m_parent_id, filter_function, m_child_offset, m_next_offset);
+}
+
+template <typename T_child>
+dac_set_iterator_t<T_child> reference_container_t<T_child>::end() const
+{
+    return end_dac_set_iterator();
+}
+
+template <typename T_child>
+void reference_container_t<T_child>::insert(gaia::common::gaia_id_t id)
+{
+    connect(id);
+}
+
+template <typename T_child>
+void reference_container_t<T_child>::insert(const T_child& child)
+{
+    insert(child.gaia_id());
+}
+
+template <typename T_child>
+bool reference_container_t<T_child>::connect(gaia::common::gaia_id_t id)
+{
+    if (id == gaia::common::c_invalid_gaia_id || m_parent_id == gaia::common::c_invalid_gaia_id)
+    {
+        report_invalid_object_id(id);
+    }
+    return dac_db_t::insert_into_anchor_chain(m_parent_id, id, m_child_offset);
+}
+
+template <typename T_child>
+bool reference_container_t<T_child>::connect(const T_child& child)
+{
+    return connect(child.gaia_id());
+}
+
+template <typename T_child>
+void reference_container_t<T_child>::remove(gaia::common::gaia_id_t id)
+{
+    disconnect(id);
+}
+
+template <typename T_child>
+void reference_container_t<T_child>::remove(const T_child& child)
+{
+    remove(child.gaia_id());
+}
+
+template <typename T_child>
+bool reference_container_t<T_child>::disconnect(gaia::common::gaia_id_t id)
+{
+    return dac_db_t::remove_from_anchor_chain(m_parent_id, id, m_child_offset);
+}
+
+template <typename T_child>
+bool reference_container_t<T_child>::disconnect(const T_child& child)
+{
+    return disconnect(child.gaia_id());
+}
+
+template <typename T_child>
+dac_set_iterator_t<T_child> reference_container_t<T_child>::erase(dac_set_iterator_t<T_child> position)
+{
+    auto current = *position;
+    position++;
+    remove(current);
+    return position;
+}
+
+template <typename T_child>
+void reference_container_t<T_child>::clear()
+{
+    for (auto it = begin(); it != end();)
+    {
+        it = erase(it);
+    }
+}
+
+template <typename T_child>
+size_t reference_container_t<T_child>::size() const
 {
     return std::distance(begin(), end());
 }

--- a/production/inc/gaia_internal/catalog/catalog_generated.h
+++ b/production/inc/gaia_internal/catalog/catalog_generated.h
@@ -12,6 +12,10 @@ namespace gaia {
 namespace catalog {
 namespace internal {
 
+struct gaia_ref_anchor;
+struct gaia_ref_anchorBuilder;
+struct gaia_ref_anchorT;
+
 struct gaia_index;
 struct gaia_indexBuilder;
 struct gaia_indexT;
@@ -39,6 +43,45 @@ struct gaia_tableT;
 struct gaia_database;
 struct gaia_databaseBuilder;
 struct gaia_databaseT;
+
+struct gaia_ref_anchorT : public flatbuffers::NativeTable {
+  typedef gaia_ref_anchor TableType;
+};
+
+struct gaia_ref_anchor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef gaia_ref_anchorT NativeTableType;
+  typedef gaia_ref_anchorBuilder Builder;
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           verifier.EndTable();
+  }
+  gaia_ref_anchorT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(gaia_ref_anchorT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<gaia_ref_anchor> Pack(flatbuffers::FlatBufferBuilder &_fbb, const gaia_ref_anchorT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct gaia_ref_anchorBuilder {
+  typedef gaia_ref_anchor Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  explicit gaia_ref_anchorBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<gaia_ref_anchor> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<gaia_ref_anchor>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<gaia_ref_anchor> Creategaia_ref_anchor(
+    flatbuffers::FlatBufferBuilder &_fbb) {
+  gaia_ref_anchorBuilder builder_(_fbb);
+  return builder_.Finish();
+}
+
+flatbuffers::Offset<gaia_ref_anchor> Creategaia_ref_anchor(flatbuffers::FlatBufferBuilder &_fbb, const gaia_ref_anchorT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 struct gaia_indexT : public flatbuffers::NativeTable {
   typedef gaia_index TableType;
@@ -857,6 +900,29 @@ inline flatbuffers::Offset<gaia_database> Creategaia_databaseDirect(
 }
 
 flatbuffers::Offset<gaia_database> Creategaia_database(flatbuffers::FlatBufferBuilder &_fbb, const gaia_databaseT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+inline gaia_ref_anchorT *gaia_ref_anchor::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<gaia_ref_anchorT>(new gaia_ref_anchorT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void gaia_ref_anchor::UnPackTo(gaia_ref_anchorT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+}
+
+inline flatbuffers::Offset<gaia_ref_anchor> gaia_ref_anchor::Pack(flatbuffers::FlatBufferBuilder &_fbb, const gaia_ref_anchorT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return Creategaia_ref_anchor(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<gaia_ref_anchor> Creategaia_ref_anchor(flatbuffers::FlatBufferBuilder &_fbb, const gaia_ref_anchorT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const gaia_ref_anchorT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  return gaia::catalog::internal::Creategaia_ref_anchor(
+      _fbb);
+}
 
 inline gaia_indexT *gaia_index::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<gaia_indexT>(new gaia_indexT());

--- a/production/inc/gaia_internal/catalog/gaia_catalog.h
+++ b/production/inc/gaia_internal/catalog/gaia_catalog.h
@@ -19,46 +19,50 @@ namespace catalog {
 // The initial size of the flatbuffer builder buffer.
 constexpr size_t c_flatbuffer_builder_size = 128;
 
+// Constants contained in the gaia_ref_anchor object.
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_ref_anchor = 4294967295u;
+
 // Constants contained in the gaia_index object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_index = 4294967289u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_index = 4294967290u;
 constexpr common::reference_offset_t c_gaia_index_parent_table = 0;
 constexpr common::reference_offset_t c_gaia_index_next_table = 1;
 
 // Constants contained in the gaia_rule object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_rule = 4294967293u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_rule = 4294963202u;
 constexpr common::reference_offset_t c_gaia_rule_parent_ruleset = 0;
 constexpr common::reference_offset_t c_gaia_rule_next_ruleset = 1;
 
 // Constants contained in the gaia_ruleset object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_ruleset = 4294967292u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_ruleset = 4294963201u;
 constexpr common::reference_offset_t c_gaia_ruleset_first_gaia_rules = 0;
 
 // Constants contained in the gaia_relationship object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_relationship = 4294967290u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_relationship = 4294967291u;
 constexpr common::reference_offset_t c_gaia_relationship_parent_parent = 0;
 constexpr common::reference_offset_t c_gaia_relationship_next_parent = 1;
-constexpr common::reference_offset_t c_gaia_relationship_parent_child = 2;
-constexpr common::reference_offset_t c_gaia_relationship_next_child = 3;
+constexpr common::reference_offset_t c_gaia_relationship_parent_child = 3;
+constexpr common::reference_offset_t c_gaia_relationship_next_child = 4;
 
 // Constants contained in the gaia_field object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_field = 4294967295u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_field = 4294967294u;
 constexpr common::reference_offset_t c_gaia_field_parent_table = 0;
 constexpr common::reference_offset_t c_gaia_field_next_table = 1;
 
 // Constants contained in the gaia_table object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_table = 4294967294u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_table = 4294967293u;
 constexpr common::reference_offset_t c_gaia_table_parent_database = 0;
 constexpr common::reference_offset_t c_gaia_table_next_database = 1;
-constexpr common::reference_offset_t c_gaia_table_first_gaia_fields = 2;
-constexpr common::reference_offset_t c_gaia_table_first_outgoing_relationships = 3;
-constexpr common::reference_offset_t c_gaia_table_first_incoming_relationships = 4;
-constexpr common::reference_offset_t c_gaia_table_first_gaia_indexes = 5;
+constexpr common::reference_offset_t c_gaia_table_first_gaia_fields = 3;
+constexpr common::reference_offset_t c_gaia_table_first_outgoing_relationships = 4;
+constexpr common::reference_offset_t c_gaia_table_first_incoming_relationships = 5;
+constexpr common::reference_offset_t c_gaia_table_first_gaia_indexes = 6;
 
 // Constants contained in the gaia_database object.
-constexpr common::gaia_type_t::value_type c_gaia_type_gaia_database = 4294967291u;
+constexpr common::gaia_type_t::value_type c_gaia_type_gaia_database = 4294967292u;
 constexpr common::reference_offset_t c_gaia_database_first_gaia_tables = 0;
 
 
+class gaia_ref_anchor_t;
 class gaia_index_t;
 class gaia_rule_t;
 class gaia_ruleset_t;
@@ -66,6 +70,31 @@ class gaia_relationship_t;
 class gaia_field_t;
 class gaia_table_t;
 class gaia_database_t;
+
+
+typedef gaia::direct_access::dac_writer_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t, internal::gaia_ref_anchor, internal::gaia_ref_anchorT> gaia_ref_anchor_writer;
+class gaia_ref_anchor_t : public gaia::direct_access::dac_object_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t, internal::gaia_ref_anchor, internal::gaia_ref_anchorT> {
+    friend class dac_object_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t, internal::gaia_ref_anchor, internal::gaia_ref_anchorT>;
+public:
+    gaia_ref_anchor_t() : dac_object_t() {}
+    static const char* gaia_typename();
+    static gaia::common::gaia_id_t insert_row();
+    static gaia::direct_access::dac_container_t<c_gaia_type_gaia_ref_anchor, gaia_ref_anchor_t> list();
+
+    template<class unused_t>
+    struct expr_ {
+        static gaia::direct_access::expression_t<gaia_ref_anchor_t, gaia::common::gaia_id_t> gaia_id;
+    };
+    using expr = expr_<void>;
+private:
+    explicit gaia_ref_anchor_t(gaia::common::gaia_id_t id) : dac_object_t(id) {}
+};
+
+namespace gaia_ref_anchor_expr {
+    static auto& gaia_id = gaia_ref_anchor_t::expr::gaia_id;
+} // gaia_ref_anchor_expr
+
+template<class unused_t> gaia::direct_access::expression_t<gaia_ref_anchor_t, gaia::common::gaia_id_t> gaia_ref_anchor_t::expr_<unused_t>::gaia_id{&gaia_ref_anchor_t::gaia_id};
 
 
 typedef gaia::direct_access::dac_writer_t<c_gaia_type_gaia_index, gaia_index_t, internal::gaia_index, internal::gaia_indexT> gaia_index_writer;
@@ -150,7 +179,7 @@ typedef gaia::direct_access::dac_writer_t<c_gaia_type_gaia_ruleset, gaia_ruleset
 class gaia_ruleset_t : public gaia::direct_access::dac_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT> {
     friend class dac_object_t<c_gaia_type_gaia_ruleset, gaia_ruleset_t, internal::gaia_ruleset, internal::gaia_rulesetT>;
 public:
-    typedef gaia::direct_access::reference_chain_container_t<gaia_rule_t> gaia_rules_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_rule_t> gaia_rules_list_t;
     gaia_ruleset_t() : dac_object_t() {}
     static const char* gaia_typename();
     static gaia::common::gaia_id_t insert_row(const char* name, bool active_on_startup, const std::vector<uint64_t>& table_ids, const char* source_location, const char* serial_stream);
@@ -338,10 +367,10 @@ typedef gaia::direct_access::dac_writer_t<c_gaia_type_gaia_table, gaia_table_t, 
 class gaia_table_t : public gaia::direct_access::dac_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT> {
     friend class dac_object_t<c_gaia_type_gaia_table, gaia_table_t, internal::gaia_table, internal::gaia_tableT>;
 public:
-    typedef gaia::direct_access::reference_chain_container_t<gaia_index_t> gaia_indexes_list_t;
-    typedef gaia::direct_access::reference_chain_container_t<gaia_relationship_t> incoming_relationships_list_t;
-    typedef gaia::direct_access::reference_chain_container_t<gaia_relationship_t> outgoing_relationships_list_t;
-    typedef gaia::direct_access::reference_chain_container_t<gaia_field_t> gaia_fields_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_index_t> gaia_indexes_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_relationship_t> incoming_relationships_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_relationship_t> outgoing_relationships_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_field_t> gaia_fields_list_t;
     gaia_table_t() : dac_object_t() {}
     static const char* gaia_typename();
     static gaia::common::gaia_id_t insert_row(const char* name, uint32_t type, bool is_system, const std::vector<uint8_t>& binary_schema, const std::vector<uint8_t>& serialization_template);
@@ -407,7 +436,7 @@ typedef gaia::direct_access::dac_writer_t<c_gaia_type_gaia_database, gaia_databa
 class gaia_database_t : public gaia::direct_access::dac_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT> {
     friend class dac_object_t<c_gaia_type_gaia_database, gaia_database_t, internal::gaia_database, internal::gaia_databaseT>;
 public:
-    typedef gaia::direct_access::reference_chain_container_t<gaia_table_t> gaia_tables_list_t;
+    typedef gaia::direct_access::reference_container_t<gaia_table_t> gaia_tables_list_t;
     gaia_database_t() : dac_object_t() {}
     static const char* gaia_typename();
     static gaia::common::gaia_id_t insert_row(const char* name);

--- a/production/inc/gaia_internal/common/system_table_types.hpp
+++ b/production/inc/gaia_internal/common/system_table_types.hpp
@@ -19,37 +19,37 @@ constexpr gaia_type_t c_system_table_reserved_range_end = std::numeric_limits<ga
 constexpr gaia_type_t c_system_table_reserved_range_start
     = c_system_table_reserved_range_end.value() - c_system_table_reserved_range.value() + 1;
 
-// The order of these fields is relevant to the generated order of the catalog
-// table structs in the direct access classes (DAC) code. The child table
-// referencing the parent table (child->parent) should come before the parent
-// table. In other words, the child table should have a larger id than the
-// parent table. This allows incomplete forward declaration of structs that
-// refer to each other in the DAC code.
-enum class catalog_table_type_t : gaia_type_t::value_type
+// NOTE: The following tables are essential for the db server to operate at
+// lowest level. Consider adding to system tables instead unless necessary.
+enum class catalog_core_table_type_t : gaia_type_t::value_type
 {
-    gaia_field = c_system_table_reserved_range_end.value(),
+    gaia_ref_anchor = c_system_table_reserved_range_end.value(),
+    gaia_field = gaia_ref_anchor - 1,
     gaia_table = gaia_field - 1,
-    gaia_rule = gaia_table - 1,
-    gaia_ruleset = gaia_rule - 1,
-    gaia_database = gaia_ruleset - 1,
+    gaia_database = gaia_table - 1,
     gaia_relationship = gaia_database - 1,
     gaia_index = gaia_relationship - 1,
-    gaia_ref_anchor = gaia_index - 1,
+    last = gaia_index
 };
 
 enum class system_table_type_t : gaia_type_t::value_type
 {
-    catalog_gaia_table = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_table),
-    catalog_gaia_field = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_field),
-    catalog_gaia_ruleset = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_ruleset),
-    catalog_gaia_rule = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_rule),
-    catalog_gaia_database = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_database),
-    catalog_gaia_relationship = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_relationship),
-    catalog_gaia_index = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_index),
-    catalog_gaia_ref_anchor = static_cast<gaia_type_t::value_type>(catalog_table_type_t::gaia_ref_anchor),
+    catalog_gaia_table = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_table),
+    catalog_gaia_field = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_field),
+    catalog_gaia_database = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_database),
+    catalog_gaia_relationship = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_relationship),
+    catalog_gaia_index = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_index),
+    catalog_gaia_ref_anchor = static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::gaia_ref_anchor),
     // Assign constant IDs to other system tables starting from lower end of the reserved range.
     event_log = c_system_table_reserved_range_start.value(),
+    gaia_ruleset = event_log + 1,
+    gaia_rule = gaia_ruleset + 1,
 };
+
+inline bool is_catalog_core_object(gaia_type_t type)
+{
+    return type >= static_cast<gaia_type_t::value_type>(catalog_core_table_type_t::last) && type <= c_system_table_reserved_range_end;
+}
 
 inline bool is_system_object(gaia_type_t type)
 {

--- a/production/inc/gaia_internal/db/catalog_core.hpp
+++ b/production/inc/gaia_internal/db/catalog_core.hpp
@@ -68,7 +68,7 @@ struct table_view_t : catalog_db_object_view_t
 struct relationship_view_t : catalog_db_object_view_t
 {
     static constexpr common::reference_offset_t c_parent_gaia_table_ref_offset = 0;
-    static constexpr common::reference_offset_t c_child_gaia_table_ref_offset = 2;
+    static constexpr common::reference_offset_t c_child_gaia_table_ref_offset = 3;
 
     using catalog_db_object_view_t::catalog_db_object_view_t;
     [[nodiscard]] const char* name() const;
@@ -111,44 +111,46 @@ struct catalog_core_t
     static constexpr common::reference_offset_t c_gaia_field_parent_gaia_table_offset = 0;
     // The ref slot in gaia_field pointing to the next gaia_field.
     static constexpr common::reference_offset_t c_gaia_field_next_gaia_field_offset = 1;
+    // The ref slot in gaia_field pointing to the prev gaia_field.
+    static constexpr common::reference_offset_t c_gaia_field_prev_gaia_field_offset = 2;
     //
     // The ref slot in gaia_table pointing to the parent gaia_database.
     static constexpr common::reference_offset_t c_gaia_table_parent_gaia_database_offset = 0;
     // The ref slot in gaia_table pointing to the next gaia_table.
     static constexpr common::reference_offset_t c_gaia_table_next_gaia_table_offset = 1;
+    // The ref slot in gaia_table pointing to the prev gaia_table.
+    static constexpr common::reference_offset_t c_gaia_table_prev_gaia_table_offset = 2;
     // The ref slot in gaia_table pointing to the first gaia_field.
-    static constexpr common::reference_offset_t c_gaia_table_first_gaia_field_offset = 2;
+    static constexpr common::reference_offset_t c_gaia_table_first_gaia_field_offset = 3;
     // The ref slot in gaia_table pointing to the first parent gaia_relationship.
-    static constexpr common::reference_offset_t c_gaia_table_first_parent_gaia_relationship_offset = 3;
+    static constexpr common::reference_offset_t c_gaia_table_first_parent_gaia_relationship_offset = 4;
     // The ref slot in gaia_table pointing to the first child gaia_relationship.
-    static constexpr common::reference_offset_t c_gaia_table_first_child_gaia_relationship_offset = 4;
+    static constexpr common::reference_offset_t c_gaia_table_first_child_gaia_relationship_offset = 5;
     // The ref slot in gaia_table pointing to the first gaia_index.
-    static constexpr common::reference_offset_t c_gaia_table_first_gaia_index_offset = 5;
+    static constexpr common::reference_offset_t c_gaia_table_first_gaia_index_offset = 6;
     //
     // The ref slot in gaia_relationship pointing to the parent gaia_table.
     static constexpr common::reference_offset_t c_gaia_relationship_parent_parent_gaia_table_offset = 0;
     // The ref slot in gaia_relationship pointing to the next parent gaia_relationship.
     static constexpr common::reference_offset_t c_gaia_relationship_next_parent_gaia_relationship_offset = 1;
+    // The ref slot in gaia_relationship pointing to the prev parent gaia_relationship.
+    static constexpr common::reference_offset_t c_gaia_relationship_prev_parent_gaia_relationship_offset = 2;
     // The ref slot in gaia_relationship pointing to the parent child gaia_relationship.
-    static constexpr common::reference_offset_t c_gaia_relationship_parent_child_gaia_table_offset = 2;
+    static constexpr common::reference_offset_t c_gaia_relationship_parent_child_gaia_table_offset = 3;
     // The ref slot in gaia_relationship pointing to the next child gaia_relationship.
-    static constexpr common::reference_offset_t c_gaia_relationship_next_child_gaia_relationship_offset = 3;
+    static constexpr common::reference_offset_t c_gaia_relationship_next_child_gaia_relationship_offset = 4;
+    // The ref slot in gaia_relationship pointing to the prev child gaia_relationship.
+    static constexpr common::reference_offset_t c_gaia_relationship_prev_child_gaia_relationship_offset = 5;
     //
     // The ref slot in gaia_database pointing to the first gaia_table.
     static constexpr common::reference_offset_t c_gaia_database_first_gaia_table_offset = 0;
-    //
-    // The ref slot in gaia_ruleset pointing to the first gaia_rule.
-    static constexpr common::reference_offset_t c_gaia_ruleset_first_gaia_rule_offset = 0;
-    //
-    // The ref slot in gaia_rule pointing to the parent gaia_ruleset.
-    static constexpr common::reference_offset_t c_gaia_rule_parent_gaia_ruleset_offset = 0;
-    // The ref slot in gaia_rule pointing to the next gaia_rule.
-    static constexpr common::reference_offset_t c_gaia_rule_next_gaia_rule_offset = 1;
     //
     // The ref slot in gaia_index pointing to the parent gaia_table.
     static constexpr common::reference_offset_t c_gaia_index_parent_gaia_table_offset = 0;
     // The ref slot in gaia_index pointing to the next gaia_index.
     static constexpr common::reference_offset_t c_gaia_index_next_gaia_index_offset = 1;
+    // The ref slot in gaia_index pointing to the prev gaia_index.
+    static constexpr common::reference_offset_t c_gaia_index_prev_gaia_index_offset = 2;
 
     [[nodiscard]] static inline const db_object_t* get_db_object_ptr(common::gaia_id_t);
 

--- a/production/inc/gaia_internal/db/gaia_ptr.hpp
+++ b/production/inc/gaia_internal/db/gaia_ptr.hpp
@@ -11,9 +11,10 @@
 
 #include "gaia_internal/common/generator_iterator.hpp"
 #include "gaia_internal/common/retail_assert.hpp"
+#include "gaia_internal/common/system_table_types.hpp"
 #include "gaia_internal/db/db_object.hpp"
 #include "gaia_internal/db/db_types.hpp"
-#include "gaia_internal/db/type_metadata.hpp"
+#include "gaia_internal/db/gaia_ptr_api.hpp"
 
 #include "memory_types.hpp"
 
@@ -25,9 +26,16 @@ namespace db
 /**
  * gaia_ptr_t is implemented differently on the server and client-side.
  * See their respective cpp files for differences.
+ *
+ * NOTE: All methods in this class will not check for referential integrity,
+ * create triggers, or make auto connection w.r.t payload value changes. Use
+ * methods in 'gaia_ptr_op' if those higher level functionalities are needed.
  */
 class gaia_ptr_t
 {
+    friend void gaia_ptr::update_payload(gaia_ptr_t& obj, size_t data_size, const void* data);
+    friend gaia_ptr_t gaia_ptr::create(common::gaia_id_t id, common::gaia_type_t type, size_t data_size, const void* data);
+
 public:
     gaia_ptr_t() = default;
 
@@ -45,17 +53,6 @@ public:
 
     static common::gaia_id_t generate_id();
 
-    static gaia_ptr_t create(
-        common::gaia_type_t type,
-        size_t data_size,
-        const void* data);
-
-    static gaia_ptr_t create(
-        common::gaia_id_t id,
-        common::gaia_type_t type,
-        size_t data_size,
-        const void* data);
-
     // TODO This should be private but it is still used in some code paths
     //  that could be painful to update.
     static gaia_ptr_t create(
@@ -65,16 +62,13 @@ public:
         size_t data_size,
         const void* data);
 
-    // Removes the database record at the given pointer object. Throws
-    // exceptions in case of referential integrity violation.
-    static void remove(gaia_ptr_t& object);
-
-    gaia_ptr_t& update_payload(size_t data_size, const void* data);
+    void update_payload(size_t data_size, const void* data);
 
     static gaia_ptr_t find_first(common::gaia_type_t type);
     gaia_ptr_t find_next() const;
 
     inline bool is_null() const;
+    inline bool is_ref_anchor() const;
 
     inline common::gaia_id_t id() const;
     inline common::gaia_type_t type() const;
@@ -98,81 +92,31 @@ public:
     static common::iterators::generator_range_t<gaia_ptr_t> find_all_range(
         common::gaia_type_t type);
 
-    /**
-     * Adds a child reference to a parent object. All the pointers involved in the relationship
-     * will be updated, not only first_child_offset.
-     *
-     * Calling `parent.add_child_reference(child)` is the same as calling
-     * `child.add_parent_reference(parent)`.
-     *
-     * @param child_id The id of the children.
-     * @param first_child_offset The offset in the references array where the pointer to the child is placed.
-     * @throws Exceptions there is no relationship between the parent and the child or if other
-     *         integrity constraints are violated.
-     */
-    bool add_child_reference(common::gaia_id_t child_id, common::reference_offset_t first_child_offset);
-
-    /**
-     * Add a parent reference to a child object. All the pointers involved in the relationship
-     * will be updated, not only parent_offset.
-     *
-     * Note: Children objects have 2 pointers per relationship (next_child_offset, parent_offset)
-     * only one (parent_offset) is used to denote the relationship with parent.
-     *
-     * @param parent_id The id of the parent
-     * @param parent_offset The offset in the references array where the pointer to the parent is placed.
-     * @throws Exceptions there is no relationship between the parent and the child  or if other
-     *         integrity constraints are violated.
-     */
-    bool add_parent_reference(common::gaia_id_t parent_id, common::reference_offset_t parent_offset);
-
-    /**
-     * Removes a child reference from a parent object. Without an index this operation
-     * could have O(n) time complexity where n is the number of children.
-     *
-     * All the pointers involved in the relationship will be updated, not only first_child_offset.
-     *
-     * @param child_id The id of the children to be removed.
-     * @param first_child_offset The offset, in the references array, of the pointer to the first child.
-     */
-    bool remove_child_reference(common::gaia_id_t child_id, common::reference_offset_t first_child_offset);
-
-    /**
-     * Removes a parent reference from a child object at the given parent offset.
-     *
-     * @param parent_offset The offset, in the references array, of the pointer to the parent.
-     */
-    bool remove_parent_reference(common::reference_offset_t parent_offset);
-
-    /**
-     * Update the parent reference with the given new_parent_id. If the this object does not
-     * have a parent for the relationship denoted by parent_offset, it will just create the
-     * relationship.
-     *
-     * All the pointers involved in the relationship will be updated, not only parent_offset.
-     *
-     * @param new_parent_id The id of the new parent.
-     * @param parent_offset The offset, in the references array, of the pointer to the parent.
-     */
-    bool update_parent_reference(common::gaia_id_t new_parent_id, common::reference_offset_t parent_offset);
-
-    // Delete the database record at the pointer. This method will not check
-    // referential integrity violation for the deletion. Use 'remove()' instead
-    // if you want referential integrity to be respected.
     void reset();
+
+    gaia_ptr_t set_reference(common::reference_offset_t offset, common::gaia_id_t id);
+
+    gaia_ptr_t set_references(
+        common::reference_offset_t offset1, common::gaia_id_t id1,
+        common::reference_offset_t offset2, common::gaia_id_t id2,
+        common::reference_offset_t offset3 = common::c_invalid_reference_offset,
+        common::gaia_id_t id3 = common::c_invalid_gaia_id);
+
+    static gaia_ptr_t create_ref_anchor(
+        common::gaia_id_t parent_id,
+        common::gaia_id_t first_child_id);
 
 protected:
     void allocate(size_t size);
+
+    void finalize_create();
+    void finalize_update(gaia_offset_t old_offset);
 
     inline bool is(common::gaia_type_t type) const;
 
     gaia_ptr_t find_next(common::gaia_type_t type) const;
 
 private:
-    static gaia_ptr_t create_ref_anchor(
-        common::gaia_id_t parent_id,
-        common::gaia_id_t first_child_id);
-
     static gaia_ptr_t create_no_txn(
         common::gaia_id_t id,
         common::gaia_type_t type,
@@ -180,83 +124,11 @@ private:
         size_t data_size,
         const void* data);
 
+    void update_payload_no_txn(size_t data_size, const void* data);
+
     void clone_no_txn();
 
-    void create_insert_trigger(common::gaia_type_t type, common::gaia_id_t id);
-
     static std::shared_ptr<common::iterators::generator_t<common::gaia_id_t>> get_id_generator_for_type(common::gaia_type_t type);
-
-    static bool update_parent_reference(
-        common::gaia_id_t child_id,
-        common::gaia_type_t child_type,
-        common::gaia_id_t* child_references,
-        common::gaia_id_t new_parent_id,
-        common::reference_offset_t parent_offset);
-
-    /**
-     * Try to auto connect a record to matching record(s).
-     *
-     * @param id The record id
-     * @param type The record type
-     * @param type The record id of the table type
-     * @param references The record references
-     * @param candidate_fields The list of candidate fields' positions.
-     */
-    static void auto_connect(
-        common::gaia_id_t id,
-        common::gaia_type_t type,
-        common::gaia_id_t type_id,
-        common::gaia_id_t* references,
-        const uint8_t* payload,
-        const common::field_position_list_t& candidate_fields);
-
-    static void auto_connect(
-        common::gaia_id_t id,
-        common::gaia_type_t type,
-        common::gaia_id_t* references,
-        const uint8_t* payload);
-
-    // Helper method to perform auto connection for a given field in the node on
-    // the parent side of a relationship.
-    static void parent_side_auto_connect(
-        common::gaia_id_t id,
-        common::gaia_type_t type,
-        common::gaia_id_t type_id,
-        common::gaia_id_t* references,
-        const uint8_t* payload,
-        common::field_position_t field_position);
-
-    // Helper method to perform auto connection for a given field in the node on
-    // the child side of a relationship.
-    static void child_side_auto_connect(
-        common::gaia_id_t id,
-        common::gaia_type_t type,
-        common::gaia_id_t type_id,
-        common::gaia_id_t* references,
-        const uint8_t* payload,
-        common::field_position_t field_position);
-
-    gaia_ptr_t set_reference(common::reference_offset_t offset, common::gaia_id_t id);
-
-    /**
-     * Try to find a record in an indexed table (using the index) that matches
-     * the field value in the given data payload.
-     *
-     * @param payload The data payload
-     * @param field_position The field position of the payload
-     * @param type The type of the given data payload
-     * @param type_id The table id of the given type
-     * @param indexed_table_id The table to find from
-     * @param indexed_field_position The indexed field of the target table
-     * @return id of the found record; 'c_invalid_gaia_id' if not found
-     */
-    static common::gaia_id_t find_using_index(
-        const uint8_t* payload,
-        common::field_position_t field_position,
-        common::gaia_type_t type,
-        common::gaia_id_t type_id,
-        common::gaia_id_t indexed_table_id,
-        common::field_position_t indexed_field_position);
 
 private:
     gaia_locator_t m_locator{c_invalid_gaia_locator};

--- a/production/inc/gaia_internal/db/gaia_ptr.inc
+++ b/production/inc/gaia_internal/db/gaia_ptr.inc
@@ -33,6 +33,11 @@ bool gaia_ptr_t::is_null() const
     return m_locator == c_invalid_gaia_locator;
 }
 
+bool gaia_ptr_t::is_ref_anchor() const
+{
+    return is(static_cast<common::gaia_type_t::value_type>(common::system_table_type_t::catalog_gaia_ref_anchor));
+}
+
 common::gaia_id_t gaia_ptr_t::id() const
 {
     return to_ptr() ? to_ptr()->id : common::c_invalid_gaia_id;

--- a/production/inc/gaia_internal/db/gaia_ptr_api.hpp
+++ b/production/inc/gaia_internal/db/gaia_ptr_api.hpp
@@ -1,0 +1,57 @@
+/////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+// All rights reserved.
+/////////////////////////////////////////////
+
+#pragma once
+
+#include <memory>
+
+#include "gaia/common.hpp"
+
+namespace gaia
+{
+namespace db
+{
+
+class gaia_ptr_t;
+
+/*
+ * This namespace provides 'gaia_ptr_t' operations that include functionalities
+ * like referential integrity check and value linked relationship auto
+ * connection that require the type metadata and the catalog.
+ */
+namespace gaia_ptr
+{
+
+gaia_ptr_t create(
+    common::gaia_type_t type,
+    size_t data_size,
+    const void* data);
+
+gaia_ptr_t create(
+    common::gaia_id_t id,
+    common::gaia_type_t type,
+    size_t data_size,
+    const void* data);
+
+void remove(gaia_ptr_t& object);
+
+void update_payload(common::gaia_id_t id, size_t data_size, const void* data);
+void update_payload(gaia_ptr_t& obj, size_t data_size, const void* data);
+
+bool insert_into_reference_container(common::gaia_id_t parent_id, common::gaia_id_t child_id, common::reference_offset_t parent_anchor_slot);
+bool insert_into_reference_container(gaia_ptr_t& parent, common::gaia_id_t child_id, common::reference_offset_t parent_anchor_slot);
+
+bool remove_from_reference_container(common::gaia_id_t parent_id, common::gaia_id_t child_id, common::reference_offset_t parent_anchor_slot);
+bool remove_from_reference_container(gaia_ptr_t& parent, common::gaia_id_t child_id, common::reference_offset_t parent_anchor_slot);
+
+bool remove_from_reference_container(common::gaia_id_t child_id, common::reference_offset_t child_anchor_slot);
+bool remove_from_reference_container(gaia_ptr_t& child, common::reference_offset_t child_anchor_slot);
+
+bool update_parent_reference(common::gaia_id_t child_id, common::gaia_id_t new_parent_id, common::reference_offset_t parent_offset);
+bool update_parent_reference(gaia_ptr_t& child, common::gaia_id_t new_parent_id, common::reference_offset_t parent_offset);
+
+} // namespace gaia_ptr
+} // namespace db
+} // namespace gaia

--- a/production/inc/gaia_internal/db/gaia_relationships.hpp
+++ b/production/inc/gaia_internal/db/gaia_relationships.hpp
@@ -31,29 +31,9 @@ enum class cardinality_t
  * will allocate reference slots (in the object header before the data payload)
  * for each relationship the object is in.
  *
- * The objects in a relationship can form two different topologies from the
- * references that connect them: one without an anchor node and one with an
- * anchor node. The connected data structures are called reference chain and
- * reference anchor chain respectively.
- *
- * A reference chain will look like the following graph.
- *
- *   +---------------------------------------+
- *   |                                       |
- *   |  +-----------------------+            |
- *   |  |                       |            |
- *   v  v                       |            |
- *  +----+  <--  +----+       +----+       +----+
- *  | P  |  -->  | C1 |  -->  | C2 |  -->  | C3 |
- *  +----+       +----+       +----+       +----+
- *
- * In the above graph, P is a parent node; C1, C2, and C3 are child nodes. A
- * parent node has one reference at the 'first_child_offset' slot pointing to
- * the first child node in the list. Each child node has two references: one at
- * the 'next_child_offset' slot pointing to the next child in the list; another
- * at the 'parent_offset' slot pointing to the parent node.
- *
- * A reference anchor chain will look like the following graph.
+ * The objects in a relationship form a strucutre from the references that
+ * connect them. The connected data structures are called reference containers
+ * which look like the following graph.
  *
  *                +---------------------------------------+
  *                |                                       |
@@ -74,7 +54,6 @@ enum class cardinality_t
  * previous node in the list; one at the 'parent_offset' slot pointing to the
  * anchor node.
  *
- * TODO: GAIAPLAT-1769 Replace reference chains with anchor chains.
  */
 struct relationship_t
 {

--- a/production/inc/gaia_internal/db/triggers.hpp
+++ b/production/inc/gaia_internal/db/triggers.hpp
@@ -57,7 +57,7 @@ typedef void (*commit_trigger_fn)(const trigger_event_list_t&);
 /**
  * Use this constant to specify that no fields are needed when generating trigger_event_t.
  */
-const common::field_position_list_t empty_position_list = {};
+const common::field_position_list_t c_empty_position_list = {};
 
 } // namespace triggers
 } // namespace db

--- a/production/java/com/gaiaplatform/database/GaiaDatabase.java
+++ b/production/java/com/gaiaplatform/database/GaiaDatabase.java
@@ -121,7 +121,7 @@ public class GaiaDatabase
 
     private static void printPayload(byte[] payload)
     {
-        if (payload.length == 0)
+        if (payload == null || payload.length == 0)
         {
             return;
         }
@@ -169,7 +169,7 @@ public class GaiaDatabase
         System.out.println(
             "Node id: " + nodeId
             + ", type: " + getNodeType(nodeId)
-            + ", payload size: " + payload.length
+            + ", payload size: " + (payload == null ? 0 : payload.length)
             + ";");
 
         printPayload(payload);

--- a/production/rules/event_manager/tests/test_event_manager.cpp
+++ b/production/rules/event_manager/tests/test_event_manager.cpp
@@ -273,9 +273,9 @@ void rule5(const rule_context_t* context)
            // TODO[GAIAPLAT-155]: Determine how the rule schedule deals with cycles
            //{context->event_type, context->gaia_type, context->record, nullptr, 0},
            // Allow event call on different gaia_type.
-           {context->event_type, test_gaia_other_t::s_gaia_type, context->record, empty_position_list, dummy_txn_id},
+           {context->event_type, test_gaia_other_t::s_gaia_type, context->record, c_empty_position_list, dummy_txn_id},
            // Allow event call on different event_type.
-           {event_type_t::row_insert, context->gaia_type, test_gaia_ptr->gaia_id(), empty_position_list, dummy_txn_id}};
+           {event_type_t::row_insert, context->gaia_type, test_gaia_ptr->gaia_id(), c_empty_position_list, dummy_txn_id}};
     test::commit_trigger(trigger_events, 2);
 }
 
@@ -322,7 +322,7 @@ void rule8(const rule_context_t* context)
 
     test_gaia_t row;
     trigger_event_t trigger_event
-        = {event_type_t::row_update, test_gaia_t::s_gaia_type, row.gaia_id(), empty_position_list, dummy_txn_id};
+        = {event_type_t::row_update, test_gaia_t::s_gaia_type, row.gaia_id(), c_empty_position_list, dummy_txn_id};
     test::commit_trigger(&trigger_event, 1);
 }
 
@@ -391,7 +391,7 @@ struct rule_decl_t
  * transaction_rollback: rule3, rule4
  */
 static const rule_decl_t c_rule_decl[] = {
-    //TODO[GAIAPLAT-445] We don't expose deleted row events
+    // TODO[GAIAPLAT-445] We don't expose deleted row events
     // {{c_ruleset1_name, c_rule1_name, test_gaia_t::s_gaia_type, event_type_t::row_delete, 0, 1}, rule1},
     // {{c_ruleset1_name, c_rule2_name, test_gaia_t::s_gaia_type, event_type_t::row_delete, 0, 2}, rule2},
     {{c_ruleset1_name, c_rule2_name, test_gaia_t::s_gaia_type, event_type_t::row_insert, 0, 2}, rule2},
@@ -694,8 +694,8 @@ TEST_F(event_manager_test, log_database_event_single_event_single_rule)
     const gaia_id_t new_record = 20;
     const gaia_id_t record = 55;
     trigger_event_t events[] = {
-        {event_type_t::row_insert, test_gaia_t::s_gaia_type, new_record, empty_position_list, dummy_txn_id},
-        {event_type_t::row_update, test_gaia_t::s_gaia_type, record, empty_position_list, dummy_txn_id}};
+        {event_type_t::row_insert, test_gaia_t::s_gaia_type, new_record, c_empty_position_list, dummy_txn_id},
+        {event_type_t::row_update, test_gaia_t::s_gaia_type, record, c_empty_position_list, dummy_txn_id}};
 
     test::commit_trigger(events, 2);
 
@@ -802,8 +802,8 @@ TEST_F(event_manager_test, log_database_event_single_rule_multi_event)
     trigger_event_t events[] = {
         // TODO[GAIAPLAT-445] We don't expose deleted row events
         //{event_type_t::row_delete, test_gaia_t::s_gaia_type, record, empty_position_list, dummy_txn_id},
-        {event_type_t::row_update, test_gaia_t::s_gaia_type, record + 1, empty_position_list, dummy_txn_id},
-        {event_type_t::row_insert, test_gaia_t::s_gaia_type, record + 2, empty_position_list, dummy_txn_id}};
+        {event_type_t::row_update, test_gaia_t::s_gaia_type, record + 1, c_empty_position_list, dummy_txn_id},
+        {event_type_t::row_insert, test_gaia_t::s_gaia_type, record + 2, c_empty_position_list, dummy_txn_id}};
 
     test::commit_trigger(events, 2);
     validate_rule_sequence(sequence);
@@ -823,8 +823,8 @@ TEST_F(event_manager_test, log_database_event_multi_rule_single_event)
     // fired in response to the insert event.
     const gaia_id_t record = 100;
     trigger_event_t events[] = {
-        {event_type_t::row_update, test_gaia_t::s_gaia_type, 1, empty_position_list, dummy_txn_id},
-        {event_type_t::row_insert, test_gaia_t::s_gaia_type, record, empty_position_list, dummy_txn_id},
+        {event_type_t::row_update, test_gaia_t::s_gaia_type, 1, c_empty_position_list, dummy_txn_id},
+        {event_type_t::row_insert, test_gaia_t::s_gaia_type, record, c_empty_position_list, dummy_txn_id},
     };
     test::commit_trigger(events, 2);
     validate_rule_sequence(sequence);
@@ -854,7 +854,7 @@ TEST_F(event_manager_test, log_event_multi_rule_multi_event)
 
     trigger_event_t events[] = {
         {event_type_t::row_update, test_gaia_t::s_gaia_type, 1, g_first_name, dummy_txn_id},
-        {event_type_t::row_insert, test_gaia_other_t::s_gaia_type, record, empty_position_list, dummy_txn_id}};
+        {event_type_t::row_insert, test_gaia_other_t::s_gaia_type, record, c_empty_position_list, dummy_txn_id}};
     test::commit_trigger(events, 2);
     validate_rule_sequence(sequence);
 
@@ -875,7 +875,7 @@ TEST_F(event_manager_test, log_event_multi_rule_multi_event)
 
     const gaia_id_t another_record = 205;
     trigger_event_t single_event
-        = {event_type_t::row_insert, test_gaia_t::s_gaia_type, another_record, empty_position_list, dummy_txn_id};
+        = {event_type_t::row_insert, test_gaia_t::s_gaia_type, another_record, c_empty_position_list, dummy_txn_id};
     test::commit_trigger(&single_event, 1);
     validate_rule_sequence(sequence);
     validate_rule(event_type_t::row_insert, test_gaia_t::s_gaia_type, another_record);
@@ -984,7 +984,7 @@ TEST_F(event_manager_test, unsubscribe_rule_not_found)
     // Try to remove the rule from the other table events that we didn't register the rule on.
     EXPECT_EQ(false, unsubscribe_rule(test_gaia_t::s_gaia_type, event_type_t::row_insert, empty_fields, rb));
     // TODO[GAIAPLAT-445] We don't expose deleted row events
-    //EXPECT_EQ(false, unsubscribe_rule(test_gaia_t::s_gaia_type, event_type_t::row_delete, empty_fields, rb));
+    // EXPECT_EQ(false, unsubscribe_rule(test_gaia_t::s_gaia_type, event_type_t::row_delete, empty_fields, rb));
 
     // Try to remove the rule from a type that we didn't register the rule on
     EXPECT_EQ(false, unsubscribe_rule(test_gaia_other_t::s_gaia_type, event_type_t::row_update, empty_fields, rb));

--- a/production/tools/gaia_dump/src/gaia_dump.cpp
+++ b/production/tools/gaia_dump/src/gaia_dump.cpp
@@ -167,7 +167,7 @@ string gaia_dump(gaia_id_t low, gaia_id_t high, bool payload, bool references, b
             if (node_ptr)
             {
                 // If 'catalog' is true, don't check the catalog range.
-                if (catalog || node_ptr.type() < c_system_table_reserved_range_start)
+                if (catalog || !is_system_object(node_ptr.type()))
                 {
                     if (type_in(node_ptr.type(), type_vec))
                     {


### PR DESCRIPTION
Using the anchor chain introduced for value linked relationships for all relationships. The replacement goes as follows.

`referenced_chain_container_t` -> `reference_container_t`
`reference_anchor_chain_container_t` -> `value_linked_reference_container_t`

This will enable efficient deletion (O(1)) vs (O(n)) of both parent and child node. The trade off are 1) one more ref slots in the child node for each relationship; 2) extra hop(s) to retrieve the parent/child node(s). 

https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1769
