### PR TITLE
Comment fixes (doxygen)

### DIFF
--- a/production/catalog/gaiac/src/main.cpp
+++ b/production/catalog/gaiac/src/main.cpp
@@ -33,8 +33,9 @@ using namespace gaia::catalog::ddl;
 using namespace gaia::common;
 using namespace gaia::db;
 
+// Use unnamed namespace to restrict external linkage.
 namespace
-{ // Use unnamed namespace to restrict external linkage.
+{
 
 const string c_error_prompt = "ERROR: ";
 const string c_warning_prompt = "WARNING: ";

--- a/production/db/inc/index/hash_index.hpp
+++ b/production/db/inc/index/hash_index.hpp
@@ -23,7 +23,6 @@ using hash_index_iterator_t = index_iterator_t<hash_type_t, hash_type_t::const_i
 /**
  * Actual hash index implementation.
  */
-
 class hash_index_t : public index_t<hash_type_t, hash_index_iterator_t>
 {
 public:

--- a/production/db/inc/index/index.hpp
+++ b/production/db/inc/index/index.hpp
@@ -51,10 +51,9 @@ private:
 
 constexpr size_t c_offset_buffer_size = 32;
 
-/*
+/**
  * Buffer storing data for garbage collecting offsets.
  */
-
 class index_offset_buffer_t
 {
 public:

--- a/production/db/inc/index/index_iterator.hpp
+++ b/production/db/inc/index/index_iterator.hpp
@@ -21,7 +21,6 @@ namespace index
 /**
  * Class iterating over indexes, with locks handled via RAII.
  */
-
 template <typename T_structure, typename T_index_it>
 class index_iterator_t
 {

--- a/production/db/inc/index/index_key.hpp
+++ b/production/db/inc/index/index_key.hpp
@@ -25,8 +25,7 @@ namespace index
 
 /**
  * Schema required to compute index keys from a binary payload.
- **/
-
+ */
 struct index_key_schema_t
 {
     common::gaia_type_t table_type;

--- a/production/db/inc/query_processor/index_scan.hpp
+++ b/production/db/inc/query_processor/index_scan.hpp
@@ -25,7 +25,7 @@ namespace scan
 
 class base_index_scan_physical_t;
 
-/*
+/**
  * Additional scan state for index scans.
  *
  * In future could be modified to also collect statistics.
@@ -64,7 +64,7 @@ inline bool scan_state_t::limit_reached()
  * Instantiating the iterator will cause the init() method
  * of the implementation to be called.
  *
- **/
+ */
 class index_scan_iterator_t
 {
 public:
@@ -89,7 +89,7 @@ private:
 };
 
 /**
- *  This method is a point of entry and is compatible with C++'s range-based for loop.
+ * This method is a point of entry and is compatible with C++'s range-based for loop.
  *
  * Example usage:
  *
@@ -98,8 +98,7 @@ private:
  *   {
  *     ...
  *   }
- *
- **/
+ */
 class index_scan_t
 {
 public:

--- a/production/db/inc/query_processor/index_scan_physical.hpp
+++ b/production/db/inc/query_processor/index_scan_physical.hpp
@@ -68,8 +68,7 @@ protected:
  * - The RPC calls to the server for initialization.
  * - Merge operation between local and remote.
  * - Visibility resolution of locators.
- *
- * */
+ */
 template <typename T_index, typename T_index_iterator>
 class index_scan_physical_t : public base_index_scan_physical_t
 {

--- a/production/db/inc/query_processor/predicate.hpp
+++ b/production/db/inc/query_processor/predicate.hpp
@@ -77,4 +77,4 @@ public:
 } // namespace scan
 } // namespace query_processor
 } // namespace db
-}; // namespace gaia
+} // namespace gaia

--- a/production/db/inc/query_processor/qp_operator.hpp
+++ b/production/db/inc/query_processor/qp_operator.hpp
@@ -22,8 +22,7 @@ namespace query_processor
  *
  * In future, this class should be much more well fleshed out,
  * perhaps with methods like explain()?
- *
- * */
+ */
 class physical_operator_t
 {
 };

--- a/production/db/index/src/index.cpp
+++ b/production/db/index/src/index.cpp
@@ -121,7 +121,7 @@ const std::vector<gaia::db::payload_types::data_holder_t>& index_key_t::values()
     return m_key_values;
 }
 
-/*
+/**
  * Combine hash of all data holders in this key.
  * Repeatedly concatenate hash values and rehash.
  */
@@ -144,7 +144,7 @@ gaia::db::payload_types::data_hash_t index_key_hash::operator()(index_key_t cons
     return prev_hash;
 }
 
-/*
+/**
  * ostream operator overloads
  */
 

--- a/production/db/index/src/index_offset_buffer.cpp
+++ b/production/db/index/src/index_offset_buffer.cpp
@@ -37,6 +37,7 @@ void index_offset_buffer_t::insert(gaia_offset_t offset, common::gaia_type_t typ
     m_offsets[m_size] = std::make_pair<gaia_offset_t, common::gaia_type_t>(std::move(offset), std::move(type));
     ++m_size;
 }
+
 } // namespace index
 } // namespace db
 } // namespace gaia

