### PR TITLE
GAIAPLAT-1781: Fix sporadic failure in test_two_rules

### DIFF
--- a/production/rules/event_manager/tests/test_rule_integration.cpp
+++ b/production/rules/event_manager/tests/test_rule_integration.cpp
@@ -52,7 +52,6 @@ atomic<int> g_wait_for_count;
 atomic<int> g_num_conflicts;
 bool g_manual_commit;
 
-// When an employee is inserted insert an address.
 void rule_insert(const rule_context_t* context)
 {
     employee_t e = employee_t::get(context->record);
@@ -61,6 +60,7 @@ void rule_insert(const rule_context_t* context)
     g_wait_for_count--;
 }
 
+// When an employee is inserted insert an address.
 void rule_insert_address(const rule_context_t* context)
 {
     employee_t e = employee_t::get(context->record);
@@ -487,7 +487,6 @@ TEST_F(rule_integration_test, test_two_rules)
         txn.commit();
 
         // Update second record.
-        employee_t::delete_row(first);
         writer = employee_t::get(second).writer();
         writer.name_first = c_name;
         writer.update_row();


### PR DESCRIPTION
**_Sadness_** is that this was an actual bug in the test introduced when I made the change a long time ago not to call a rule if its anchor row was deleted out from under it.  There was a race condition when:

1. txn1: inserts two rows and commits.  This enqueues two rule invocations that fire on insert.
2. txn2: deletes the first row and updates the second.  This enqueues a rule invocation for an update.
3. If the insert rules were able to run before the row got deleted, then the test would pass
4. otherwise only 2 rules are invoked, instead of the expected 3

I was finally able to reproduce this test (and verify the fix) by running this test 50,000 times.

**_Happiness_** is that this was, in fact, a test bug, and not an issue with the scheduler.