### PR TITLE
Allow public samples to be built against internal paths

### DIFF
--- a/production/cmake/gaia_internal.cmake
+++ b/production/cmake/gaia_internal.cmake
@@ -392,3 +392,22 @@ macro(check_param PARAM)
     message(FATAL_ERROR "The parameter ${PARAM} is required!")
   endif()
 endmacro()
+
+# Set include and lib paths expected by the public gaia.cmake file
+# to internal production source and build paths. Also loads the
+# public cmake file.
+# NOTE: GAIA_REPO must be set before calling this macro.
+macro(set_gaia_internal_paths)
+  set(GAIA_SOURCE "${GAIA_REPO}/production")
+  set(GAIA_BUILD "${GAIA_REPO}/production/build")
+
+  set(GAIA_INC "${GAIA_SOURCE}/inc")
+  set(GAIA_GAIAT_CMD "${GAIA_BUILD}/tools/gaia_translate/gaiat")
+  set(GAIA_GAIAC_CMD "${GAIA_BUILD}/catalog/gaiac/gaiac")
+  set(GAIA_LIB_DIR "${GAIA_BUILD}/sdk")
+
+  set(FLATBUFFERS_INC "${GAIA_BUILD}/deps/flatbuffers/include")
+  set(SPDLOG_INC "${GAIA_BUILD}/deps/gaia_spdlog/include")
+
+  include("${GAIA_SOURCE}/cmake/gaia.cmake")
+endmacro()

--- a/production/examples/direct_access/CMakeLists_internal.txt
+++ b/production/examples/direct_access/CMakeLists_internal.txt
@@ -1,0 +1,45 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(rules)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads support.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# --- Generate Direct Access classes from DDL---
+process_schema(
+  DDL_FILE ${PROJECT_SOURCE_DIR}/hospital.ddl
+  DATABASE_NAME hospital
+)
+
+add_executable(direct_access
+  hospital.cpp
+)
+
+target_add_gaia_generated_sources(direct_access)
+target_include_directories(direct_access PRIVATE
+  ${GAIA_INC}
+  ${SPDLOG_INC}
+  ${FLATBUFFERS_INC}
+  ${PROJECT_SOURCE_DIR}
+)
+target_link_directories(direct_access PRIVATE ${GAIA_LIB_DIR})
+target_link_libraries(direct_access PRIVATE gaia Threads::Threads)

--- a/production/examples/direct_access_multithread/CMakeLists_internal.txt
+++ b/production/examples/direct_access_multithread/CMakeLists_internal.txt
@@ -1,0 +1,43 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(direct_access_multithread)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads support.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# --- Generate Direct Access classes from DDL---
+process_schema(
+  DDL_FILE ${PROJECT_SOURCE_DIR}/counter.ddl
+  DATABASE_NAME counter
+)
+
+add_executable(direct_access_multithread
+  counter.cpp
+)
+
+target_add_gaia_generated_sources(direct_access_multithread)
+target_include_directories(direct_access_multithread PRIVATE
+  ${GAIA_INC}
+  ${FLATBUFFERS_INC}
+  ${SPDLOG_INC}
+)
+target_link_libraries(direct_access_multithread PRIVATE ${GAIA_LIB} Threads::Threads)

--- a/production/examples/direct_access_vlr/CMakeLists_internal.txt
+++ b/production/examples/direct_access_vlr/CMakeLists_internal.txt
@@ -1,0 +1,43 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(direct_access_vlr)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# Generate Direct Access Classes from the DDL schema.
+process_schema(
+  DDL_FILE ${PROJECT_SOURCE_DIR}/direct_access_vlr.ddl
+  DATABASE_NAME direct_access_vlr
+)
+
+add_executable(direct_access_vlr
+  direct_access_vlr.cpp
+)
+
+target_add_gaia_generated_sources(direct_access_vlr)
+target_include_directories(direct_access_vlr PRIVATE
+  ${GAIA_INC}
+  ${FLATBUFFERS_INC}
+  ${SPDLOG_INC}
+)
+target_link_libraries(direct_access_vlr PRIVATE ${GAIA_LIB} Threads::Threads)

--- a/production/examples/hello/CMakeLists_internal.txt
+++ b/production/examples/hello/CMakeLists_internal.txt
@@ -1,0 +1,55 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(rules)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads support.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# Default compiler/linker flags.
+add_compile_options(-Wall -Wextra)
+
+set(HELLO_DDL ${PROJECT_SOURCE_DIR}/hello.ddl)
+set(HELLO_RULESET ${PROJECT_SOURCE_DIR}/hello.ruleset)
+
+# --- Generate Direct Access classes from DDL---
+process_schema(
+  DDL_FILE ${HELLO_DDL}
+  DATABASE_NAME hello
+)
+
+translate_ruleset(
+  RULESET_FILE ${HELLO_RULESET}
+  CLANG_PARAMS -I${FLATBUFFERS_INC}
+)
+
+add_executable(hello
+  hello.cpp
+)
+
+target_add_gaia_generated_sources(hello)
+target_include_directories(hello PRIVATE
+  ${GAIA_INC}
+  ${FLATBUFFERS_INC}
+)
+
+target_link_directories(hello PRIVATE ${GAIA_LIB_DIR})
+target_link_libraries(hello PRIVATE gaia Threads::Threads)

