### PR TITLE
Add a quick exit to gc_indexes_from_txn_log()

### DIFF
--- a/production/db/core/inc/db_internal_types.hpp
+++ b/production/db/core/inc/db_internal_types.hpp
@@ -462,6 +462,7 @@ struct id_index_t
 // These are types meant to access index types from the client/server.
 namespace index
 {
+
 class base_index_t;
 typedef std::shared_ptr<base_index_t> db_index_t;
 typedef std::unordered_map<common::gaia_id_t, db_index_t> indexes_t;

--- a/production/db/core/src/index_builder.cpp
+++ b/production/db/core/src/index_builder.cpp
@@ -350,7 +350,6 @@ void index_builder_t::update_index(
 
 void index_builder_t::populate_index(common::gaia_id_t index_id, gaia_locator_t locator)
 {
-    ASSERT_PRECONDITION(get_indexes(), "Indexes are not initialized.");
     auto payload = reinterpret_cast<const uint8_t*>(locator_to_ptr(locator)->data());
 
     auto it = get_indexes()->find(index_id);
@@ -484,7 +483,6 @@ void index_builder_t::update_indexes_from_txn_log(
 
         for (const auto& index : indexes_for_type[obj->type])
         {
-            ASSERT_PRECONDITION(get_indexes(), "Indexes are not initialized.");
             auto it = get_indexes()->find(index.id());
 
             if (allow_create_empty && it == get_indexes()->end())
@@ -525,12 +523,19 @@ void remove_entries_with_offsets(
 
 void index_builder_t::gc_indexes_from_txn_log(txn_log_t* txn_log, bool deallocate_new_offsets)
 {
+    // No indexes, no work needed.
+    if (get_indexes()->empty())
+    {
+        return;
+    }
+
     size_t record_index = 0;
     size_t record_count = txn_log->record_count;
 
     while (record_index < record_count)
     {
         index_offset_buffer_t collected_offsets;
+
         // Fill the offset buffer for garbage collection.
         // Exit the loop when we either have run out of records to process or the offsets buffer is full.
         for (; record_index < record_count && collected_offsets.size() < c_offset_buffer_size; ++record_index)


### PR DESCRIPTION
Two changes:

- added a quick exit for gc_indexes_from_txn_log in the case that there are no indexes.
- removed a couple of asserts that were impossible to trip (get_indexes cannot ever return null).

Recovery tests seem to run a bit faster after this change: ~2.3s instead of ~2.4s. I picked these tests because I've noticed the new exit path being taken multiple times during their execution.