### PR TITLE
Replace ULL suffix with UL

### DIFF
--- a/production/db/core/inc/db_internal_types.hpp
+++ b/production/db/core/inc/db_internal_types.hpp
@@ -85,13 +85,13 @@ constexpr char c_gaia_internal_txn_log_prefix[] = "gaia_internal_txn_log_";
 // However, this would introduce a circular dependency between the memory
 // manager headers and this header (which probably indicates excessive
 // modularization).
-constexpr size_t c_max_locators{(1ULL << 29) - 1};
+constexpr size_t c_max_locators{(1UL << 29) - 1};
 #else
 // We allow as many locators as the number of 64B objects (the minimum size)
 // that will fit into the data segment size of 256GB, or 2^38 / 2^6 = 2^32. The
 // first entry of the locators array must be reserved for the invalid locator
 // value, so we subtract 1.
-constexpr size_t c_max_locators{(1ULL << 32) - 1};
+constexpr size_t c_max_locators{(1UL << 32) - 1};
 #endif
 
 // This is the largest power of 2 that is compatible with a collision
@@ -117,7 +117,7 @@ constexpr size_t c_max_types = 64;
 // unswizzle gaia_ids to locators during recovery, or persist the
 // gaia_id->locator mapping separately). Other expensive hash map lookups could
 // be similarly optimized by substituting locators for gaia_ids.
-constexpr size_t c_hash_buckets{1ULL << 26};
+constexpr size_t c_hash_buckets{1UL << 26};
 
 // This is an array of offsets in the data segment corresponding to object
 // versions, where each array index is referred to as a "locator."
@@ -193,7 +193,7 @@ static_assert(c_txn_log_record_size == sizeof(log_record_t), "Txn log record siz
 
 // We can reference at most 2^16 logs from the 16 bits available in a txn
 // metadata entry, and we must reserve the value 0 for an invalid log offset.
-constexpr size_t c_max_logs{(1ULL << 16) - 1};
+constexpr size_t c_max_logs{(1UL << 16) - 1};
 
 // The total size of a txn log in shared memory.
 // We need to allow as many log records as the maximum number of live object
@@ -280,9 +280,9 @@ struct txn_log_t
         return os;
     }
 
-    static constexpr size_t c_txn_log_refcount_bit_width{16ULL};
+    static constexpr size_t c_txn_log_refcount_bit_width{16UL};
     static constexpr uint64_t c_txn_log_refcount_shift{common::c_uint64_bit_count - c_txn_log_refcount_bit_width};
-    static constexpr uint64_t c_txn_log_refcount_mask{((1ULL << c_txn_log_refcount_bit_width) - 1) << c_txn_log_refcount_shift};
+    static constexpr uint64_t c_txn_log_refcount_mask{((1UL << c_txn_log_refcount_bit_width) - 1) << c_txn_log_refcount_shift};
 
     static gaia_txn_id_t begin_ts_from_word(uint64_t word)
     {

--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -109,7 +109,7 @@ private:
     static inline server_config_t s_server_conf{};
 
     // This is arbitrary but seems like a reasonable starting point (pending benchmarks).
-    static constexpr size_t c_stream_batch_size{1ULL << 10};
+    static constexpr size_t c_stream_batch_size{1UL << 10};
 
     // This is necessary to avoid VM exhaustion in the worst case where all
     // sessions are opened from a single process (we remap the 256GB data
@@ -119,7 +119,7 @@ private:
     // of error, hence the choice of 128 for the session limit).
     // REVIEW: How much could we relax this limit if we revert to per-process
     // mappings of the data segment?
-    static constexpr size_t c_session_limit{1ULL << 7};
+    static constexpr size_t c_session_limit{1UL << 7};
 
     static inline int s_server_shutdown_eventfd = -1;
     static inline int s_listening_socket = -1;

--- a/production/db/core/inc/txn_metadata_entry.hpp
+++ b/production/db/core/inc/txn_metadata_entry.hpp
@@ -105,28 +105,28 @@ private:
     static constexpr size_t c_txn_status_flags_bit_width{3};
     static constexpr size_t c_txn_status_flags_shift{c_txn_metadata_bit_width - c_txn_status_flags_bit_width};
     static constexpr uint64_t c_txn_status_flags_mask{
-        ((1ULL << c_txn_status_flags_bit_width) - 1) << c_txn_status_flags_shift};
+        ((1UL << c_txn_status_flags_bit_width) - 1) << c_txn_status_flags_shift};
 
     // These are all begin_ts status values.
