### PR TITLE
Use size_t consistently throughout perf test code

### DIFF
--- a/production/direct_access/tests/test_insert_perf_rel.cpp
+++ b/production/direct_access/tests/test_insert_perf_rel.cpp
@@ -62,7 +62,7 @@ TEST_F(test_insert_perf_rel, value_linked_relationships_parent_only)
 {
     // VLR are so slow that we need to use a lower number of insertion to
     // finish in a reasonable amount of time.
-    constexpr uint64_t c_vlr_insertions = c_num_records / 10;
+    constexpr size_t c_vlr_insertions = c_num_records / 10;
 
     auto insert = []() {
         bulk_insert(
@@ -78,7 +78,7 @@ TEST_F(test_insert_perf_rel, value_linked_relationships_child_only)
 {
     // VLR are so slow that we need to use a lower number of insertion to
     // finish in a reasonable amount of time.
-    constexpr uint64_t c_vlr_insertions = c_num_records / 10;
+    constexpr size_t c_vlr_insertions = c_num_records / 10;
 
     auto insert = []() {
         bulk_insert(
@@ -94,7 +94,7 @@ TEST_F(test_insert_perf_rel, value_linked_relationships_autoconnect_to_same_pare
 {
     // VLR are so slow that we need to use a lower number of insertion to
     // finish in a reasonable amount of time.
-    constexpr uint64_t c_vlr_insertions = c_num_records / 50;
+    constexpr size_t c_vlr_insertions = c_num_records / 50;
 
     auto insert = []() {
         gaia::db::begin_transaction();
@@ -119,7 +119,7 @@ TEST_F(test_insert_perf_rel, value_linked_relationships_autoconnect_to_different
 {
     // VLR are so slow that we need to use a lower number of insertion to
     // finish in a reasonable amount of time.
-    constexpr uint64_t c_vlr_insertions = c_num_records / 10;
+    constexpr size_t c_vlr_insertions = c_num_records / 10;
 
     auto insert = []() {
         bulk_insert(

--- a/production/direct_access/tests/test_read_perf_basic.cpp
+++ b/production/direct_access/tests/test_read_perf_basic.cpp
@@ -67,7 +67,7 @@ TEST_F(test_read_perf_basic, table_scan)
     auto work = []() {
         gaia::db::begin_transaction();
 
-        int i = 0;
+        size_t i = 0;
         for ([[maybe_unused]] auto& record :
              simple_table_t::list())
         {
@@ -91,7 +91,7 @@ TEST_F(test_read_perf_basic, table_scan_data_access)
     auto work = []() {
         gaia::db::begin_transaction();
 
-        int i = 0;
+        size_t i = 0;
         for (auto& record : simple_table_t::list())
         {
             (void)record.uint64_field();
@@ -116,7 +116,7 @@ TEST_F(test_read_perf_basic, filter_no_match)
     auto work = []() {
         gaia::db::begin_transaction();
 
-        int i = 0;
+        size_t i = 0;
         for ([[maybe_unused]] auto& record :
              simple_table_t::list().where(simple_table_t::expr::uint64_field > c_num_records))
         {
@@ -140,7 +140,7 @@ TEST_F(test_read_perf_basic, filter_match)
     auto work = []() {
         gaia::db::begin_transaction();
 
-        int i = 0;
+        size_t i = 0;
         for ([[maybe_unused]] auto& record :
              simple_table_t::list().where(simple_table_t::expr::uint64_field >= (c_num_records / 2)))
         {


### PR DESCRIPTION
Just some additional cleanup that I've made while experimenting with the tests.

This change mainly replaces the use of `int64_t`, `uin64_t`, and `int` with `size_t`.