### PR TITLE
Implement client incremental index maintenance

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -129,6 +129,9 @@ private:
 
     thread_local static inline int s_session_socket = -1;
 
+    // A log processing watermark that is used for index maintenance.
+    thread_local static inline size_t s_last_index_processed_log = 0;
+
     // A list of data mappings that we manage together.
     // The order of declarations must be the order of data_mapping_t::index_t values!
     thread_local static inline data_mapping_t s_data_mappings[] = {

--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -73,6 +73,9 @@ void client_t::txn_cleanup()
     // Reset transaction log offset.
     s_txn_log_offset = c_invalid_log_offset;
 
+    // Reset the log processing watermark that is used for index building.
+    s_last_index_processed_log = 0;
+
     // Reset TLS events vector for the next transaction that will run on this thread.
     s_events.clear();
 }

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -775,7 +775,7 @@ void server_t::update_indexes_from_txn_log()
     auto cleanup_local_snapshot = make_scope_guard([]() { s_local_snapshot_locators.close(); });
 
     index::index_builder_t::update_indexes_from_txn_log(
-        get_txn_log(), s_server_conf.skip_catalog_integrity_checks());
+        get_txn_log(), 0, s_server_conf.skip_catalog_integrity_checks());
 }
 
 void server_t::recover_db()

