### PR TITLE
Cache indexes by type during index updates from txn log

### DIFF
--- a/production/db/core/src/index_builder.cpp
+++ b/production/db/core/src/index_builder.cpp
@@ -461,7 +461,7 @@ void index_builder_t::update_indexes_from_txn_log(
 
         ASSERT_INVARIANT(table_id.is_valid(), "Cannot find table id for object type.");
 
-        if (!indexes_for_type.count(obj->type))
+        if (indexes_for_type.find(obj->type) == indexes_for_type.end())
         {
             std::vector<catalog_core::index_view_t> indexes;
             auto index_list = catalog_core::list_indexes(table_id);


### PR DESCRIPTION
This brings time/insert for `test_insert_perf.simple_table_insert` down from 0.54us to 0.49us. There's still a ton of wasted work on txn commit for types that aren't indexed, but it's a little better.