-    static constexpr uint64_t c_txn_status_active{0b010ULL};
-    static constexpr uint64_t c_txn_status_submitted{0b011ULL};
-    static constexpr uint64_t c_txn_status_terminated{0b001ULL};
+    static constexpr uint64_t c_txn_status_active{0b010UL};
+    static constexpr uint64_t c_txn_status_submitted{0b011UL};
+    static constexpr uint64_t c_txn_status_terminated{0b001UL};
 
     // This is the bitwise intersection of all commit_ts status values.
-    static constexpr uint64_t c_txn_status_commit_ts{0b100ULL};
+    static constexpr uint64_t c_txn_status_commit_ts{0b100UL};
     static constexpr uint64_t c_txn_status_commit_mask{
         c_txn_status_commit_ts << c_txn_status_flags_shift};
 
     // This is the bitwise intersection of all commit_ts decided status values
     // (i.e., committed or aborted).
-    static constexpr uint64_t c_txn_status_decided{0b110ULL};
+    static constexpr uint64_t c_txn_status_decided{0b110UL};
     static constexpr uint64_t c_txn_status_decided_mask{
         c_txn_status_decided << c_txn_status_flags_shift};
 
     // These are all commit_ts status values.
-    static constexpr uint64_t c_txn_status_validating{0b100ULL};
-    static constexpr uint64_t c_txn_status_committed{0b111ULL};
-    static constexpr uint64_t c_txn_status_aborted{0b110ULL};
+    static constexpr uint64_t c_txn_status_validating{0b100UL};
+    static constexpr uint64_t c_txn_status_committed{0b111UL};
+    static constexpr uint64_t c_txn_status_aborted{0b110UL};
 
     // Transaction GC status values.
     // These only apply to a commit_ts metadata entry.
@@ -138,15 +138,15 @@ private:
     static constexpr size_t c_txn_gc_flags_shift{
         (c_txn_metadata_bit_width - c_txn_gc_flags_bit_width) - c_txn_status_flags_bit_width};
     static constexpr uint64_t c_txn_gc_flags_mask{
-        ((1ULL << c_txn_gc_flags_bit_width) - 1) << c_txn_gc_flags_shift};
+        ((1UL << c_txn_gc_flags_bit_width) - 1) << c_txn_gc_flags_shift};
 
     // These are all commit_ts flag values.
-    static constexpr uint64_t c_txn_gc_unknown{0b0ULL};
+    static constexpr uint64_t c_txn_gc_unknown{0b0UL};
 
     // This flag indicates that the txn log and all obsolete versions (undo
     // versions for a committed txn, redo versions for an aborted txn) have been
     // reclaimed by the system.
-    static constexpr uint64_t c_txn_gc_complete{0b1ULL};
+    static constexpr uint64_t c_txn_gc_complete{0b1UL};
 
     // This flag indicates whether the txn has been made externally durable
     // (i.e., persisted to the write-ahead log). It can't be combined with the
@@ -161,11 +161,11 @@ private:
         (c_txn_metadata_bit_width - c_txn_persistence_flags_bit_width)
         - (c_txn_status_flags_bit_width + c_txn_gc_flags_bit_width)};
     static constexpr uint64_t c_txn_persistence_flags_mask{
-        ((1ULL << c_txn_persistence_flags_bit_width) - 1) << c_txn_persistence_flags_shift};
+        ((1UL << c_txn_persistence_flags_bit_width) - 1) << c_txn_persistence_flags_shift};
 
     // These are all commit_ts flag values.
-    static constexpr uint64_t c_txn_persistence_unknown{0b0ULL};
-    static constexpr uint64_t c_txn_persistence_complete{0b1ULL};
+    static constexpr uint64_t c_txn_persistence_unknown{0b0UL};
+    static constexpr uint64_t c_txn_persistence_complete{0b1UL};
 
     // This is a placeholder for the single (currently) reserved bit in the txn
     // metadata format.
@@ -182,7 +182,7 @@ private:
            + c_txn_persistence_flags_bit_width
            + c_txn_reserved_flags_bit_width)};
     static constexpr uint64_t c_txn_log_offset_mask{
-        ((1ULL << c_txn_log_offset_bit_width) - 1) << c_txn_log_offset_shift};
+        ((1UL << c_txn_log_offset_bit_width) - 1) << c_txn_log_offset_shift};
 
     // We need the timestamp size constants to be public for now, because
     // they're used by the txn log metadata.
