### PR TITLE
INDEX: Internal APIs for range queries on index

### DIFF
--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -535,8 +535,8 @@ void server_t::handle_request_stream(
         case index_query_t::index_range_query_t:
         {
             bool apply_logs = false;
-            create_local_snapshot(apply_logs);
-            auto cleanup_local_snapshot = make_scope_guard([]() { s_local_snapshot_locators.close(); });
+            create_or_refresh_local_snapshot(apply_logs);
+            auto cleanup_local_snapshot = make_scope_guard([]() { local_snapshot_locators().close(); });
 
             std::optional<index::index_key_t> lower_bound_key, upper_bound_key;
             auto query = request_data->query_as_index_range_query_t();

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -544,15 +544,15 @@ void server_t::handle_request_stream(
             if (query->lower_bound_key())
             {
                 auto lower_bound_key_buffer = payload_types::data_read_buffer_t(*(query->lower_bound_key()));
-                auto deserialized = index::index_builder_t::deserialize_key(index_id, lower_bound_key_buffer);
-                lower_bound_key.emplace(std::move(deserialized));
+                index::index_key_t deserialized_key = index::index_builder_t::deserialize_key(index_id, lower_bound_key_buffer);
+                lower_bound_key.emplace(std::move(deserialized_key));
             }
 
             if (query->upper_bound_key())
             {
                 auto upper_bound_key_buffer = payload_types::data_read_buffer_t(*(query->upper_bound_key()));
-                auto deserialized = index::index_builder_t::deserialize_key(index_id, upper_bound_key_buffer);
-                upper_bound_key.emplace(std::move(deserialized));
+                index::index_key_t deserialized_key = index::index_builder_t::deserialize_key(index_id, upper_bound_key_buffer);
+                upper_bound_key.emplace(std::move(deserialized_key));
             }
             auto range_index = static_cast<index::range_index_t*>(index.get());
             start_stream_producer(server_socket, range_index->range_generator(txn_id, lower_bound_key, upper_bound_key));

--- a/production/db/inc/index/base_index.hpp
+++ b/production/db/inc/index/base_index.hpp
@@ -57,6 +57,17 @@ enum class index_record_operation_t : uint8_t
     update,
 };
 
+class index_operation_not_supported : public common::gaia_exception
+{
+public:
+    explicit index_operation_not_supported()
+    {
+        std::stringstream message;
+        message << "Index operation not supported. ";
+        m_message = message.str();
+    }
+};
+
 struct index_record_t
 {
     // The following fields should occupy 3x64bit.

--- a/production/db/inc/index/range_index.hpp
+++ b/production/db/inc/index/range_index.hpp
@@ -10,6 +10,7 @@
 
 #include <iterator>
 #include <map>
+#include <optional>
 #include <tuple>
 
 #include "index.hpp"
@@ -45,6 +46,13 @@ public:
     range_index_iterator_t upper_bound(const index_key_t& key);
 
     std::pair<range_index_iterator_t, range_index_iterator_t> equal_range(const index_key_t& key) override;
+    std::shared_ptr<common::iterators::generator_t<index_record_t>> equal_range_generator(
+        gaia_txn_id_t txn_id,
+        const index_key_t& key) override;
+    std::shared_ptr<common::iterators::generator_t<index_record_t>> range_generator(
+        gaia_txn_id_t txn_id,
+        std::optional<index_key_t> lower_bound,
+        std::optional<index_key_t> upper_bound);
 };
 
 } // namespace index

--- a/production/db/inc/query_processor/index_scan_physical.inc
+++ b/production/db/inc/query_processor/index_scan_physical.inc
@@ -14,10 +14,27 @@ bool base_index_scan_physical_t::is_visible(const db::index::index_record_t& rec
     return db::locator_exists(rec.locator) && db::locator_to_offset(rec.locator) == rec.offset;
 }
 
+template <typename T_index, typename T_index_iterator>
+std::pair<T_index_iterator, T_index_iterator> compute_range_iterators(T_index*, index_range_predicate_t&)
+{
+    // index_range_predicates are only supported on RANGE indexes.
+    throw index::index_operation_not_supported();
+}
+
+template <>
+std::pair<db::index::range_index_iterator_t, db::index::range_index_iterator_t> compute_range_iterators(db::index::range_index_t* index, index_range_predicate_t& predicate)
+{
+    std::pair<db::index::range_index_iterator_t, db::index::range_index_iterator_t> result;
+
+    result.first = (predicate.lower_bound().key()) ? index->lower_bound(*predicate.lower_bound().key()) : index->begin();
+    result.second = (predicate.upper_bound().key()) ? index->upper_bound(*predicate.upper_bound().key()) : index->end();
+
+    return result;
+}
+
 // Helper to get iterators for querying client-side indexes
 template <typename T_index, typename T_index_iterator>
-std::pair<T_index_iterator, T_index_iterator>
-local_iterator_helper(T_index* index, index_predicate_t& predicate)
+std::pair<T_index_iterator, T_index_iterator> local_iterator_helper(T_index* index, index_predicate_t& predicate)
 {
     std::pair<T_index_iterator, T_index_iterator> result;
 
@@ -28,9 +45,22 @@ local_iterator_helper(T_index* index, index_predicate_t& predicate)
         result.second = index->end();
         break;
     case messages::index_query_t::index_equal_range_query_t:
-    case messages::index_query_t::index_point_read_query_t:
-        result = index->equal_range(predicate.key());
+    {
+        auto& key = static_cast<index_equal_range_predicate_t&>(predicate).key();
+        result = index->equal_range(key);
         break;
+    }
+    case messages::index_query_t::index_point_read_query_t:
+    {
+        auto& key = static_cast<index_point_read_predicate_t&>(predicate).key();
+        result = index->equal_range(key);
+        break;
+    }
+    case messages::index_query_t::index_range_query_t:
+    {
+        result = compute_range_iterators<T_index, T_index_iterator>(index, static_cast<index_range_predicate_t&>(predicate));
+        break;
+    }
     default:
         ASSERT_UNREACHABLE("Unknown query type.");
     }
@@ -44,14 +74,6 @@ local_iterator_helper(T_index* index, index_predicate_t& predicate)
 template <typename T_index, typename T_index_iterator>
 void index_scan_physical_t<T_index, T_index_iterator>::init()
 {
-    auto rec_generator = scan_generator_t::get_record_generator_for_index(
-        m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
-
-    // Only return visible records from remote.
-    m_remote_it = remote_scan_iterator_t(
-        rec_generator,
-        is_visible);
-
     auto idx_iter = db::get_indexes()->find(m_index_id);
 
     ASSERT_PRECONDITION(idx_iter != db::get_indexes()->end(), "Index does not exist.");
@@ -70,6 +92,13 @@ void index_scan_physical_t<T_index, T_index_iterator>::init()
         m_local_it = static_cast<T_index*>(m_index.get())->begin();
         m_local_it_end = static_cast<T_index*>(m_index.get())->end();
     }
+
+    auto rec_generator = scan_generator_t::get_record_generator_for_index(m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
+
+    // Only return visible records from remote.
+    m_remote_it = remote_scan_iterator_t(
+        rec_generator,
+        is_visible);
 
     // Advance local iterator to first visible record.
     if (!local_end() && !is_visible(m_local_it->second))

--- a/production/db/inc/query_processor/index_scan_physical.inc
+++ b/production/db/inc/query_processor/index_scan_physical.inc
@@ -22,7 +22,8 @@ std::pair<T_index_iterator, T_index_iterator> compute_range_iterators(T_index*, 
 }
 
 template <>
-std::pair<db::index::range_index_iterator_t, db::index::range_index_iterator_t> compute_range_iterators(db::index::range_index_t* index, index_range_predicate_t& predicate)
+std::pair<db::index::range_index_iterator_t, db::index::range_index_iterator_t>
+compute_range_iterators(db::index::range_index_t* index, index_range_predicate_t& predicate)
 {
     std::pair<db::index::range_index_iterator_t, db::index::range_index_iterator_t> result;
 
@@ -93,11 +94,11 @@ void index_scan_physical_t<T_index, T_index_iterator>::init()
         m_local_it_end = static_cast<T_index*>(m_index.get())->end();
     }
 
-    auto rec_generator = scan_generator_t::get_record_generator_for_index(m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
+    auto record_generator = scan_generator_t::get_record_generator_for_index(m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
 
     // Only return visible records from remote.
     m_remote_it = remote_scan_iterator_t(
-        rec_generator,
+        record_generator,
         is_visible);
 
     // Advance local iterator to first visible record.

--- a/production/db/inc/query_processor/predicate.hpp
+++ b/production/db/inc/query_processor/predicate.hpp
@@ -91,7 +91,7 @@ public:
 
 private:
     std::optional<index::index_key_t> m_key;
-    bool m_inclusive;
+    bool m_is_inclusive;
 };
 
 // Range predicate for indexes.

--- a/production/db/inc/query_processor/predicate.hpp
+++ b/production/db/inc/query_processor/predicate.hpp
@@ -46,15 +46,7 @@ public:
 
     // flatbuffers query object.
     // By default, returns empty flatbuffers union.
-<<<<<<< HEAD
-    virtual serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& fbb) const;
-    const index::index_key_t& key() const;
-
-protected:
-    index::index_key_t m_key;
-=======
     virtual serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& fbb) const;
->>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 // Point read predicate for indexes.
@@ -66,15 +58,11 @@ public:
     ~index_point_read_predicate_t() override = default;
 
     gaia::db::messages::index_query_t query_type() const override;
-<<<<<<< HEAD
-    serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& fbb) const override;
-=======
     serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& fbb) const override;
     const index::index_key_t& key() const;
 
 private:
     index::index_key_t m_key;
