### PR TITLE
Remove unused parameteres of db server event handlers

### DIFF
--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -359,22 +359,21 @@ private:
     // Function pointer type that executes side effects of a session state transition.
     // REVIEW: replace void* with std::any?
     typedef void (*transition_handler_fn)(
-        int* fds, size_t fd_count,
         messages::session_event_t event,
         const void* event_data,
         messages::session_state_t old_state,
         messages::session_state_t new_state);
 
     // Session state transition handler functions.
-    static void handle_connect_ddl(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_connect(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_begin_txn(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_rollback_txn(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_commit_txn(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_decide_txn(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_client_shutdown(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_server_shutdown(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
-    static void handle_request_stream(int*, size_t, messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_connect_ddl(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_connect(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_begin_txn(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_rollback_txn(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_commit_txn(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_decide_txn(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_client_shutdown(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_server_shutdown(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
+    static void handle_request_stream(messages::session_event_t, const void*, messages::session_state_t, messages::session_state_t);
 
     struct transition_t
     {
@@ -405,7 +404,7 @@ private:
         {messages::session_state_t::ANY, messages::session_event_t::REQUEST_STREAM, {messages::session_state_t::ANY, handle_request_stream}},
     };
 
-    static void apply_transition(messages::session_event_t event, const void* event_data, int* fds, size_t fd_count);
+    static void apply_transition(messages::session_event_t event, const void* event_data);
 
     static void build_server_reply_info(
         flatbuffers::FlatBufferBuilder& builder,

--- a/production/db/core/src/db_server.cpp
+++ b/production/db/core/src/db_server.cpp
@@ -78,17 +78,17 @@ static constexpr char c_message_preceding_txn_should_have_been_validated[]
 static constexpr char c_message_unexpected_query_type[] = "Unexpected query type!";
 
 void server_t::handle_connect_ddl(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(event == session_event_t::CONNECT_DDL, c_message_unexpected_event_received);
 
     s_is_ddl_session = true;
 
-    handle_connect(nullptr, 0, session_event_t::CONNECT, nullptr, old_state, new_state);
+    handle_connect(session_event_t::CONNECT, nullptr, old_state, new_state);
 }
 
 void server_t::handle_connect(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(event == session_event_t::CONNECT, c_message_unexpected_event_received);
 
@@ -114,7 +114,7 @@ void server_t::handle_connect(
 }
 
 void server_t::handle_begin_txn(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(event == session_event_t::BEGIN_TXN, c_message_unexpected_event_received);
 
@@ -266,7 +266,7 @@ void server_t::release_transaction_resources()
 }
 
 void server_t::handle_rollback_txn(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(event == session_event_t::ROLLBACK_TXN, c_message_unexpected_event_received);
 
@@ -284,7 +284,7 @@ void server_t::handle_rollback_txn(
 }
 
 void server_t::handle_commit_txn(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(event == session_event_t::COMMIT_TXN, c_message_unexpected_event_received);
 
@@ -312,11 +312,11 @@ void server_t::handle_commit_txn(
     }
 
     // REVIEW: This is the only reentrant transition handler, and the only server-side state transition.
-    apply_transition(decision, nullptr, nullptr, 0);
+    apply_transition(decision, nullptr);
 }
 
 void server_t::handle_decide_txn(
-    int*, size_t, session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void*, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(
         event == session_event_t::DECIDE_TXN_COMMIT
@@ -346,7 +346,7 @@ void server_t::handle_decide_txn(
 }
 
 void server_t::handle_client_shutdown(
-    int*, size_t, session_event_t event, const void*, session_state_t, session_state_t new_state)
+    session_event_t event, const void*, session_state_t, session_state_t new_state)
 {
     ASSERT_PRECONDITION(
         event == session_event_t::CLIENT_SHUTDOWN,
@@ -374,7 +374,7 @@ void server_t::handle_client_shutdown(
 }
 
 void server_t::handle_server_shutdown(
-    int*, size_t, session_event_t event, const void*, session_state_t, session_state_t new_state)
+    session_event_t event, const void*, session_state_t, session_state_t new_state)
 {
     ASSERT_PRECONDITION(
         event == session_event_t::SERVER_SHUTDOWN,
@@ -420,7 +420,7 @@ std::pair<int, int> server_t::get_stream_socket_pair()
 }
 
 void server_t::handle_request_stream(
-    int*, size_t, session_event_t event, const void* event_data, session_state_t old_state, session_state_t new_state)
+    session_event_t event, const void* event_data, session_state_t old_state, session_state_t new_state)
 {
     ASSERT_PRECONDITION(
         event == session_event_t::REQUEST_STREAM,
@@ -510,7 +510,7 @@ void server_t::handle_request_stream(
     send_msg_with_fds(s_session_socket, &client_socket, 1, builder.GetBufferPointer(), builder.GetSize());
 }
 
-void server_t::apply_transition(session_event_t event, const void* event_data, int* fds, size_t fd_count)
+void server_t::apply_transition(session_event_t event, const void* event_data)
 {
     if (event == session_event_t::NOP)
     {
@@ -534,7 +534,7 @@ void server_t::apply_transition(session_event_t event, const void* event_data, i
 
             if (t.transition.handler)
             {
-                t.transition.handler(fds, fd_count, event, event_data, old_state, s_session_state);
+                t.transition.handler(event, event_data, old_state, s_session_state);
             }
 
             return;
@@ -1324,8 +1324,6 @@ void server_t::session_handler(int session_socket)
         // Buffer used to receive file descriptors.
         int fd_buf[c_max_fd_count] = {-1};
         size_t fd_buf_size = std::size(fd_buf);
-        int* fds = nullptr;
-        size_t fd_count = 0;
 
         // If the shutdown flag is set, we need to exit immediately before
         // processing the next ready fd.
@@ -1383,12 +1381,6 @@ void server_t::session_handler(int session_socket)
                     const client_request_t* request = msg->msg_as_request();
                     event = request->event();
                     event_data = static_cast<const void*>(request);
-
-                    if (fd_buf_size > 0)
-                    {
-                        fds = fd_buf;
-                        fd_count = fd_buf_size;
-                    }
                 }
                 else
                 {
@@ -1415,7 +1407,7 @@ void server_t::session_handler(int session_socket)
             // exception thrown from that method (translated from EPIPE).
             try
             {
-                apply_transition(event, event_data, fds, fd_count);
+                apply_transition(event, event_data);
             }
             catch (const peer_disconnected& e)
             {


### PR DESCRIPTION
Just some code cleanup to remove some unused method parameters.