### PR TITLE
Fix incorrect clang version

### DIFF
--- a/production/gdev.cfg
+++ b/production/gdev.cfg
@@ -62,7 +62,7 @@ update-alternatives --install "/usr/bin/python3" "python3" "/usr/bin/python3.8" 
 # Enable the Postgres FDW to run under AddressSanitizer.
 # We can't put this in third_party/production/postgresql/gdev.cfg because clang-13 isn't yet available when that is run.
 mkdir -p /etc/postgresql/12/main
-echo "LD_PRELOAD = '$(clang-10 -print-file-name=libclang_rt.asan-$(uname -m).so)'" >> /etc/postgresql/12/main/environment
+echo "LD_PRELOAD = '$(clang-13 -print-file-name=libclang_rt.asan-$(uname -m).so)'" >> /etc/postgresql/12/main/environment
 echo "ASAN_OPTIONS = 'detect_leaks=0'" >> /etc/postgresql/12/main/environment
 
 # Default persistent store location.


### PR DESCRIPTION
The clang version used to find the ASan shared lib for the Postgres FDW was incorrectly changed to 10 in this commit:
```
commit da184a7f2e8036f01069e19a7384a4b223f2277a
Author: JackAtGaia <86691241+JackAtGaia@users.noreply.github.com>
Date:   Tue Jan 18 16:31:17 2022 -0800

    Implementation of GitHub Actions for Build Workflow (#1213)

diff --git a/production/gdev.cfg b/production/gdev.cfg

 # Enable the Postgres FDW to run under AddressSanitizer.
-# We can't put this in third_party/production/postgresql/gdev.cfg because clang isn't yet available when that is run.
-echo "LD_PRELOAD = '$(clang-13 -print-file-name=libclang_rt.asan-$(uname -m).so)'" >> /etc/postgresql/12/main/environment
+# We can't put this in third_party/production/postgresql/gdev.cfg because clang-13 isn't yet available when that is run.
+mkdir -p /etc/postgresql/12/main
+echo "LD_PRELOAD = '$(clang-10 -print-file-name=libclang_rt.asan-$(uname -m).so)'" >> /etc/postgresql/12/main/environment
```
This PR reverts the version to 13.