### PR TITLE
Change hardcoded count of data mappings to enum value

### DIFF
--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -272,7 +272,8 @@ void client_t::begin_session(config::session_options_t session_options)
     // authentication is currently disabled in the server).
     try
     {
-        client_messenger.send_and_receive(s_session_socket, nullptr, 0, builder, 4);
+        client_messenger.send_and_receive(
+            s_session_socket, nullptr, 0, builder, static_cast<size_t>(data_mapping_t::index_t::count_mappings));
     }
     catch (const gaia::common::peer_disconnected&)
     {


### PR DESCRIPTION
This is an utterly trivial change, but I got some pretty cryptic runtime errors due to this hardcoded value when I added another shmem segment to the data mappings, and I want to be sure the fix goes in irrespective of the fate of my current work.