--- a/production/db/query_processor/src/scan_generators.cpp
+++ b/production/db/query_processor/src/scan_generators.cpp
@@ -99,6 +99,7 @@ std::shared_ptr<int> scan_generator_t::get_record_cursor_socket_for_index(
 
     return stream_socket_ptr;
 }
+
 } // namespace scan
 } // namespace query_processor
 } // namespace db

--- a/production/direct_access/src/dac_base.cpp
+++ b/production/direct_access/src/dac_base.cpp
@@ -25,6 +25,7 @@ namespace direct_access
 //
 // Exception class implementations.
 //
+
 invalid_object_state_internal::invalid_object_state_internal()
 {
     m_message = "An operation was attempted on an object that does not exist.";
@@ -245,6 +246,7 @@ void dac_base_t::set(common::gaia_id_t new_id)
 //
 // dac_base_reference_t implementation
 //
+
 dac_base_reference_t::dac_base_reference_t(gaia_id_t parent, reference_offset_t child_offset)
     : m_parent_id(parent), m_child_offset(child_offset)
 {

--- a/production/examples/direct_access/hospital.cpp
+++ b/production/examples/direct_access/hospital.cpp
@@ -44,10 +44,10 @@ void create_record_insert()
 }
 
 /**
- *  Creates a record using the writer class (patient_writer in this case).
- *  A writer class does not require that values are set for all of the
- *  fields in the class. Fields for which a value is not specified
- *  are assigned a default value. The writer returns a gaia_id_t.
+ * Creates a record using the writer class (patient_writer in this case).
+ * A writer class does not require that values are set for all of the
+ * fields in the class. Fields for which a value is not specified
+ * are assigned a default value. The writer returns a gaia_id_t.
  */
 void create_record_writer()
 {

--- a/production/tools/gaia_translate/inc/table_navigation.h
+++ b/production/tools/gaia_translate/inc/table_navigation.h
@@ -23,7 +23,6 @@ using namespace std;
 
 namespace gaia
 {
-
 namespace translation
 {
 
@@ -76,5 +75,6 @@ private:
     static navigation_code_data_t generate_navigation_code(llvm::StringRef anchor_table, llvm::StringRef anchor_variable, const llvm::StringSet<>& tables, const llvm::StringMap<string>& tags, string& last_table);
     static bool generate_navigation_step(llvm::StringRef source_table, llvm::StringRef source_field, llvm::StringRef destination_table, llvm::StringRef source_variable_name, llvm::StringRef variable_name, navigation_code_data_t& navigation_data);
 };
+
 } // namespace translation
 } // namespace gaia

--- a/production/tools/gaia_translate/src/main.cpp
+++ b/production/tools/gaia_translate/src/main.cpp
@@ -3420,14 +3420,15 @@ public:
                 }
                 else
                 {
-                    insert_data.argument_replacement_map[argument->getSourceRange()] = (Twine("std::vector(")
-                                                                                        + m_rewriter.getRewrittenText(argument->getSourceRange())
-                                                                                        + ","
-                                                                                        + m_rewriter.getRewrittenText(argument->getSourceRange())
-                                                                                        + "+"
-                                                                                        + array_size_expression
-                                                                                        + ")")
-                                                                                           .str();
+                    insert_data.argument_replacement_map[argument->getSourceRange()]
+                        = (Twine("std::vector(")
+                           + m_rewriter.getRewrittenText(argument->getSourceRange())
+                           + ","
+                           + m_rewriter.getRewrittenText(argument->getSourceRange())
+                           + "+"
+                           + array_size_expression
+                           + ")")
+                              .str();
                 }
             }
             else


### PR DESCRIPTION
Just did a pass to verify that doxygen comments use a consistent style. I also fixed some other indentation/formatting issues that I came across.

- I changed C-style comments to documentation comments.
- I fixed some doxygen comments that were terminated in a different way.
- Added some empty lines around namespaces.
- Fixed some other minor issues.
