### PR TITLE
Update index maintenance logic to account for system indexes

### DIFF
--- a/production/inc/gaia_internal/catalog/catalog.hpp
+++ b/production/inc/gaia_internal/catalog/catalog.hpp
@@ -33,6 +33,9 @@ namespace catalog
  * @{
  */
 
+// The total count of system indexes.
+constexpr size_t c_system_index_count = 11;
+
 // The top level namespace for all the Gaia generated code.
 const std::string c_gaia_namespace = "gaia";
 


### PR DESCRIPTION
The basic gist of this change is that it updates the logic to skip index maintenance to account for system indexes.

An assertion is added to detect a situation in which the number of system indexes might change without updating the corresponding constant. This check relies on the continuing existence of some tests that do not use any user-level indexes (such as `test_insert_perf_basic`).

Here's the performance improvement for a test with 4 threads doing batches of 6 insertions:
BEFORE:
```
381: [simple_table_t::insert_row_small_txn with 4 threads] 1000000 records, 3 iterations:
381:    [total]: avg:4303.82ms min:4270.01ms max:4345.70ms
381:   [single]: avg:4.30us min:4.27us max:4.35us
```
AFTER:
```
381: [simple_table_t::insert_row_small_txn with 4 threads] 1000000 records, 3 iterations:
381:    [total]: avg:3193.07ms min:3163.89ms max:3216.14ms
381:   [single]: avg:3.19us min:3.16us max:3.22us
```