--- a/production/examples/incubator/CMakeLists_internal.txt
+++ b/production/examples/incubator/CMakeLists_internal.txt
@@ -1,0 +1,50 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(incubator)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads support.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# --- Generate Direct Access classes from DDL---
+process_schema(
+  DDL_FILE ${PROJECT_SOURCE_DIR}/incubator.ddl
+  DATABASE_NAME incubator
+)
+
+translate_ruleset(
+  RULESET_FILE ${PROJECT_SOURCE_DIR}/incubator.ruleset
+  CLANG_PARAMS -I${SPDLOG_INC} -I${FLATBUFFERS_INC}
+)
+
+add_executable(incubator
+  incubator.cpp
+)
+
+target_add_gaia_generated_sources(incubator)
+target_include_directories(incubator PRIVATE
+  ${GAIA_INC}
+  ${FLATBUFFERS_INC}
+  ${SPDLOG_INC}
+  ${PROJECT_SOURCE_DIR}
+)
+target_link_directories(incubator PRIVATE ${GAIA_LIB_DIR})
+target_link_libraries(incubator PRIVATE gaia Threads::Threads)

--- a/production/examples/rules/CMakeLists_internal.txt
+++ b/production/examples/rules/CMakeLists_internal.txt
@@ -21,18 +21,11 @@ if(NOT DEFINED GAIA_REPO)
   message(FATAL_ERROR "GAIA_REPO is not set!")
 endif()
 
-set(GAIA_SOURCE "${GAIA_REPO}/production")
-set(GAIA_BUILD "${GAIA_REPO}/production/build")
-
-set(GAIA_INC "${GAIA_SOURCE}/inc")
-set(GAIA_GAIAT_CMD "${GAIA_BUILD}/tools/gaia_translate/gaiat")
-set(GAIA_GAIAC_CMD "${GAIA_BUILD}/catalog/gaiac/gaiac")
-set(GAIA_LIB_DIR "${GAIA_BUILD}/sdk")
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
 
 # Use a custom gaia config file to suppress rule stats logging.
 configure_file("${PROJECT_SOURCE_DIR}/gaia.conf" "${PROJECT_BINARY_DIR}/gaia_tutorial.conf")
-
-include("${GAIA_SOURCE}/cmake/gaia.cmake")
 
 # --- Generate Direct Access classes from DDL---
 process_schema(
@@ -42,7 +35,7 @@ process_schema(
 
 translate_ruleset(
   RULESET_FILE ${PROJECT_SOURCE_DIR}/clinic.ruleset
-  CLANG_PARAMS -I${GAIA_BUILD}/deps/gaia_spdlog/include -I${GAIA_BUILD}/deps/flatbuffers/include
+  CLANG_PARAMS -I${SPDLOG_INC} -I${FLATBUFFERS_INC}
 )
 
 add_executable(rules
@@ -52,8 +45,10 @@ add_executable(rules
 
 target_add_gaia_generated_sources(rules)
 target_include_directories(rules PRIVATE
-  ${GAIA_INC} ${GAIA_BUILD}/deps/gaia_spdlog/include
-  ${GAIA_BUILD}/deps/flatbuffers/include
-  ${PROJECT_SOURCE_DIR})
+  ${GAIA_INC}
+  ${SPDLOG_INC}
+  ${FLATBUFFERS_INC}
+  ${PROJECT_SOURCE_DIR}
+)
 target_link_directories(rules PRIVATE ${GAIA_LIB_DIR})
 target_link_libraries(rules PRIVATE gaia Threads::Threads)

--- a/production/examples/rules_vlr/CMakeLists_internal.txt
+++ b/production/examples/rules_vlr/CMakeLists_internal.txt
@@ -1,0 +1,49 @@
+###################################################
+# Copyright (c) Gaia Platform LLC
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE.txt file
+# or at https://opensource.org/licenses/MIT.
+###################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(rules_vlr)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# We need pthreads.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+if(NOT DEFINED GAIA_REPO)
+  message(FATAL_ERROR "GAIA_REPO is not set!")
+endif()
+
+include ("${GAIA_REPO}/production/cmake/gaia_internal.cmake")
+set_gaia_internal_paths()
+
+# Generate Direct Access Classes from the DDL schema.
+process_schema(
+  DDL_FILE ${PROJECT_SOURCE_DIR}/rules_vlr.ddl
+  DATABASE_NAME rules_vlr
+)
+
+# Translate the ruleset into C++.
+translate_ruleset(
+  RULESET_FILE ${PROJECT_SOURCE_DIR}/rules_vlr.ruleset
+  CLANG_PARAMS -I${SPDLOG_INC} -I${FLATBUFFERS_INC}
+)
+
+add_executable(rules_vlr
+  rules_vlr.cpp
+)
+
+target_add_gaia_generated_sources(rules_vlr)
+target_include_directories(rules_vlr PRIVATE
+  ${GAIA_INC}
+  ${FLATBUFFERS_INC}
+  ${SPDLOG_INC}
+)
+target_link_libraries(rules_vlr PRIVATE ${GAIA_LIB} Threads::Threads)


### PR DESCRIPTION
I find it awfully convenient to build the public samples against a current internal build tree. I've made private "internal" flavors of CMakeLists for `incubator` and `rules` so decided to update the other SDK examples as well.  The current `CMakeLists.txt` for each sample is still the public-facing one that assumes all paths are specified by the SDK install.  I've added a `CMakeLists_internal.txt` to each project that requires the user to pass in a GAIA_REPO define as a base for the paths.  This does assume that source is under 'production' and build is under 'production/build'.  

For example, to build the `direct_access` example against an internal build, I do the following:
```
cd ~/git/GaiaPlatform/production/examples/direct_access
cp CMakeLists_internal.txt CMakeLists.txt
mkdir build
cd build
cmake -DGAIA_REPO=/home/dax/git/GaiaPlatform ..
make
```
Just be sure you don't inadvertently check in the overwritten `CMakeLists.txt` file.  At some point, we could figure out a way to have normal production builds do this.