### PR TITLE
Only call get_table_id() when type is not found in local cache

### DIFF
--- a/production/db/core/src/index_builder.cpp
+++ b/production/db/core/src/index_builder.cpp
@@ -466,7 +466,7 @@ void index_builder_t::update_indexes_from_txn_log(
             if (!table_id.is_valid())
             {
                 ASSERT_INVARIANT(skip_catalog_integrity_check, "Cannot find table id for object type!");
-                // Map this type to an empty indexes vector.
+                // Map this type to an empty indexes vector, to avoid looking up the table ID again.
                 indexes_for_type.insert({obj->type, {}});
                 continue;
             }


### PR DESCRIPTION
This improves time/insert in `test_insert_perf.simple_table_insert` from 0.49us to 0.46us.