### PR TITLE
Skip server-only processing in client calls to update_indexes_from_txn_log()

### DIFF
--- a/production/db/core/inc/db_shared_data.hpp
+++ b/production/db/core/inc/db_shared_data.hpp
@@ -25,6 +25,10 @@ class memory_manager_t;
 class chunk_manager_t;
 } // namespace memory_manager
 
+// Indicates whether the code is executed on server or client.
+extern const bool c_is_running_on_server;
+extern const bool c_is_running_on_client;
+
 // Returns a pointer to a mapping of the "locators" shared memory segment.
 gaia::db::locators_t* get_locators();
 

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -771,10 +771,11 @@ void server_t::init_indexes()
 void server_t::update_indexes_from_txn_log()
 {
     bool replay_logs = true;
-
     create_local_snapshot(replay_logs);
     auto cleanup_local_snapshot = make_scope_guard([]() { s_local_snapshot_locators.close(); });
-    index::index_builder_t::update_indexes_from_txn_log(get_txn_log(), s_server_conf.skip_catalog_integrity_checks());
+
+    index::index_builder_t::update_indexes_from_txn_log(
+        get_txn_log(), s_server_conf.skip_catalog_integrity_checks());
 }
 
 void server_t::recover_db()

--- a/production/db/core/src/db_shared_data_client.cpp
+++ b/production/db/core/src/db_shared_data_client.cpp
@@ -7,6 +7,9 @@
 #include "db_helpers.hpp"
 #include "db_shared_data.hpp"
 
+const bool gaia::db::c_is_running_on_server = false;
+const bool gaia::db::c_is_running_on_client = true;
+
 gaia::db::locators_t* gaia::db::get_locators()
 {
     if (!gaia::db::client_t::s_private_locators.is_set())

--- a/production/db/core/src/db_shared_data_server.cpp
+++ b/production/db/core/src/db_shared_data_server.cpp
@@ -7,6 +7,9 @@
 #include "db_server.hpp"
 #include "db_shared_data.hpp"
 
+const bool gaia::db::c_is_running_on_server = true;
+const bool gaia::db::c_is_running_on_client = false;
+
 gaia::db::locators_t* gaia::db::get_locators()
 {
     // The local snapshot segment should always be mapped whenever any callers

--- a/production/db/query_processor/src/qp_operator.cpp
+++ b/production/db/query_processor/src/qp_operator.cpp
@@ -39,7 +39,6 @@ void db_client_proxy_t::rebuild_local_indexes()
     }
 
     bool allow_create_empty = true;
-
     index::index_builder_t::update_indexes_from_txn_log(
         gaia::db::get_txn_log(), client_t::s_session_options.skip_catalog_integrity_check, allow_create_empty);
 }

--- a/production/inc/gaia_internal/db/index_builder.hpp
+++ b/production/inc/gaia_internal/db/index_builder.hpp
@@ -33,22 +33,26 @@ class index_builder_t
 {
 public:
     static bool index_exists(common::gaia_id_t index_id);
-    static indexes_t::iterator create_empty_index(const catalog_core::index_view_t& index_view, bool skip_catalog_integrity_check = false);
+    static indexes_t::iterator create_empty_index(
+        const catalog_core::index_view_t& index_view, bool skip_catalog_integrity_check = false);
     static void drop_index(const catalog_core::index_view_t& index_view);
     static void update_index(
         db_index_t index, const log_record_t& log_record);
 
     static index_key_t make_key(db_index_t index, const uint8_t* payload);
-    static void serialize_key(common::gaia_id_t index_id, const index_key_t& key, payload_types::data_write_buffer_t& buffer);
+    static void serialize_key(
+        common::gaia_id_t index_id, const index_key_t& key, payload_types::data_write_buffer_t& buffer);
     static index_key_t deserialize_key(common::gaia_id_t index_id, payload_types::data_read_buffer_t& buffer);
 
     static void populate_index(common::gaia_id_t index_id, gaia_locator_t locator);
-    static void update_indexes_from_txn_log(txn_log_t* txn_log, bool skip_catalog_integrity_check, bool allow_create_empty = false);
+    static void update_indexes_from_txn_log(
+        txn_log_t* txn_log, bool skip_catalog_integrity_check, bool allow_create_empty = false);
     static void gc_indexes_from_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets);
     static void mark_index_entries_committed(gaia_txn_id_t txn_id);
 
 private:
-    static index_record_t make_record(gaia_locator_t locator, gaia_offset_t offset, index_record_operation_t operation);
+    static index_record_t make_record(
+        gaia_locator_t locator, gaia_offset_t offset, index_record_operation_t operation);
 
     static void update_index(db_index_t index, index_key_t&& key, index_record_t record);
 };


### PR DESCRIPTION
Also added two constants to simplify checks about whether code is executed on server or client and re-formatted some long lines in the touched files.