->>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 // Equal range predicate for indexes.
@@ -86,9 +74,6 @@ public:
     ~index_equal_range_predicate_t() override = default;
 
     gaia::db::messages::index_query_t query_type() const override;
-<<<<<<< HEAD
-    serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& builder) const override;
-=======
     serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& builder) const override;
     const index::index_key_t& key() const;
 
@@ -127,7 +112,6 @@ private:
     common::gaia_id_t m_index_id;
     range_bound_t m_lower_bound;
     range_bound_t m_upper_bound;
->>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 } // namespace scan

--- a/production/db/inc/query_processor/predicate.hpp
+++ b/production/db/inc/query_processor/predicate.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "gaia_internal/db/gaia_ptr.hpp"
 
 #include "index.hpp"
@@ -31,8 +33,6 @@ class index_predicate_t
 {
 public:
     index_predicate_t() = default;
-    explicit index_predicate_t(index::index_key_t index_key);
-    explicit index_predicate_t(index::index_key_t&& index_key);
     virtual ~index_predicate_t() = default;
 
     // This is the client-side filter.
@@ -46,11 +46,15 @@ public:
 
     // flatbuffers query object.
     // By default, returns empty flatbuffers union.
+<<<<<<< HEAD
     virtual serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& fbb) const;
     const index::index_key_t& key() const;
 
 protected:
     index::index_key_t m_key;