@@ -218,16 +218,16 @@ public:
     static constexpr size_t c_txn_ts_bit_width{42};
 #endif
     static constexpr size_t c_txn_ts_shift{0};
-    static constexpr uint64_t c_txn_ts_mask{((1ULL << c_txn_ts_bit_width) - 1) << c_txn_ts_shift};
+    static constexpr uint64_t c_txn_ts_mask{((1UL << c_txn_ts_bit_width) - 1) << c_txn_ts_shift};
 
 private:
     // Transaction metadata special values.
 
     // The first 3 bits of this value are unused for any txn state.
-    static constexpr uint64_t c_value_uninitialized{0ULL};
+    static constexpr uint64_t c_value_uninitialized{0UL};
 
     // The first 3 bits of this value do not correspond to any valid txn status value.
-    static constexpr uint64_t c_value_sealed{0b101ULL << c_txn_status_flags_shift};
+    static constexpr uint64_t c_value_sealed{0b101UL << c_txn_status_flags_shift};
 
 private:
     const uint64_t m_word;

--- a/production/db/core/inc/txn_metadata_entry.inc
+++ b/production/db/core/inc/txn_metadata_entry.inc
@@ -21,13 +21,13 @@ uint64_t txn_metadata_entry_t::get_word()
 void txn_metadata_entry_t::check_ts_size(gaia_txn_id_t ts)
 {
     ASSERT_PRECONDITION(
-        ts < (1ULL << c_txn_ts_bit_width),
+        ts < (1UL << c_txn_ts_bit_width),
         "Timestamp values must fit in 42 bits!");
 }
 
 constexpr size_t txn_metadata_entry_t::get_max_ts_count()
 {
-    return (1ULL << c_txn_ts_bit_width);
+    return (1UL << c_txn_ts_bit_width);
 }
 
 txn_metadata_entry_t txn_metadata_entry_t::uninitialized_value()

--- a/production/db/core/inc/type_index.hpp
+++ b/production/db/core/inc/type_index.hpp
@@ -38,14 +38,14 @@ struct locator_list_node_t
     // locator reuse.
     std::atomic<uint64_t> data_word;
 
-    static constexpr size_t c_locator_bit_width{32ULL};
-    static constexpr uint64_t c_locator_shift{0ULL};
-    static constexpr uint64_t c_locator_mask{((1ULL << c_locator_bit_width) - 1) << c_locator_shift};
+    static constexpr size_t c_locator_bit_width{32UL};
+    static constexpr uint64_t c_locator_shift{0UL};
+    static constexpr uint64_t c_locator_mask{((1UL << c_locator_bit_width) - 1) << c_locator_shift};
 
-    static constexpr size_t c_deleted_flag_bit_width{1ULL};
+    static constexpr size_t c_deleted_flag_bit_width{1UL};
     static constexpr size_t c_deleted_flag_shift{
         common::c_uint64_bit_count - c_deleted_flag_bit_width};
-    static constexpr uint64_t c_deleted_flag_mask{1ULL << c_deleted_flag_shift};
+    static constexpr uint64_t c_deleted_flag_mask{1UL << c_deleted_flag_shift};
 
     // Returns the locator index of the current node's successor, or the invalid
     // locator if it has no successor.

--- a/production/db/inc/memory_manager/memory_structures.hpp
+++ b/production/db/inc/memory_manager/memory_structures.hpp
@@ -31,7 +31,7 @@ struct memory_manager_metadata_t
     // so we need 1 bit/chunk.
     // Therefore our bitmap contains 2^16 bits = 8KB, or 1024 64-bit words.
     static constexpr size_t c_chunk_bitmap_size_in_words{
-        (1ULL << (CHAR_BIT * sizeof(chunk_offset_t))) / common::c_uint64_bit_count};
+        (1UL << (CHAR_BIT * sizeof(chunk_offset_t))) / common::c_uint64_bit_count};
 
     // This is a physical array of 64-bit words, storing a logical array of
     // bits, each of which denotes whether the chunk at its logical index is
