### PR TITLE
Move private class sections after public ones and field declarations at the end

### DIFF
--- a/production/db/core/inc/txn_metadata.hpp
+++ b/production/db/core/inc/txn_metadata.hpp
@@ -133,9 +133,6 @@ private:
         txn_metadata_entry_t expected_value, txn_metadata_entry_t desired_value);
 
 private:
-    const gaia_txn_id_t m_ts;
-
-private:
     // This is an effectively infinite array of timestamp entries, indexed by
     // the txn timestamp counter and containing metadata for every txn that has
     // been submitted to the system.
@@ -180,6 +177,9 @@ private:
     // metadata. (We could store the array offset instead, but that would be
     // dangerous when we approach wraparound.)
     static inline std::atomic<uint64_t>* s_txn_metadata_map{nullptr};
+
+private:
+    const gaia_txn_id_t m_ts;
 };
 
 #include "txn_metadata.inc"

--- a/production/db/core/inc/txn_metadata_entry.hpp
+++ b/production/db/core/inc/txn_metadata_entry.hpp
@@ -46,10 +46,6 @@ public:
     friend inline bool operator==(txn_metadata_entry_t a, txn_metadata_entry_t b);
     friend inline bool operator!=(txn_metadata_entry_t a, txn_metadata_entry_t b);
 
-private:
-    const uint64_t m_word;
-
-public:
     inline uint64_t get_word();
 
     static inline void check_ts_size(gaia_txn_id_t ts);
@@ -232,6 +228,9 @@ private:
 
     // The first 3 bits of this value do not correspond to any valid txn status value.
     static constexpr uint64_t c_value_sealed{0b101ULL << c_txn_status_flags_shift};
+
+private:
+    const uint64_t m_word;
 };
 
 #include "txn_metadata_entry.inc"

--- a/production/db/core/inc/type_id_mapping.hpp
+++ b/production/db/core/inc/type_id_mapping.hpp
@@ -41,13 +41,14 @@ private:
     type_id_mapping_t()
         : m_is_initialized(std::make_unique<std::once_flag>()){};
 
+    void init_type_map();
+
+private:
     std::unique_ptr<std::once_flag> m_is_initialized;
     std::shared_mutex m_lock;
 
     // Mapping between ids of the gaia_table records and the corresponding type ID.
     std::unordered_map<common::gaia_type_t, common::gaia_id_t> m_type_map;
-
-    void init_type_map();
 };
 
 } // namespace db


### PR DESCRIPTION
Just some minor shuffling of declarations to ensure that private stuff is at the end and fields are separated from interfaces.