### PR TITLE
Cleanup some minor payload_types issues

### DIFF
--- a/production/db/payload_types/CMakeLists.txt
+++ b/production/db/payload_types/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_target(test_record_data_bin ALL DEPENDS ${PAYLOAD_TYPES_TESTS_GENERAT
 
 # Generate flatbuffers files required by test_serializaton.
 add_custom_command(
-  COMMENT "Compiling test_record.fbs with flatbuffers..."
+  COMMENT "Compiling test_serialization.fbs with flatbuffers..."
   OUTPUT ${GEN_DIR}/test_serialization_generated.h
   COMMAND ${FLATBUFFERS_BIN}/flatc
     --cpp -o ${GEN_DIR} ${PROJECT_SOURCE_DIR}/tests/test_serialization.fbs

--- a/production/db/payload_types/src/field_access.cpp
+++ b/production/db/payload_types/src/field_access.cpp
@@ -311,8 +311,8 @@ data_holder_t get_field_value(
 
         // For null strings, the field_value will come back as nullptr,
         // so just set the string_value to nullptr as well.
-        result.hold.string_value = (field_value == nullptr) ? nullptr : field_value->c_str();
         result.is_null = (field_value == nullptr);
+        result.hold.string_value = (field_value == nullptr) ? nullptr : field_value->c_str();
     }
     else
     {
@@ -548,15 +548,15 @@ data_holder_t get_field_array_element(
     result.type = field->type()->element();
     if (flatbuffers::IsInteger(field->type()->element()))
     {
+        result.is_null = false;
         result.hold.integer_value = flatbuffers::GetAnyVectorElemI(
             field_value, field->type()->element(), array_index);
-        result.is_null = false;
     }
     else if (flatbuffers::IsFloat(field->type()->element()))
     {
+        result.is_null = false;
         result.hold.float_value = flatbuffers::GetAnyVectorElemF(
             field_value, field->type()->element(), array_index);
-        result.is_null = false;
     }
     else if (field->type()->element() == reflection::String)
     {
@@ -569,8 +569,8 @@ data_holder_t get_field_array_element(
             throw invalid_serialized_data();
         }
 
-        result.hold.string_value = field_element_value->c_str();
         result.is_null = false;
+        result.hold.string_value = field_element_value->c_str();
     }
     else
     {


### PR DESCRIPTION
Just a few minor fixes for issues noticed while reviewing this code for null support work.

- fixed an incorrect cmake message
- consistently set is_null flag before setting the data when setting a data_holder instance.