@@ -162,7 +162,7 @@ struct chunk_manager_metadata_t
     // needs 2^10 - 4 64-bit words.
     static constexpr size_t c_bitmap_count{2};
     static constexpr size_t c_total_slots_count{
-        (1ULL << (CHAR_BIT * sizeof(slot_offset_t)))};
+        (1UL << (CHAR_BIT * sizeof(slot_offset_t)))};
     static constexpr size_t c_slot_bitmap_size_in_words_raw{
         c_total_slots_count / common::c_uint64_bit_count};
     static constexpr size_t c_slots_occupied_by_bitmap{

--- a/production/db/inc/memory_manager/memory_structures.inc
+++ b/production/db/inc/memory_manager/memory_structures.inc
@@ -17,9 +17,9 @@ std::pair<chunk_state_t, chunk_version_t>
 chunk_manager_metadata_t::get_chunk_state_and_version() const
 {
     constexpr chunk_version_t c_chunk_state_mask{
-        ((1ULL << c_chunk_state_bit_width) - 1) << c_chunk_state_shift};
+        ((1UL << c_chunk_state_bit_width) - 1) << c_chunk_state_shift};
     constexpr chunk_version_t c_chunk_version_mask{
-        ((1ULL << c_chunk_version_bit_width) - 1) << c_chunk_version_shift};
+        ((1UL << c_chunk_version_bit_width) - 1) << c_chunk_version_shift};
     chunk_state_t state{
         (chunk_state_and_version & c_chunk_state_mask) >> c_chunk_state_shift};
     chunk_version_t version{

--- a/production/db/memory_manager/src/bitmap.cpp
+++ b/production/db/memory_manager/src/bitmap.cpp
@@ -141,7 +141,7 @@ void find_bit_word_and_mask(
     size_t bit_index_within_word = bit_index % common::c_uint64_bit_count;
 
     word = &bitmap[word_index];
-    mask = 1ULL << bit_index_within_word;
+    mask = 1UL << bit_index_within_word;
 }
 
 bool is_bit_set(
@@ -203,7 +203,7 @@ void safe_set_bit_range_value(
     {
         uint64_t mask = (bit_count == common::c_uint64_bit_count)
             ? c_all_set_word
-            : ((1ULL << bit_count) - 1) << start_bit_index_within_word;
+            : ((1UL << bit_count) - 1) << start_bit_index_within_word;
         safe_apply_mask_to_word(bitmap[start_word_index], mask, value);
     }
     else
@@ -212,7 +212,7 @@ void safe_set_bit_range_value(
         size_t count_bits_in_first_word = common::c_uint64_bit_count - start_bit_index_within_word;
         uint64_t start_word_mask = (count_bits_in_first_word == common::c_uint64_bit_count)
             ? c_all_set_word
-            : ((1ULL << count_bits_in_first_word) - 1) << start_bit_index_within_word;
+            : ((1UL << count_bits_in_first_word) - 1) << start_bit_index_within_word;
         safe_apply_mask_to_word(bitmap[start_word_index], start_word_mask, value);
 
         // Handle any words for which we have to set all bits.
@@ -228,7 +228,7 @@ void safe_set_bit_range_value(
         size_t count_bits_in_last_word = end_bit_index_within_word + 1;
         uint64_t end_word_mask = (count_bits_in_last_word == common::c_uint64_bit_count)
             ? c_all_set_word
-            : ((1ULL << count_bits_in_last_word) - 1);
+            : ((1UL << count_bits_in_last_word) - 1);
         safe_apply_mask_to_word(bitmap[end_word_index], end_word_mask, value);
     }
 }
@@ -268,7 +268,7 @@ size_t count_set_bits(
         // then first mask out the bits that we are supposed to ignore before doing the counting.
         if (word_index == end_word_index_exclusive - 1 && end_bit_index_in_word_exclusive != common::c_uint64_bit_count)
         {
-            uint64_t mask = (1ULL << end_bit_index_in_word_exclusive) - 1;
+            uint64_t mask = (1UL << end_bit_index_in_word_exclusive) - 1;
             word &= mask;
         }
 
@@ -313,7 +313,7 @@ size_t find_first_unset_bit(
         // then first mask out the bits that we are supposed to ignore before doing any check.
         if (word_index == end_word_index_exclusive - 1 && end_bit_index_in_word_exclusive != common::c_uint64_bit_count)
         {
-            uint64_t mask = (1ULL << end_bit_index_in_word_exclusive) - 1;
+            uint64_t mask = (1UL << end_bit_index_in_word_exclusive) - 1;
             // Because we're looking out for unset bits,
             // the masking is done by setting the irrelevant bits to 1.
             word |= ~mask;

--- a/production/db/memory_manager/tests/test_bitmap.cpp
+++ b/production/db/memory_manager/tests/test_bitmap.cpp
@@ -95,7 +95,7 @@ TEST(bitmap, find_first_unset_bit)
         size_t bit_index_in_word = i % c_uint64_bit_count;
         if (bit_index_in_word != 0)
         {
-            bitmap[i / c_uint64_bit_count] = (1ULL << bit_index_in_word) - 1;
+            bitmap[i / c_uint64_bit_count] = (1UL << bit_index_in_word) - 1;
         }
 
         ASSERT_EQ(i, find_first_unset_bit(bitmap, c_bitmap_size_in_words));
@@ -145,7 +145,7 @@ TEST(bitmap, limit)
         }
         else
         {
-            bitmap = (1ULL << i) - 1;
+            bitmap = (1UL << i) - 1;
         }
 
         if (i < end_limit_bit_index)
@@ -185,7 +185,7 @@ TEST(bitmap, count_set_bits)
         size_t bit_index_in_word = i % c_uint64_bit_count;
         if (bit_index_in_word != 0)
         {
-            bitmap[i / c_uint64_bit_count] = (1ULL << bit_index_in_word) - 1;
+            bitmap[i / c_uint64_bit_count] = (1UL << bit_index_in_word) - 1;
         }
 
         ASSERT_EQ(i, count_set_bits(bitmap, c_bitmap_size_in_words));

--- a/production/inc/gaia_internal/common/inline_shared_lock.hpp
+++ b/production/inc/gaia_internal/common/inline_shared_lock.hpp
@@ -95,12 +95,12 @@ public:
 private:
     static constexpr uint64_t c_free_lock{0};
     static constexpr uint64_t c_exclusive_bit_index{63};
-    static constexpr uint64_t c_exclusive_mask{1ULL << c_exclusive_bit_index};
+    static constexpr uint64_t c_exclusive_mask{1UL << c_exclusive_bit_index};
     static constexpr uint64_t c_exclusive_intent_bit_index{62};
-    static constexpr uint64_t c_exclusive_intent_mask{1ULL << c_exclusive_intent_bit_index};
+    static constexpr uint64_t c_exclusive_intent_mask{1UL << c_exclusive_intent_bit_index};
     static constexpr uint64_t c_reader_count_bits{62};
-    static constexpr uint64_t c_reader_count_mask{(1ULL << c_reader_count_bits) - 1};
-    static constexpr size_t c_reader_count_max{(1ULL << c_reader_count_bits) - 1};
+    static constexpr uint64_t c_reader_count_mask{(1UL << c_reader_count_bits) - 1};
+    static constexpr size_t c_reader_count_max{(1UL << c_reader_count_bits) - 1};
 
 private:
     std::atomic<uint64_t> m_lock_word{c_free_lock};

--- a/production/inc/gaia_internal/common/inline_shared_lock.inc
+++ b/production/inc/gaia_internal/common/inline_shared_lock.inc
@@ -66,10 +66,10 @@ inline bool inline_shared_lock::is_valid()
     uint64_t lock_word = m_lock_word.load();
     uint64_t predicate_values{
         static_cast<uint64_t>(is_free(lock_word))
-        | (static_cast<uint64_t>(is_exclusive(lock_word)) << 1ULL)
-        | (static_cast<uint64_t>(is_shared(lock_word)) << 2ULL)
-        | (static_cast<uint64_t>(is_free_with_exclusive_intent(lock_word)) << 3ULL)
-        | (static_cast<uint64_t>(is_shared_with_exclusive_intent(lock_word)) << 4ULL)};
+        | (static_cast<uint64_t>(is_exclusive(lock_word)) << 1UL)
+        | (static_cast<uint64_t>(is_shared(lock_word)) << 2UL)
+        | (static_cast<uint64_t>(is_free_with_exclusive_intent(lock_word)) << 3UL)
+        | (static_cast<uint64_t>(is_shared_with_exclusive_intent(lock_word)) << 4UL)};
 
     // Now check that exactly one predicate is true, by separately checking that
     // at least one predicate is true[1], and at most one predicate is true[2].


### PR DESCRIPTION
Both `size_t` and `uint64_t` are defined as aliases for `unsigned long`, which makes `UL` a more appropriate suffix than `ULL`.

This change makes all code consistent with newer code in which we decided to use UL.