### PR TITLE
GAIAPLAT-1963 - Small change to 'fix_double_empty_lines.py' to bypass binary files.

### DIFF
--- a/dev_tools/github-actions/pre-commit-hooks/fix_double_empty_lines.py
+++ b/dev_tools/github-actions/pre-commit-hooks/fix_double_empty_lines.py
@@ -26,25 +26,30 @@ def __process_command_line():
 
 def __fix_file(filename):
 
-    with open(filename, mode="rt", encoding=__DEFAULT_FILE_ENCODING) as file_processed:
-        lines = file_processed.readlines()
-    newlines = lines[:]
-    line_index = 0
-    last_line_was_blank = False
-    while line_index < len(newlines):
-        this_line_is_blank = newlines[line_index] == "\n"
-        if this_line_is_blank and last_line_was_blank:
-            del newlines[line_index]
-        else:
-            last_line_was_blank = this_line_is_blank
-            line_index += 1
-    if newlines != lines:
+    try:
         with open(
-            filename, mode="wt", encoding=__DEFAULT_FILE_ENCODING
+            filename, mode="rt", encoding=__DEFAULT_FILE_ENCODING
         ) as file_processed:
-            for line in newlines:
-                file_processed.write(line)
-        return True
+            lines = file_processed.readlines()
+        newlines = lines[:]
+        line_index = 0
+        last_line_was_blank = False
+        while line_index < len(newlines):
+            this_line_is_blank = newlines[line_index] == "\n"
+            if this_line_is_blank and last_line_was_blank:
+                del newlines[line_index]
+            else:
+                last_line_was_blank = this_line_is_blank
+                line_index += 1
+        if newlines != lines:
+            with open(
+                filename, mode="wt", encoding=__DEFAULT_FILE_ENCODING
+            ) as file_processed:
+                for line in newlines:
+                    file_processed.write(line)
+            return True
+    except UnicodeDecodeError:
+        print(f"Skipping non-text file '{filename}'.")
     return False
 
 


### PR DESCRIPTION
https://gaiaplatform.atlassian.net/browse/GAIAPLAT-1963

I tested this locally with 3 types of picture files, and they all were skipped due to this change.