### PR TITLE
GAIAPLAT-1787 : Fixing duplicate builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches:
       - master
-  pull_request_target:
-    branches:
-      - master
 env:
   GAIA_VERSION: 0.3.3
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock


### PR DESCRIPTION
https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1787

The `pull_request_target` was causing the build to happen on both the source and target branches.