### PR TITLE
Also disable operator bool() const for int_type_t

### DIFF
--- a/production/db/core/src/gaia_ptr.cpp
+++ b/production/db/core/src/gaia_ptr.cpp
@@ -53,7 +53,7 @@ gaia_ptr_t gaia_ptr_t::find_first(common::gaia_type_t type)
 
 gaia_ptr_t gaia_ptr_t::find_next() const
 {
-    if (m_locator)
+    if (m_locator.is_valid())
     {
         return find_next(to_ptr()->type);
     }

--- a/production/inc/gaia/int_type.hpp
+++ b/production/inc/gaia/int_type.hpp
@@ -57,6 +57,7 @@ public:
 
     // Disable conversions to bool.
     explicit operator bool() = delete;
+    explicit operator bool() const = delete;
 
     // Returns whether the contained value is set
     // to a different value than the default_invalid_value.


### PR DESCRIPTION
Turns out that C++ will still provide a default implementation for the const version of this operator that also needs to be explicitly deleted. Fortunately, I had noticed some code in the event manager test that did not generate an error like all the other places and I traced that down to the fact that it was using this alternate operator. After disabling this operator, I found one more place that relied on it and fixed that as well.

C++ is amazing!