+=======
+    virtual serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& fbb) const;
+>>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 // Point read predicate for indexes.
@@ -62,7 +66,15 @@ public:
     ~index_point_read_predicate_t() override = default;
 
     gaia::db::messages::index_query_t query_type() const override;
+<<<<<<< HEAD
     serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& fbb) const override;
+=======
+    serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& fbb) const override;
+    const index::index_key_t& key() const;
+
+private:
+    index::index_key_t m_key;
+>>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 // Equal range predicate for indexes.
@@ -74,7 +86,48 @@ public:
     ~index_equal_range_predicate_t() override = default;
 
     gaia::db::messages::index_query_t query_type() const override;
+<<<<<<< HEAD
     serialized_index_query_t as_query(common::gaia_id_t index_id, flatbuffers::FlatBufferBuilder& builder) const override;
+=======
+    serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& builder) const override;
+    const index::index_key_t& key() const;
+
+private:
+    index::index_key_t m_key;
+};
+
+// Bound for range query.
+class range_bound_t
+{
+public:
+    range_bound_t(std::optional<index::index_key_t> index_key, bool inclusive);
+    const std::optional<index::index_key_t>& key() const;
+    bool inclusive() const;
+
+private:
+    std::optional<index::index_key_t> m_key;
+    bool m_inclusive;
+};
+
+// Range predicate for indexes.
+class index_range_predicate_t : public index_predicate_t
+{
+public:
+    index_range_predicate_t(common::gaia_id_t index_id, range_bound_t lower_bound, range_bound_t upper_bound);
+    ~index_range_predicate_t() override = default;
+
+    const range_bound_t& lower_bound() const;
+    const range_bound_t& upper_bound() const;
+
+    gaia::db::messages::index_query_t query_type() const override;
+    serialized_index_query_t as_query(flatbuffers::FlatBufferBuilder& builder) const override;
+    bool filter(const gaia_ptr_t& ptr) const override;
+
+private:
+    common::gaia_id_t m_index_id;
+    range_bound_t m_lower_bound;
+    range_bound_t m_upper_bound;
+>>>>>>> INDEX: Internal APIs for range queries on index
 };
 
 } // namespace scan

