### PR TITLE
[GAIAPLAT-2140] Disable test_catalog_core because of link error

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -266,10 +266,11 @@ add_gtest(test_relationships
   "${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC};${FLATBUFFERS_INC}"
   "gaia_common;gaia_db_client;gaia_catalog")
 
-add_gtest(test_catalog_core
-  tests/test_catalog_core.cpp
-  "${FLATBUFFERS_INC};${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC}"
-  "gaia_common;gaia_db_client;gaia_catalog")
+# TODO re-enable: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-2140
+#add_gtest(test_catalog_core
+#  tests/test_catalog_core.cpp
+#  "${FLATBUFFERS_INC};${GAIA_DB_CORE_TEST_INCLUDES};${GAIA_INC}"
+#  "gaia_common;gaia_db_client;gaia_catalog")
 
 add_gtest(test_optional_scalars
   "tests/test_optional_scalars.cpp"


### PR DESCRIPTION
Please see the comment here: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-2140

Can anyone reproduce? I started seeing this after cleaning the `ccache` cache.