### PR TITLE
Fix broken includes in Cmake translate_ruleset_internal()

### DIFF
--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -335,7 +335,7 @@ function(translate_ruleset_internal)
     COMMAND sleep 1
     COMMAND ${GAIAC_CMD} ${DDL_FILE} -n ${DB_INSTANCE_NAME}
     COMMAND ${GAIAT_CMD} ${ARG_RULESET_FILE} -output ${RULESET_CPP_PATH} -n ${DB_INSTANCE_NAME} --
-      # This variable already contain the leading -I. 
+      # This variable already contains the leading -I. 
       ${GAIAT_INCLUDE_PATH}
       -I ${GAIA_SPDLOG_INC}
       -stdlib=$<IF:$<CONFIG:Debug>,libc++,libstdc++>


### PR DESCRIPTION
This PR fix the failure in Debug built introduced by https://github.com/gaia-platform/GaiaPlatform/pull/1165. The fix is to remove the libc++ headers that apparently never worked because of a trailing `-I`.

eg:
```
-I GaiaPlatform/production/cmake-build-gaiarelease-debug-make/gaia_generated/barn_storage  \
-I  \  <==================================== This was preventing the libc++ include to be included
-I /usr/lib/llvm-13/include/c++/v1/  \
-I /usr/include/c++/10  \
-I /usr/include/x86_64-linux-gnu/c++/10  \
-I /usr/include/c++/10/backward  \
```

The `-I` problem was fixed as part of a later command and hence the presence of the libc++ headers started to make the build to fail.