### PR TITLE
Rename private set_record() method to set()

### DIFF
--- a/production/catalog/src/dac_generator.cpp
+++ b/production/catalog/src/dac_generator.cpp
@@ -840,7 +840,7 @@ std::string class_writer_t::generate_ref_class_cpp()
     code += "if (dac_base_reference_t::disconnect(this->gaia_id()))";
     code += "{";
     code.IncrementIdentLevel();
-    code += "this->set_record(gaia::common::c_invalid_gaia_id);";
+    code += "this->set(gaia::common::c_invalid_gaia_id);";
     code += "return true;";
     code.DecrementIdentLevel();
     code += "}";
@@ -856,7 +856,7 @@ std::string class_writer_t::generate_ref_class_cpp()
     code += "if (dac_base_reference_t::connect(this->gaia_id(), id))";
     code += "{";
     code.IncrementIdentLevel();
-    code += "this->set_record(id);";
+    code += "this->set(id);";
     code += "return true;";
     code.DecrementIdentLevel();
     code += "}";

--- a/production/direct_access/src/dac_base.cpp
+++ b/production/direct_access/src/dac_base.cpp
@@ -235,7 +235,7 @@ gaia_id_t* dac_base_t::references() const
     return to_const_ptr<gaia_ptr_t>()->references();
 }
 
-void dac_base_t::set_record(common::gaia_id_t new_id)
+void dac_base_t::set(common::gaia_id_t new_id)
 {
     *(to_ptr<gaia_ptr_t>()) = gaia_ptr_t::from_gaia_id(new_id);
 }

--- a/production/inc/gaia/direct_access/dac_base.hpp
+++ b/production/inc/gaia/direct_access/dac_base.hpp
@@ -102,7 +102,7 @@ protected:
     template <typename T_ptr>
     constexpr T_ptr* to_ptr();
 
-    void set_record(common::gaia_id_t new_id);
+    void set(common::gaia_id_t new_id);
 
 private:
     /**


### PR DESCRIPTION
This method is private, but is still listed in public headers. Given the debate of what term to use for database records and the fact that this method doesn't really need to mention that, I renamed it simply to `set()`.