--- a/production/db/inc/query_processor/predicate.hpp
+++ b/production/db/inc/query_processor/predicate.hpp
@@ -100,9 +100,9 @@ private:
 class range_bound_t
 {
 public:
-    range_bound_t(std::optional<index::index_key_t> index_key, bool inclusive);
+    range_bound_t(std::optional<index::index_key_t> index_key, bool is_inclusive);
     const std::optional<index::index_key_t>& key() const;
-    bool inclusive() const;
+    bool is_inclusive() const;
 
 private:
     std::optional<index::index_key_t> m_key;

--- a/production/db/index/src/range_index.cpp
+++ b/production/db/index/src/range_index.cpp
@@ -73,8 +73,8 @@ std::shared_ptr<common::iterators::generator_t<index_record_t>> range_index_t::r
 {
     std::lock_guard<std::recursive_mutex> lock(m_index_lock);
 
-    auto lower_iter = (lower_bound.has_value()) ? m_data.lower_bound(*lower_bound) : m_data.begin();
-    auto upper_iter = (upper_bound.has_value()) ? m_data.upper_bound(*upper_bound) : m_data.end();
+    range_type_t::const_iterator lower_iter = (lower_bound.has_value()) ? m_data.lower_bound(*lower_bound) : m_data.cbegin();
+    range_type_t::const_iterator upper_iter = (upper_bound.has_value()) ? m_data.upper_bound(*upper_bound) : m_data.cend();
 
     return std::make_shared<index_generator_t<range_type_t>>(get_lock(), lower_iter, upper_iter, txn_id);
 }

--- a/production/db/payload_types/src/data_buffer.cpp
+++ b/production/db/payload_types/src/data_buffer.cpp
@@ -47,7 +47,9 @@ void data_write_buffer_t::write(const char* buffer, size_t size)
 
 serialization_output_t data_write_buffer_t::output()
 {
-    return m_builder.CreateVector(m_buffer);
+    auto result = m_builder.CreateVector(m_buffer);
+    m_buffer.clear();
+    return result;
 }
 
 } // namespace payload_types

--- a/production/db/query_processor/src/predicate.cpp
+++ b/production/db/query_processor/src/predicate.cpp
@@ -101,7 +101,7 @@ const index::index_key_t& index_point_read_predicate_t::key() const
 }
 
 range_bound_t::range_bound_t(std::optional<index::index_key_t> index_key, bool is_inclusive)
-    : m_key(index_key), m_inclusive(is_inclusive)
+    : m_key(index_key), m_is_inclusive(is_inclusive)
 {
 }
 
@@ -111,7 +111,7 @@ const std::optional<index::index_key_t>& range_bound_t::key() const
 }
 bool range_bound_t::is_inclusive() const
 {
-    return m_inclusive;
+    return m_is_inclusive;
 }
 
 index_range_predicate_t::index_range_predicate_t(gaia_id_t index_id, range_bound_t lower_bound, range_bound_t upper_bound)

