### PR TITLE
TeamCity build breaks:  fix typo in host execute method

### DIFF
--- a/dev_tools/gdev/gdev/host.py
+++ b/dev_tools/gdev/gdev/host.py
@@ -59,7 +59,7 @@ class Host:
         if Host.__is_drydock_enabled:
             print(f"[execute:{command}]")
         else:
-            await Host.__execute(capture_output=False, command=command, err_ok=err_ok)
+            await Host._execute(capture_output=False, command=command, err_ok=err_ok)
 
     @staticmethod
     async def execute_and_get_lines(command: str, *, err_ok: bool = False) -> Sequence[str]:


### PR DESCRIPTION
TeamCity builds are broken after changes were made by https://github.com/gaia-platform/GaiaPlatform/pull/1367.  We are definitely trying to end of life TeamCity but I wanted to figure out why this error occurred because the PR above was only supposed to be about fixing python linting errors and shouldn't have affected functionality. 

```
File "/opt/TeamCity/buildAgent/work/439cfbd06ea3043d/dev_tools/gdev/gdev/cmd/gen/_abc/build.py", line 190, in main
[16:48:51](http://192.168.0.250:8111/buildConfiguration/GaiaPlatform_ProductionGdev/23465?showLog=23465_238_238)
      await Host.execute(
[16:48:51](http://192.168.0.250:8111/buildConfiguration/GaiaPlatform_ProductionGdev/23465?showLog=23465_239_239)
    File "/opt/TeamCity/buildAgent/work/439cfbd06ea3043d/dev_tools/gdev/gdev/host.py", line 62, in execute
[16:48:51](http://192.168.0.250:8111/buildConfiguration/GaiaPlatform_ProductionGdev/23465?showLog=23465_240_240)
      await Host.__execute(capture_output=False, command=command, err_ok=err_ok)
[16:48:51](http://192.168.0.250:8111/buildConfiguration/GaiaPlatform_ProductionGdev/23465?showLog=23465_241_241)
  AttributeError: type object 'Host' has no attribute '_Host__execute'
```
I do get a successful build with these changes but my deeper concern is that we are using the wrong `hosts.py` file in the first place.  There are two.  The one I changed as well as "the correct one" I assume under `dev_tools/docker_dev/gdev`.