### PR TITLE
Add errno literal value to system error messages

### DIFF
--- a/production/inc/gaia_internal/common/system_error.hpp
+++ b/production/inc/gaia_internal/common/system_error.hpp
@@ -40,7 +40,7 @@ private:
 inline void throw_system_error(const std::string& user_info, int err = errno)
 {
     std::stringstream ss;
-    ss << user_info << " (System error code " << err << ": " << ::strerror(err) << ")";
+    ss << user_info << " (System error code " << err << ": " << std::strerror(err) << ")";
     throw system_error(ss.str(), err);
 }
 


### PR DESCRIPTION
A little more information can never hurt, methinks.