--- a/production/db/query_processor/tests/test_index_scan.cpp
+++ b/production/db/query_processor/tests/test_index_scan.cpp
@@ -6,6 +6,7 @@
 // or at https://opensource.org/licenses/MIT.
 ////////////////////////////////////////////////////
 
+#include <optional>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -29,6 +30,8 @@ using namespace gaia::db::catalog_core;
 
 constexpr size_t c_num_initial_rows = 20;
 constexpr size_t c_query_limit_rows = 5;
+constexpr size_t c_num_inclusive_rows = 5;
+constexpr size_t c_num_exclusive_rows = 3;
 constexpr const char* c_no_match_str = "no match";
 
 class db__query_processor__index_scan__test : public gaia::db::db_catalog_test_base_t
@@ -554,6 +557,108 @@ TEST_F(db__query_processor__index_scan__test, query_local_modify_match)
     }
 
     EXPECT_EQ(num_results, 1);
+
+    gaia::db::rollback_transaction();
+}
+
+TEST_F(db__query_processor__index_scan__test, query_range)
+{
+    // Lookup index_id for integer field.
+    gaia_id_t type_record_id = type_id_mapping_t::instance().get_record_id(gaia::index_sandbox::sandbox_t::s_gaia_type);
+    gaia_id_t range_index_id = c_invalid_gaia_id;
+    gaia_id_t hash_index_id = c_invalid_gaia_id;
+
+    gaia::db::begin_transaction();
+
+    for (const auto& index : catalog_core_t::list_indexes(type_record_id))
+    {
+        for (const auto& field_id : *index.fields())
+        {
+            const auto& field = field_view_t(gaia::db::id_to_ptr(field_id));
+            if (field.data_type() == data_type_t::e_int32 && index.type() == index_type_t::range)
+            {
+                range_index_id = index.id();
+                break;
+            }
+            else if (field.data_type() == data_type_t::e_int32 && index.type() == index_type_t::hash)
+            {
+                hash_index_id = index.id();
+                break;
+            }
+        }
+    }
+
+    EXPECT_TRUE(range_index_id != c_invalid_gaia_id && hash_index_id != c_invalid_gaia_id);
+
+    auto lower_key = std::make_optional<index_key_t>(1);
+    auto upper_key = std::make_optional<index_key_t>(5);
+    size_t num_results = 0;
+    bool inclusive = true;
+
+    auto lower_bound_inclusive = range_bound_t(lower_key, inclusive);
+    auto upper_bound_inclusive = range_bound_t(upper_key, inclusive);
+
+    inclusive = false;
+
+    auto lower_bound_exclusive = range_bound_t(lower_key, inclusive);
+    auto upper_bound_exclusive = range_bound_t(upper_key, inclusive);
+
+    auto null_bound = range_bound_t(std::nullopt, inclusive);
+
+    auto range_predicate
+        = std::make_shared<index_range_predicate_t>(range_index_id, lower_bound_inclusive, upper_bound_inclusive);
+
+    for (const auto& scan : index_scan_t(range_index_id, range_predicate))
+    {
+        (void)scan;
+        ++num_results;
+    }
+
+    EXPECT_EQ(num_results, c_num_inclusive_rows);
+
+    num_results = 0;
+    range_predicate
+        = std::make_shared<index_range_predicate_t>(range_index_id, lower_bound_exclusive, upper_bound_exclusive);
+    for (const auto& scan : index_scan_t(range_index_id, range_predicate))
+    {
+        (void)scan;
+        ++num_results;
+    }
+
+    EXPECT_EQ(num_results, c_num_exclusive_rows);
+
+    num_results = 0;
+    range_predicate
+        = std::make_shared<index_range_predicate_t>(range_index_id, null_bound, null_bound);
+    for (const auto& scan : index_scan_t(range_index_id, range_predicate))
+    {
+        (void)scan;
+        ++num_results;
+    }
+
+    EXPECT_EQ(num_results, c_num_initial_rows);
+
+    range_predicate
+        = std::make_shared<index_range_predicate_t>(hash_index_id, null_bound, null_bound);
+    ASSERT_THROW(index_scan_t(hash_index_id, range_predicate).begin(), index_operation_not_supported);
+
+    auto w = gaia::index_sandbox::sandbox_writer();
+    w.str = "";
+    w.f = 21.0;
+    w.i = 5;
+    w.insert_row();
+
+    range_predicate
+        = std::make_shared<index_range_predicate_t>(range_index_id, lower_bound_inclusive, upper_bound_inclusive);
+
+    num_results = 0;
+    for (const auto& scan : index_scan_t(range_index_id, range_predicate))
+    {
+        (void)scan;
+        ++num_results;
+    }
+
+    EXPECT_EQ(num_results, c_num_inclusive_rows + 1);
 
     gaia::db::rollback_transaction();
 }

