### PR TITLE
Add logging for new session termination

### DIFF
--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -1171,6 +1171,7 @@ void server_t::client_dispatch_handler(const std::string& socket_name)
                 {
                     // The connecting client will get ECONNRESET on their first
                     // read from this socket.
+                    std::cerr << "Disconnecting new session because authentication failed or session limit has been exceeded." << std::endl;
                     close_fd(session_socket);
                     continue;
                 }
@@ -1224,6 +1225,7 @@ void server_t::session_handler(int session_socket)
     // directly ensure that `session_limit_exceeded_internal` is thrown in this case.
     if (!reserve_safe_ts_index())
     {
+        std::cerr << "Disconnecting new session because session handler failed to reserve a safe_ts entry index." << std::endl;
         return;
     }
 


### PR DESCRIPTION
We're seeing some new failures suggesting that the session limit on the server has been exceeded, but there are multiple possible causes, so adding some logging to narrow down the cause.