### PR TITLE
Fix memory manager check broken by recent change

### DIFF
--- a/production/db/memory_manager/src/memory_manager.cpp
+++ b/production/db/memory_manager/src/memory_manager.cpp
@@ -175,7 +175,7 @@ chunk_offset_t memory_manager_t::allocate_chunk()
 {
     // First try to reuse a deallocated chunk.
     chunk_offset_t allocated_chunk_offset = allocate_used_chunk();
-    if (!allocated_chunk_offset.is_valid())
+    if (allocated_chunk_offset.is_valid())
     {
 #ifdef DEBUG
         // In debug mode, we write-protect all allocations after writes are


### PR DESCRIPTION
I inverted a checked condition by mistake when updating it to not use the invalid value constant.