### PR TITLE
Update comment on manual closing of client fd

### DIFF
--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -143,6 +143,9 @@ client_t::get_stream_generator_for_socket(std::shared_ptr<int> stream_socket_ptr
                 // We received EOF from the server, so tell the caller to stop iterating.
                 // We also close the socket here to make it easier to detect further calls
                 // into the iterator, which would now hit the earlier assertion.
+                // This early close is also an optimization to allow the server to close
+                // its cursor socket and terminate its cursor thread immediately
+                // after the client detects the end of iteration.
                 //
                 // See: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-2056
                 // for additional discussion of this code.


### PR DESCRIPTION
It seems safer to let the client fd be closed when its enclosing `shared_ptr` would finally get destroyed.

This doesn't seem to affect much about 1475, but I thought of checking it in separately. Let me know what you think, @senderista .