### PR TITLE
Disable new txn log allocation

### DIFF
--- a/production/db/core/inc/db_client.inc
+++ b/production/db/core/inc/db_client.inc
@@ -84,19 +84,19 @@ inline void client_t::txn_log(
     // OLD
 
     // NEW (txn log offsets)
-    {
-        txn_log_t* txn_log = get_txn_log();
-        if (txn_log->record_count == c_max_log_records)
-        {
-            throw transaction_object_limit_exceeded_internal();
-        }
+    // {
+    //     txn_log_t* txn_log = get_txn_log();
+    //     if (txn_log->record_count == c_max_log_records)
+    //     {
+    //         throw transaction_object_limit_exceeded_internal();
+    //     }
 
-        // Initialize the new record and increment the record count.
-        auto& lr = txn_log->log_records[txn_log->record_count++];
-        lr.locator = locator;
-        lr.old_offset = old_offset;
-        lr.new_offset = new_offset;
-    }
+    //     // Initialize the new record and increment the record count.
+    //     auto& lr = txn_log->log_records[txn_log->record_count++];
+    //     lr.locator = locator;
+    //     lr.old_offset = old_offset;
+    //     lr.new_offset = new_offset;
+    // }
     // NEW
 }
 

--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -387,9 +387,10 @@ void client_t::begin_transaction()
     ASSERT_INVARIANT(
         s_txn_id.is_valid(),
         "Begin timestamp should not be invalid!");
-    ASSERT_INVARIANT(
-        s_txn_log_offset != c_invalid_log_offset,
-        "Txn log offset should not be invalid!");
+    // NEW (txn log offsets)
+    // ASSERT_INVARIANT(
+    //     s_txn_log_offset != c_invalid_log_offset,
+    //     "Txn log offset should not be invalid!");
 
     // Apply all txn logs received from the server to our snapshot, in order.
     size_t fds_remaining_count = txn_info->log_fds_to_apply_count();

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -142,7 +142,8 @@ void server_t::handle_begin_txn(
 
     ASSERT_POSTCONDITION(s_txn_id != c_invalid_gaia_txn_id, "Transaction begin timestamp should be valid!");
     ASSERT_POSTCONDITION(s_log.is_set(), "Transaction log should be initialized!");
-    ASSERT_POSTCONDITION(s_txn_log_offset != c_invalid_log_offset, "Transaction log offset should be valid!");
+    // NEW (txn log offsets)
+    // ASSERT_POSTCONDITION(s_txn_log_offset != c_invalid_log_offset, "Transaction log offset should be valid!");
 
     // Send the reply message to the client, with the number of txn log fds to
     // be sent later.
@@ -196,19 +197,19 @@ void server_t::txn_begin(std::vector<int>& txn_log_fds_for_snapshot)
     // OLD
 
     // NEW (txn log offsets)
-    {
-        // Allocate the txn log offset on the server, for rollback-safety if the client session crashes.
-        s_txn_log_offset = allocate_log_offset();
-        if (s_txn_log_offset == c_invalid_log_offset)
-        {
-            throw transaction_log_allocation_failure_internal();
-        }
+    // {
+    //     // Allocate the txn log offset on the server, for rollback-safety if the client session crashes.
+    //     s_txn_log_offset = allocate_log_offset();
+    //     if (s_txn_log_offset == c_invalid_log_offset)
+    //     {
+    //         throw transaction_log_allocation_failure_internal();
+    //     }
 
-        // Update the log header with our begin timestamp and initialize it to empty.
-        txn_log_t* txn_log = gaia::db::get_txn_log();
-        txn_log->begin_ts = s_txn_id;
-        txn_log->record_count = 0;
-    }
+    //     // Update the log header with our begin timestamp and initialize it to empty.
+    //     txn_log_t* txn_log = gaia::db::get_txn_log();
+    //     txn_log->begin_ts = s_txn_id;
+    //     txn_log->record_count = 0;
+    // }
     // NEW
 }
 


### PR DESCRIPTION
The current txn log changes in master are incomplete, and do not include the deallocation implementation (that was included in the next PR, which is in review). I missed that when I extracted the changes that went into the first PR. The result is that the new logs are allocated and written alongside the old logs, but are never deallocated, so the log address space is quickly exhausted. (The test suite doesn't have any tests that run long enough to expose this bug, but @LaurentiuCristofor found it while running a stress test during a bug investigation).

This PR just comments out the code which allocates and writes to the new txn logs. This bug has no bearing on the correctness of the final implementation (which was stress-tested for multiple days); it was an artifact of a rushed effort to extract incremental changes for reviewing convenience.