### PR TITLE
[GAIAPLAT-2102] Workaround to improve the db_hash_map performance.

### DIFF
--- a/production/db/core/inc/db_internal_types.hpp
+++ b/production/db/core/inc/db_internal_types.hpp
@@ -108,7 +108,7 @@ constexpr size_t c_max_types = 64;
 // should be able to solve this by storing locators directly in each object's
 // references array rather than gaia_ids. Other expensive index lookups could be
 // similarly optimized by substituting locators for gaia_ids.
-constexpr size_t c_hash_buckets{1ULL << 20};
+constexpr size_t c_hash_buckets{1ULL << 26};
 
 // This is an array of offsets in the data segment corresponding to object
 // versions, where each array index is referred to as a "locator."


### PR DESCRIPTION
From @senderista: 
> Based on a conversation with Tengiz Kharatishvili , I suggest increasing c_hash_buckets to 2^26 and rerunning the benchmark. Memory usage will be much higher (~1GB for the bucket array, a 64x increase), but this might be acceptable as a quick fix while we prioritize replacing the existing hash map. 

The workaround seems working and fixing https://gaiaplatform.atlassian.net/browse/GAIAPLAT-2097 too. Insertion time is now constant.

I will keep both GAIAPLAT-2102 and GAIAPLAT-2097 open waiting for a better long term solution.