### PR TITLE
Enable performance tests with smaller datasets

### DIFF
--- a/production/direct_access/tests/test_read_perf.cpp
+++ b/production/direct_access/tests/test_read_perf.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using g_timer_t = gaia::common::timer_t;
 
 static const uint64_t c_num_records = 100000;
-static const uint64_t c_num_iterations = 5;
+static const uint64_t c_num_iterations = 1;
 
 // This is a hard limit imposed by the db architecture.
 static const uint64_t c_max_insertion_single_txn = (1 << 16) - 1;
@@ -207,7 +207,7 @@ void insert_data()
     }
 }
 
-TEST_F(test_read_perf, DISABLED_table_scan)
+TEST_F(test_read_perf, table_scan)
 {
     insert_data();
 
@@ -229,7 +229,7 @@ TEST_F(test_read_perf, DISABLED_table_scan)
     run_performance_test(work, "simple_table_t::table_scan", 2);
 }
 
-TEST_F(test_read_perf, DISABLED_table_scan_data_access)
+TEST_F(test_read_perf, table_scan_data_access)
 {
     insert_data();
 
@@ -249,10 +249,10 @@ TEST_F(test_read_perf, DISABLED_table_scan_data_access)
         ASSERT_EQ(c_num_records, i);
     };
 
-    run_performance_test(work, "simple_table_t::table_scan_data_access", 2);
+    run_performance_test(work, "simple_table_t::table_scan_data_access");
 }
 
-TEST_F(test_read_perf, DISABLED_filter_no_match)
+TEST_F(test_read_perf, filter_no_match)
 {
     insert_data();
 
@@ -271,10 +271,10 @@ TEST_F(test_read_perf, DISABLED_filter_no_match)
         ASSERT_EQ(0, i);
     };
 
-    run_performance_test(work, "simple_table_t::filter_no_match", 2);
+    run_performance_test(work, "simple_table_t::filter_no_match");
 }
 
-TEST_F(test_read_perf, DISABLED_filter_match)
+TEST_F(test_read_perf, filter_match)
 {
     insert_data();
 
@@ -293,5 +293,5 @@ TEST_F(test_read_perf, DISABLED_filter_match)
         ASSERT_EQ(c_num_records / 2, i);
     };
 
-    run_performance_test(work, gaia_fmt::format("simple_table_t::filter_match {} matches", c_num_records / 2), 2);
+    run_performance_test(work, gaia_fmt::format("simple_table_t::filter_match {} matches", c_num_records / 2));
 }


### PR DESCRIPTION
As suggested by @LaurentiuCristofor I'm enabling the performance tests with smaller datasets and just 1 iteration.


1. Make `test_insert_perf` and `test_read_perf` insert/read 100lk records with just 1 iteration. On my machine this takes 5.5seconds for the `test_insert_perf`  and 1.2 seconds for `test_read_perf`.
2. Rename `c_num_insertion` to `c_num_records`

```
Test project /home/simone/repos/GaiaPlatform/production/cmake-build-gaiarelease-debug-llvmtests
      Start 343: test_insert_perf.simple_table_insert
 1/10 Test #343: test_insert_perf.simple_table_insert ..........................................   Passed    0.25 sec
      Start 344: test_insert_perf.simple_table_writer
 2/10 Test #344: test_insert_perf.simple_table_writer ..........................................   Passed    0.23 sec
      Start 345: test_insert_perf.simple_table_2
 3/10 Test #345: test_insert_perf.simple_table_2 ...............................................   Passed    0.26 sec
      Start 346: test_insert_perf.simple_table_index
 4/10 Test #346: test_insert_perf.simple_table_index ...........................................   Passed    0.55 sec
      Start 347: test_insert_perf.simple_relationships
 5/10 Test #347: test_insert_perf.simple_relationships .........................................   Passed    0.56 sec
      Start 348: test_insert_perf.value_linked_relationships_parent_only
 6/10 Test #348: test_insert_perf.value_linked_relationships_parent_only .......................   Passed    0.78 sec
      Start 349: test_insert_perf.value_linked_relationships_child_only
 7/10 Test #349: test_insert_perf.value_linked_relationships_child_only ........................   Passed    1.36 sec
      Start 350: test_insert_perf.value_linked_relationships_autoconnect_to_same_parent
 8/10 Test #350: test_insert_perf.value_linked_relationships_autoconnect_to_same_parent ........   Passed    0.91 sec
      Start 351: test_insert_perf.value_linked_relationships_autoconnect_to_different_parent
 9/10 Test #351: test_insert_perf.value_linked_relationships_autoconnect_to_different_parent ...   Passed    0.72 sec
      Start 352: test_insert_perf.simple_table_concurrent
10/10 Test #352: test_insert_perf.simple_table_concurrent ......................................   Passed    0.23 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =   5.90 sec
```

```
Test project /home/simone/repos/GaiaPlatform/production/cmake-build-gaiarelease-debug-llvmtests
    Start 353: test_read_perf.table_scan
1/4 Test #353: test_read_perf.table_scan ...............   Passed    0.31 sec
    Start 354: test_read_perf.table_scan_data_access
2/4 Test #354: test_read_perf.table_scan_data_access ...   Passed    0.30 sec
    Start 355: test_read_perf.filter_no_match
3/4 Test #355: test_read_perf.filter_no_match ..........   Passed    0.28 sec
    Start 356: test_read_perf.filter_match
4/4 Test #356: test_read_perf.filter_match .............   Passed    0.28 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   1.22 sec
```