### PR TITLE
Clear local indexes on txn cleanup and add comments

### DIFF
--- a/production/db/core/inc/db_client.hpp
+++ b/production/db/core/inc/db_client.hpp
@@ -130,7 +130,7 @@ private:
     thread_local static inline int s_session_socket = -1;
 
     // A log processing watermark that is used for index maintenance.
-    thread_local static inline size_t s_last_index_processed_log = 0;
+    thread_local static inline size_t s_last_index_processed_log_count = 0;
 
     // A list of data mappings that we manage together.
     // The order of declarations must be the order of data_mapping_t::index_t values!

--- a/production/db/core/src/db_client.cpp
+++ b/production/db/core/src/db_client.cpp
@@ -74,7 +74,13 @@ void client_t::txn_cleanup()
     s_txn_log_offset = c_invalid_log_offset;
 
     // Reset the log processing watermark that is used for index building.
-    s_last_index_processed_log = 0;
+    s_last_index_processed_log_count = 0;
+
+    // Clear the local indexes.
+    for (const auto& index : client_t::s_local_indexes)
+    {
+        index.second->clear();
+    }
 
     // Reset TLS events vector for the next transaction that will run on this thread.
     s_events.clear();

--- a/production/db/inc/query_processor/index_scan_physical.inc
+++ b/production/db/inc/query_processor/index_scan_physical.inc
@@ -41,7 +41,8 @@ local_iterator_helper(T_index* index, index_predicate_t& predicate)
 template <typename T_index, typename T_index_iterator>
 void index_scan_physical_t<T_index, T_index_iterator>::init()
 {
-    auto rec_generator = scan_generator_t::get_record_generator_for_index(m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
+    auto rec_generator = scan_generator_t::get_record_generator_for_index(
+        m_index_id, db_client_proxy_t::get_current_txn_id(), m_predicate);
 
     // Only return visible records from remote.
     m_remote_it = remote_scan_iterator_t(
@@ -56,7 +57,8 @@ void index_scan_physical_t<T_index, T_index_iterator>::init()
 
     if (m_predicate)
     {
-        auto range = local_iterator_helper<T_index, T_index_iterator>(static_cast<T_index*>(m_index.get()), *m_predicate);
+        auto range = local_iterator_helper<T_index, T_index_iterator>(
+            static_cast<T_index*>(m_index.get()), *m_predicate);
         m_local_it = range.first;
         m_local_it_end = range.second;
     }
@@ -68,7 +70,9 @@ void index_scan_physical_t<T_index, T_index_iterator>::init()
 
     // Advance local iterator to first visible record.
     if (!local_end() && !is_visible(m_local_it->second))
+    {
         advance_local();
+    }
 
     // Assign the first visible locator.
     next_visible_locator();
@@ -142,7 +146,8 @@ bool index_scan_physical_t<T_index, T_index_iterator>::has_more()
 }
 
 template <typename T_index, typename T_index_iterator>
-db::index::index_key_t index_scan_physical_t<T_index, T_index_iterator>::record_to_key(const db::index::index_record_t& record) const
+db::index::index_key_t index_scan_physical_t<T_index, T_index_iterator>::record_to_key(
+    const db::index::index_record_t& record) const
 {
     auto obj = db::locator_to_ptr(record.locator);
     return db::index::index_builder_t::make_key(m_index, reinterpret_cast<const uint8_t*>(obj->data()));

--- a/production/db/inc/query_processor/qp_operator.hpp
+++ b/production/db/inc/query_processor/qp_operator.hpp
@@ -32,6 +32,10 @@ class db_client_proxy_t
 public:
     static void verify_txn_active();
     static gaia::db::gaia_txn_id_t get_current_txn_id();
+
+    // The client maintains local indexes for uncommitted changes.
+    // These are used to augment the server index information.
+    // The merging is performed in the physical index scan implementation.
     static void update_local_indexes();
 };
 

--- a/production/db/query_processor/src/qp_operator.cpp
+++ b/production/db/query_processor/src/qp_operator.cpp
@@ -32,14 +32,19 @@ gaia_txn_id_t db_client_proxy_t::get_current_txn_id()
 
 void db_client_proxy_t::update_local_indexes()
 {
+    // Update local indexes with our transaction's changes,
+    // using the transaction log.
     bool allow_create_empty = true;
     txn_log_t* txn_log = gaia::db::get_txn_log();
     index::index_builder_t::update_indexes_from_txn_log(
         txn_log,
-        client_t::s_last_index_processed_log,
+        client_t::s_last_index_processed_log_count,
         client_t::s_session_options.skip_catalog_integrity_check,
         allow_create_empty);
-    client_t::s_last_index_processed_log = txn_log->record_count;
+
+    // Update our log processing watermark, so that future calls
+    // will not reprocess the log records that we already processed so far.
+    client_t::s_last_index_processed_log_count = txn_log->record_count;
 }
 
 } // namespace query_processor

--- a/production/inc/gaia_internal/db/index_builder.hpp
+++ b/production/inc/gaia_internal/db/index_builder.hpp
@@ -47,7 +47,7 @@ public:
     static void populate_index(common::gaia_id_t index_id, gaia_locator_t locator);
     static void update_indexes_from_txn_log(
         txn_log_t* txn_log,
-        size_t last_client_processed_log,
+        size_t last_client_processed_log_count,
         bool skip_catalog_integrity_check,
         bool allow_create_empty = false);
     static void gc_indexes_from_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets);


### PR DESCRIPTION
The main functional change is that local indexes are now cleared on txn cleanup. Without this clearing, we'd waste time due to identical index records existing both in the server indexes and in the local indexes. This was a regression from my previous change that removed the index clearing. Placing the clearing on txn cleanup still is an improvement because it prevents it from happening multiple times needlessly.

The rest of this change consists of adding some comments and fixing some existing ones.