--- a/production/db/query_processor/tests/test_index_scan.cpp
+++ b/production/db/query_processor/tests/test_index_scan.cpp
@@ -570,7 +570,7 @@ TEST_F(db__query_processor__index_scan__test, query_range_inclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : : list_indexes(type_record_id))
+    for (const index_view_t& index : list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {
@@ -657,7 +657,7 @@ TEST_F(db__query_processor__index_scan__test, query_range_exclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : : list_indexes(type_record_id))
+    for (const index_view_t& index : list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {

--- a/production/db/query_processor/tests/test_index_scan.cpp
+++ b/production/db/query_processor/tests/test_index_scan.cpp
@@ -561,7 +561,7 @@ TEST_F(db__query_processor__index_scan__test, query_local_modify_match)
     gaia::db::rollback_transaction();
 }
 
-TEST_F(test_index_scan, query_rang_inclusive)
+TEST_F(db__query_processor__index_scan__test, query_range_inclusive)
 {
     // Lookup index_id for integer field.
     gaia_id_t type_record_id = type_id_mapping_t::instance().get_record_id(gaia::index_sandbox::sandbox_t::s_gaia_type);
@@ -570,7 +570,7 @@ TEST_F(test_index_scan, query_rang_inclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : catalog_core::list_indexes(type_record_id))
+    for (const index_view_t& index : : list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {
@@ -648,7 +648,7 @@ TEST_F(test_index_scan, query_rang_inclusive)
     gaia::db::rollback_transaction();
 }
 
-TEST_F(test_index_scan, query_range_exclusive)
+TEST_F(db__query_processor__index_scan__test, query_range_exclusive)
 {
     // Lookup index_id for integer field.
     gaia_id_t type_record_id = type_id_mapping_t::instance().get_record_id(gaia::index_sandbox::sandbox_t::s_gaia_type);
@@ -657,7 +657,7 @@ TEST_F(test_index_scan, query_range_exclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : catalog_core::list_indexes(type_record_id))
+    for (const index_view_t& index : : list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {

--- a/production/db/query_processor/tests/test_index_scan.cpp
+++ b/production/db/query_processor/tests/test_index_scan.cpp
@@ -184,6 +184,7 @@ TEST_F(db__query_processor__index_scan__test, query_single_match)
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {
             const auto& field = field_view_t(gaia::db::id_to_ptr(field_id));
+            if (field.data_type() == data_type_t::e_int32 && !field.optional() && index.type() == index_type_t::range)
             {
                 range_index_id = index.id();
                 break;
@@ -569,7 +570,7 @@ TEST_F(test_index_scan, query_rang_inclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : catalog_core_t::list_indexes(type_record_id))
+    for (const index_view_t& index : catalog_core::list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {
@@ -656,7 +657,7 @@ TEST_F(test_index_scan, query_range_exclusive)
 
     gaia::db::begin_transaction();
 
-    for (const index_view_t& index : catalog_core_t::list_indexes(type_record_id))
+    for (const index_view_t& index : catalog_core::list_indexes(type_record_id))
     {
         for (const gaia::common::gaia_id_t field_id : *index.fields())
         {


### PR DESCRIPTION
This PR completes the last internal API that was specified but not implemented:

Create RANGE predicates.
Pushdown RANGE predicates.
Query/SCAN range predicates.