--- a/production/db/core/src/index_builder.cpp
+++ b/production/db/core/src/index_builder.cpp
@@ -368,8 +368,16 @@ void index_builder_t::populate_index(common::gaia_id_t index_id, gaia_locator_t 
  * As such, we rely on the logs being sorted by temporal order.
  */
 void index_builder_t::update_indexes_from_txn_log(
-    txn_log_t* txn_log, bool skip_catalog_integrity_check, bool allow_create_empty)
+    txn_log_t* txn_log,
+    size_t last_client_processed_log,
+    bool skip_catalog_integrity_check,
+    bool allow_create_empty)
 {
+    ASSERT_PRECONDITION(c_is_running_on_client || last_client_processed_log == 0, "Server calls to update_indexes_from_txn_log should pass a 'last_client_processed_log' value of 0!")
+    ASSERT_PRECONDITION(
+        last_client_processed_log <= txn_log->record_count,
+        "An unexpected value was detected for last client processed log!");
+
     std::vector<gaia_type_t> dropped_types;
     if (c_is_running_on_server)
     {
@@ -377,10 +385,9 @@ void index_builder_t::update_indexes_from_txn_log(
         // table is created or dropped in the txn.
         // Keep track of dropped tables.
         bool has_cleared_cache = false;
-        for (auto log_record = txn_log->log_records;
-             log_record < txn_log->log_records + txn_log->record_count;
-             ++log_record)
+        for (size_t i = 0; i < txn_log->record_count; ++i)
         {
+            auto log_record = &(txn_log->log_records[i]);
             if ((log_record->operation() == gaia_operation_t::remove
                  || log_record->operation() == gaia_operation_t::create)
                 && offset_to_ptr(
@@ -406,10 +413,9 @@ void index_builder_t::update_indexes_from_txn_log(
     }
 
     gaia_operation_t last_index_operation = gaia_operation_t::not_set;
-    for (auto log_record = txn_log->log_records;
-         log_record < txn_log->log_records + txn_log->record_count;
-         ++log_record)
+    for (size_t i = last_client_processed_log; i < txn_log->record_count; ++i)
     {
+        auto log_record = &(txn_log->log_records[i]);
         db_object_t* obj = offset_to_ptr(
             (log_record->operation() == gaia_operation_t::remove)
                 ? log_record->old_offset
@@ -450,7 +456,7 @@ void index_builder_t::update_indexes_from_txn_log(
             continue;
         }
 
-        ASSERT_INVARIANT(table_id.is_valid(), "Cannot find type table id for object.");
+        ASSERT_INVARIANT(table_id.is_valid(), "Cannot find table id for object type.");
 
         for (const auto& index : catalog_core::list_indexes(table_id))
         {

--- a/production/db/inc/query_processor/qp_operator.hpp
+++ b/production/db/inc/query_processor/qp_operator.hpp
@@ -32,7 +32,7 @@ class db_client_proxy_t
 public:
     static void verify_txn_active();
     static gaia::db::gaia_txn_id_t get_current_txn_id();
-    static void rebuild_local_indexes();
+    static void update_local_indexes();
 };
 
 } // namespace query_processor

--- a/production/db/query_processor/src/index_scan.cpp
+++ b/production/db/query_processor/src/index_scan.cpp
@@ -128,7 +128,7 @@ std::shared_ptr<base_index_scan_physical_t>
 base_index_scan_physical_t::open(common::gaia_id_t index_id, std::shared_ptr<index_predicate_t> predicate)
 {
     db_client_proxy_t::verify_txn_active();
-    db_client_proxy_t::rebuild_local_indexes();
+    db_client_proxy_t::update_local_indexes();
 
     // Get type of index.
     auto it = db::get_indexes()->find(index_id);

--- a/production/db/query_processor/src/qp_operator.cpp
+++ b/production/db/query_processor/src/qp_operator.cpp
@@ -30,17 +30,16 @@ gaia_txn_id_t db_client_proxy_t::get_current_txn_id()
     return client_t::s_txn_id;
 }
 
-void db_client_proxy_t::rebuild_local_indexes()
+void db_client_proxy_t::update_local_indexes()
 {
-    // Clear the indexes.
-    for (const auto& index : client_t::s_local_indexes)
-    {
-        index.second->clear();
-    }
-
     bool allow_create_empty = true;
+    txn_log_t* txn_log = gaia::db::get_txn_log();
     index::index_builder_t::update_indexes_from_txn_log(
-        gaia::db::get_txn_log(), client_t::s_session_options.skip_catalog_integrity_check, allow_create_empty);
+        txn_log,
+        client_t::s_last_index_processed_log,
+        client_t::s_session_options.skip_catalog_integrity_check,
+        allow_create_empty);
+    client_t::s_last_index_processed_log = txn_log->record_count;
 }
 
 } // namespace query_processor

--- a/production/inc/gaia_internal/db/index_builder.hpp
+++ b/production/inc/gaia_internal/db/index_builder.hpp
@@ -46,7 +46,10 @@ public:
 
     static void populate_index(common::gaia_id_t index_id, gaia_locator_t locator);
     static void update_indexes_from_txn_log(
-        txn_log_t* txn_log, bool skip_catalog_integrity_check, bool allow_create_empty = false);
+        txn_log_t* txn_log,
+        size_t last_client_processed_log,
+        bool skip_catalog_integrity_check,
+        bool allow_create_empty = false);
     static void gc_indexes_from_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets);
     static void mark_index_entries_committed(gaia_txn_id_t txn_id);
 


### PR DESCRIPTION
I've changed `rebuild_local_indexes` into `update_local_indexes`, which now incrementally updates the indexes using only the newer log entries since the last call.

The VLR tests show significant improvements, although there is still a lot of work to be done before they near the performance of simple insertions:

BEFORE:
```
349: [value_linked_relationships_parent_only] 1000 records, 3 iterations:
349:    [total]: avg:516.93ms min:513.76ms max:519.56ms
349:   [single]: avg:516.93us min:513.76us max:519.56us

350: [value_linked_relationships_child_only] 1000 records, 3 iterations:
350:    [total]: avg:1097.24ms min:1062.18ms max:1166.19ms
350:   [single]: avg:1097.24us min:1062.18us max:1166.19us

351: [value_linked_relationships_autoconnect_to_same_parent] 501 records, 3 iterations:
351:    [total]: avg:615.74ms min:605.46ms max:627.46ms
351:   [single]: avg:1229.03us min:1208.51us max:1252.41us

352: [value_linked_relationships_autoconnect_to_different_parent] 1000 records, 3 iterations:
352:    [total]: avg:516.74ms min:515.17ms max:518.11ms
352:   [single]: avg:516.74us min:515.17us max:518.11us
```
AFTER: 
```
349: [value_linked_relationships_parent_only] 1000 records, 3 iterations:
349:    [total]: avg:71.83ms min:66.51ms max:76.76ms
349:   [single]: avg:71.83us min:66.51us max:76.76us


350: [value_linked_relationships_child_only] 1000 records, 3 iterations:
350:    [total]: avg:135.66ms min:131.55ms max:142.29ms
350:   [single]: avg:135.66us min:131.55us max:142.29us


351: [value_linked_relationships_autoconnect_to_same_parent] 501 records, 3 iterations:
351:    [total]: avg:45.63ms min:43.11ms max:49.92ms
351:   [single]: avg:91.07us min:86.04us max:99.64us


352: [value_linked_relationships_autoconnect_to_different_parent] 1000 records, 3 iterations:
352:    [total]: avg:73.96ms min:69.43ms max:76.91ms
352:   [single]: avg:73.96us min:69.43us max:76.91us
```