### PR TITLE
Fix some perf test issues and enable a new test

### DIFF
--- a/production/direct_access/tests/test_read_perf_basic.cpp
+++ b/production/direct_access/tests/test_read_perf_basic.cpp
@@ -160,12 +160,12 @@ TEST_F(test_read_perf_basic, filter_match)
         clear_db_after_each_iteration);
 }
 
-TEST_F(test_read_perf_basic, DISABLED_table_scan_read_size)
+TEST_F(test_read_perf_basic, table_scan_read_size)
 {
-    insert_data();
-
-    for (size_t num_reads : {10UL, 100UL, 1000UL, 100000UL, 1000000UL, c_num_records})
+    for (size_t num_reads : {10UL, 100UL, 1000UL, /*100000UL, 1000000UL, c_num_records*/})
     {
+        insert_data();
+
         auto work = [num_reads]() {
             gaia::db::begin_transaction();
 
@@ -173,8 +173,7 @@ TEST_F(test_read_perf_basic, DISABLED_table_scan_read_size)
             for ([[maybe_unused]] auto& record :
                  simple_table_t::list())
             {
-                i++;
-                if (i == num_reads)
+                if (++i == num_reads)
                 {
                     break;
                 }

--- a/production/direct_access/tests/test_read_perf_rel.cpp
+++ b/production/direct_access/tests/test_read_perf_rel.cpp
@@ -105,7 +105,7 @@ TEST_F(test_read_perf_rel, single_join)
         for (const auto& parent : table_parent_t::list())
         {
             i++;
-            for (auto& child : parent.children())
+            for ([[maybe_unused]] auto& child : parent.children())
             {
                 i++;
             }
@@ -184,7 +184,7 @@ TEST_F(test_read_perf_rel, nested_joins)
             {
                 for (const auto& j2 : j1.j2())
                 {
-                    for (const auto& j3 : j2.j3())
+                    for ([[maybe_unused]] const auto& j3 : j2.j3())
                     {
                         i++;
                     }


### PR DESCRIPTION
Some of the new perf tests code generated warnings during build or just failed to pass. This change fixes these issues and also enabled a new test to run by default (after commenting some options that would require extra changes to work, as well as increase execution time).