### PR TITLE
Use relaxed loads and stores in bitmap operations

### DIFF
--- a/production/db/memory_manager/src/bitmap.cpp
+++ b/production/db/memory_manager/src/bitmap.cpp
@@ -82,7 +82,7 @@ bool apply_mask_to_word(
 bool try_apply_mask_to_word(
     std::atomic<uint64_t>& word, uint64_t mask, bool set, bool fail_if_already_applied = false)
 {
-     // We read the word once, because other threads may be updating it.
+    // We read the word once, because other threads may be updating it.
     // A relaxed load is sufficient, because a stale read will cause the
     // subsequent CAS to fail.
     uint64_t old_word = word.load(std::memory_order_relaxed);


### PR DESCRIPTION
This improves time/insert by 0.01us in `test_insert_perf.simple_table_concurrent`, tested at 4 and 8 threads. No improvement in single-threaded performance was observed.