### PR TITLE
Improve unit test validation checks

### DIFF
--- a/production/common/tests/test_multi_process.cpp
+++ b/production/common/tests/test_multi_process.cpp
@@ -186,7 +186,9 @@ TEST_F(gaia_multi_process_test, multi_process_inserts)
         for (auto const& employee : employee_t::list())
         {
             EXPECT_EQ(employee_names.count(employee.name_first()), 1);
+            employee_names.extract(employee.name_first());
         }
+        EXPECT_EQ(employee_names.size(), 0);
         commit_transaction();
 
         // EXCHANGE 2: concurrent transactions.
@@ -214,7 +216,9 @@ TEST_F(gaia_multi_process_test, multi_process_inserts)
         for (auto const& employee : employee_t::list())
         {
             EXPECT_EQ(employee_names.count(employee.name_first()), 1);
+            employee_names.extract(employee.name_first());
         }
+        EXPECT_EQ(employee_names.size(), 0);
         commit_transaction();
 
         end_session();
@@ -326,12 +330,14 @@ TEST_F(gaia_multi_process_test, multi_process_aborts)
 
         // Scan through all resulting rows.
         // See if all objects exist.
-        employee_names = {"Howard", "Henry", "Harold", "Hank"};
+        employee_names = {"Howard", "Henry", "Hank"};
         begin_transaction();
         for (auto const& employee : employee_t::list())
         {
             EXPECT_EQ(employee_names.count(employee.name_first()), 1);
+            employee_names.extract(employee.name_first());
         }
+        EXPECT_EQ(employee_names.size(), 0);
         commit_transaction();
 
         // EXCHANGE 2: concurrent transactions.
@@ -354,12 +360,14 @@ TEST_F(gaia_multi_process_test, multi_process_aborts)
 
         // Scan through all resulting rows.
         // See if all objects exist.
-        employee_names = {"Howard", "Henry", "Harold", "Hank", "Hubert"};
+        employee_names = {"Howard", "Henry", "Hank", "Hubert"};
         begin_transaction();
         for (auto const& employee : employee_t::list())
         {
             EXPECT_EQ(employee_names.count(employee.name_first()), 1);
+            employee_names.extract(employee.name_first());
         }
+        EXPECT_EQ(employee_names.size(), 0);
         commit_transaction();
 
         end_session();

--- a/production/direct_access/tests/test_direct_access.cpp
+++ b/production/direct_access/tests/test_direct_access.cpp
@@ -328,10 +328,14 @@ TEST_F(dac_object_test, pre_post_iterator)
     auto e = employee_t::list().begin();
     auto name_first = (*e).name_first();
     EXPECT_EQ(employee_names.count(name_first), 1);
+    employee_names.extract(name_first);
     EXPECT_STREQ((*e++).name_first(), name_first);
     EXPECT_EQ(employee_names.count((*e).name_first()), 1);
+    employee_names.extract(e->name_first());
     name_first = (*++e).name_first();
     EXPECT_EQ(employee_names.count(name_first), 1);
+    employee_names.extract(name_first);
+    EXPECT_EQ(employee_names.size(), 0);
     EXPECT_STREQ((*e).name_first(), name_first);
     e++;
     EXPECT_EQ(e == employee_t::list().end(), true);

--- a/production/tools/gaia_translate/tests/test_amr_swarm.cpp
+++ b/production/tools/gaia_translate/tests/test_amr_swarm.cpp
@@ -108,10 +108,14 @@ TEST_F(test_amr_swarm, setup_complete_event)
 
     auto robot = configuration.main_pallet_bot();
     EXPECT_EQ(robot_ids.count(robot.id()), 1);
+    robot_ids.extract(robot.id());
     robot = configuration.left_widget_bot();
     EXPECT_EQ(robot_ids.count(robot.id()), 1);
+    robot_ids.extract(robot.id());
     robot = configuration.right_widget_bot();
     EXPECT_EQ(robot_ids.count(robot.id()), 1);
+    robot_ids.extract(robot.id());
+    EXPECT_EQ(robot_ids.size(), 0);
 
     commit_transaction();
 }


### PR DESCRIPTION
This PR improves the validation of some unit tests, to more strictly verify the outcome of table scans.