### PR TITLE
[GAIAPLAT-1901] Add dependency between process_schema_internal() and gaia_db_server_exec

### DIFF
--- a/production/catalog/gaiac/CMakeLists.txt
+++ b/production/catalog/gaiac/CMakeLists.txt
@@ -32,7 +32,6 @@ add_executable(gaiac
 configure_gaia_target(gaiac)
 target_include_directories(gaiac PRIVATE ${GAIA_CATALOG_TOOL_INCLUDES})
 target_link_libraries(gaiac PRIVATE rt gaia_common gaia_catalog gaia_parser flatbuffers tabulate Threads::Threads)
-add_dependencies(gaiac gaia_db_server_exec)
 
 if(ENABLE_STACKTRACE)
   target_link_libraries(gaiac PRIVATE gaia_stack_trace)

--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -236,6 +236,7 @@ function(process_schema_internal)
     COMMAND ${GAIAC_COMMAND} ${GAIAC_ARGS}
     DEPENDS ${ARG_DDL_FILE}
     DEPENDS gaiac
+    DEPENDS gaia_db_server_exec
   )
 
   if(NOT DEFINED ARG_LIB_NAME)


### PR DESCRIPTION
Fix the wrong dependency added in #1217. `gaiac` does not need to depend on `gaia_db_server` it should be the `process_schema_internal()` function that does.