### PR TITLE
Enable incremental maintenance of locator snapshot across transactions

### DIFF
--- a/production/db/core/inc/db_helpers.hpp
+++ b/production/db/core/inc/db_helpers.hpp
@@ -110,6 +110,15 @@ inline void apply_log_to_locators(locators_t* locators, txn_log_t* txn_log, size
     }
 }
 
+inline void revert_log_from_locators(locators_t* locators, txn_log_t* txn_log, size_t log_record_count)
+{
+    for (size_t i = log_record_count; i > 0; --i)
+    {
+        auto log_record = &(txn_log->log_records[i - 1]);
+        (*locators)[log_record->locator] = log_record->old_offset;
+    }
+}
+
 inline gaia::db::txn_log_t* get_txn_log_from_offset(log_offset_t offset)
 {
     ASSERT_PRECONDITION(offset != gaia::db::c_invalid_log_offset, "Txn log offset is invalid!");
@@ -121,6 +130,12 @@ inline void apply_log_from_offset(locators_t* locators, log_offset_t log_offset,
 {
     txn_log_t* txn_log = get_txn_log_from_offset(log_offset);
     apply_log_to_locators(locators, txn_log, starting_log_record_index);
+}
+
+inline void revert_log_from_offset(locators_t* locators, log_offset_t log_offset, size_t log_record_count)
+{
+    txn_log_t* txn_log = get_txn_log_from_offset(log_offset);
+    revert_log_from_locators(locators, txn_log, log_record_count);
 }
 
 inline index::db_index_t id_to_index(common::gaia_id_t index_id)

--- a/production/db/core/inc/db_server.hpp
+++ b/production/db/core/inc/db_server.hpp
@@ -140,12 +140,7 @@ private:
     thread_local static inline gaia_txn_id_t s_txn_id = c_invalid_gaia_txn_id;
     thread_local static inline log_offset_t s_txn_log_offset = c_invalid_log_offset;
     thread_local static inline std::vector<std::pair<gaia_txn_id_t, log_offset_t>> s_txn_logs_for_snapshot{};
-
-    // Local snapshot for server-side transactions.
-    thread_local static inline mapped_data_t<locators_t> s_local_snapshot_locators{};
-    // Watermark that tracks how many log records have been used for the current snapshot instance.
-    // This is used to permit the incremental updating of the snapshot.
-    thread_local static inline size_t s_last_snapshot_processed_log_record_count{0};
+    thread_local static inline bool s_has_applied_txn_logs_for_snapshot{false};
 
     // The allocated status of each log offset is tracked in this bitmap. When
     // opening a new txn, each session thread must allocate an offset for its txn
@@ -175,6 +170,12 @@ private:
 
     thread_local static inline gaia::db::memory_manager::memory_manager_t s_memory_manager{};
     thread_local static inline gaia::db::memory_manager::chunk_manager_t s_chunk_manager{};
+
+    // Local snapshot for server-side transactions.
+    thread_local static inline mapped_data_t<locators_t> s_local_snapshot_locators{};
+    // Watermark that tracks how many log records have been used for the current snapshot instance.
+    // This is used to permit the incremental updating of the snapshot.
+    thread_local static inline size_t s_last_snapshot_processed_log_record_count{0};
 
     thread_local static inline bool s_is_ddl_session{false};
 


### PR DESCRIPTION
The best improvement due to this prototype change was seen for the insertion test with a transaction size of 1:

BEFORE:
```
359: [simple_table_t::simple_table_insert_txn_size with txn of size 1] 100000 records, 3 iterations:
359:    [total]: avg:4063.21ms min:3987.32ms max:4141.19ms
359:   [single]: avg:40.63us min:39.87us max:41.41us
```
AFTER:
```
360: [simple_table_t::simple_table_insert_txn_size with txn of size 1] 100000 records, 3 iterations:
360:    [total]: avg:3703.99ms min:3643.87ms max:3738.82ms
360:   [single]: avg:37.04us min:36.44us max:37.39us
```

But the improvement diminished rapidly as the transaction size increased.