### PR TITLE
[GAIAPLAT-1901] Add dependency between gaiac and gaia_db_server_exec

### DIFF
--- a/production/catalog/gaiac/CMakeLists.txt
+++ b/production/catalog/gaiac/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(gaiac
 configure_gaia_target(gaiac)
 target_include_directories(gaiac PRIVATE ${GAIA_CATALOG_TOOL_INCLUDES})
 target_link_libraries(gaiac PRIVATE rt gaia_common gaia_catalog gaia_parser flatbuffers tabulate Threads::Threads)
+add_dependencies(gaiac gaia_db_server_exec)
 
 if(ENABLE_STACKTRACE)
   target_link_libraries(gaiac PRIVATE gaia_stack_trace)


### PR DESCRIPTION
GHA sometimes fail with the following problem:

```
2022-01-18T16:31:31.4785106Z #119 632.5 [ 59%] Generating DAC code in /build/production/gaia_generated/direct_access/prerequisites...
2022-01-18T16:31:31.4785956Z #119 632.5 terminate called after throwing an instance of 'gaia::common::system_error'
2022-01-18T16:31:31.4786335Z #119 632.5   what():  execve() failed while executing gaia_db_server! (System error code 2: No such file or directory)
```

It could be due to the fact that `gaiac` does not have a direct dependency to `gaia_db_server_exec` hence the server executable may not be ready by the time we start generating DAC classes.