### PR TITLE
Add debug helper to display fd name

### DIFF
--- a/production/inc/gaia_internal/common/fd_helpers.hpp
+++ b/production/inc/gaia_internal/common/fd_helpers.hpp
@@ -64,7 +64,7 @@ inline std::string get_fd_name(int fd)
     // Now get decimal representation of fd.
     std::snprintf(fd_str_value.data(), fd_str_value.size(), fd_fmt, fd);
     int proc_dir_fd = open("/proc/self/fd/", 0);
-    if (proc_dir_fd < 0)
+    if (proc_dir_fd == -1)
     {
         throw_system_error("open(\"/proc/self/fd/\") failed!");
     }


### PR DESCRIPTION
This just returns the contents of the `/proc/self/fd/<N>` symlink, so you can read e.g. the name of a memfd assigned in `memfd_create()`. I found it helpful for debugging, which is all it's intended for.