### PR TITLE
Fix build failure due to all tables marked as system tables

### DIFF
--- a/production/catalog/src/ddl_executor.cpp
+++ b/production/catalog/src/ddl_executor.cpp
@@ -916,7 +916,7 @@ gaia_id_t ddl_executor_t::create_table_impl(
     gaia_table_writer table_w;
     table_w.name = table_name.c_str();
     table_w.type = table_type;
-    table_w.is_system = true;
+    table_w.is_system = is_system;
     gaia_id_t table_id = table_w.insert_row();
     gaia_table_t gaia_table = gaia_table_t::get(table_id);
 

--- a/production/catalog/tests/test_ddl_executor.cpp
+++ b/production/catalog/tests/test_ddl_executor.cpp
@@ -108,6 +108,26 @@ TEST_F(ddl_executor_test, create_table)
     ASSERT_THROW(create_table(test_db_name, test_table_name, fields), table_already_exists);
 }
 
+TEST_F(ddl_executor_test, system_tables)
+{
+    string test_table_name{"create_table_test"};
+    ddl::field_def_list_t fields;
+    gaia_id_t table_id = create_table(test_table_name, fields);
+
+    auto_transaction_t txn;
+
+    ASSERT_FALSE(gaia_table_t::get(table_id).is_system());
+
+    for (gaia_table_t gaia_table : gaia_table_t::list())
+    {
+        if (strcmp(c_catalog_db_name.c_str(), gaia_table.database().name()) == 0
+            || strcmp(c_event_log_db_name.c_str(), gaia_table.database().name()) == 0)
+        {
+            ASSERT_TRUE(gaia_table.is_system());
+        }
+    }
+}
+
 TEST_F(ddl_executor_test, create_existing_table)
 {
     string test_table_name{"create_existing_table"};


### PR DESCRIPTION
- Fixes a bug introduced in 3eca9d7289a0e14ce8ecb7e1e51580d532833ce8 that would mark all the tables (including user-defined ones) as system tables. This leads to the translation engine not seeing any table because it skips the system tables.
- Add regression test.