### PR TITLE
Expressions: XOR implementation

### DIFF
--- a/production/direct_access/tests/test_expressions.cpp
+++ b/production/direct_access/tests/test_expressions.cpp
@@ -519,6 +519,30 @@ TEST_F(test_expressions, and_expr)
             .where(hire_date <= date(2021, 1, 1) && hire_date >= date(2036, 2, 7)));
 }
 
+TEST_F(test_expressions, xor_expr)
+{
+    auto_transaction_t txn;
+
+    auto employees = employee_t::list().where(
+        name_first == "Wayne"
+        ^ name_first == "Bill"
+        ^ name_first == "Cristofor");
+
+    assert_contains(employees, {wayne, bill});
+    employees = employee_t::list().where(
+        hire_date <= date(2020, 1, 10)
+        ^ hire_date >= date(2020, 5, 31)
+        ^ name_last == "Cristofor");
+
+    assert_contains(employees, {dax, bill, wayne, laurentiu, simone, mihir});
+
+    employees = employee_t::list().where(
+        hire_date <= date(1991, 1, 1)
+        ^ hire_date >= date(2036, 2, 7));
+
+    assert_empty(employees);
+}
+
 TEST_F(test_expressions, not_expr)
 {
     auto_transaction_t txn;

--- a/production/inc/gaia/expressions/builders/expression_builder.hpp
+++ b/production/inc/gaia/expressions/builders/expression_builder.hpp
@@ -179,6 +179,24 @@ operator||(const T_left& left, const T_right& right)
         expression_bind<T_bind>(left), expression_bind<T_bind>(right));
 }
 
+// ^ operator.
+template <
+    typename T_left,
+    typename T_right,
+    typename T_bind = bind_type<T_left, T_right>,
+    typename T_eval_left = eval_type<T_left>,
+    typename T_eval_right = eval_type<T_right>,
+    typename T_return = xor_type<T_eval_left, T_eval_right>,
+    typename T_token = operator_xor_t,
+    typename T_type_constraint = typename std::enable_if<
+        is_expression<T_left>::value || is_expression<T_right>::value>::type>
+binary_expression_t<T_bind, T_return, T_eval_left, T_eval_right, T_token>
+operator^(const T_left& left, const T_right& right)
+{
+    return binary_expression_t<T_bind, T_return, T_eval_left, T_eval_right, T_token>(
+        expression_bind<T_bind>(left), expression_bind<T_bind>(right));
+}
+
 // ! operator.
 template <
     typename T_operand,

--- a/production/inc/gaia/expressions/operators.hpp
+++ b/production/inc/gaia/expressions/operators.hpp
@@ -194,6 +194,13 @@ evaluate_operator(const T_left& left, const T_right& right, operator_or_t)
     return left || right;
 }
 
+template <typename T_left, typename T_right>
+static inline xor_default_type<T_left, T_right>
+evaluate_operator(const T_left& left, const T_right& right, operator_xor_t)
+{
+    return left ^ right;
+}
+
 template <typename T_operand>
 static inline not_default_type<T_operand>
 evaluate_operator(const T_operand& operand, operator_not_t)


### PR DESCRIPTION
Suggestion: compare against branch yiwen_expr_refactor

This is a small PR for the brownbag demonstrating how operators are implemented as part of the expressions API.

Steps:
1) Add the overload to the AST builder
2) Define evaluate_operator(...) for the operator
3) Write a small unit test.