### PR TITLE
[GAIAPLAT-2142] Fix gaia::system::initialize() ASAN failure

### DIFF
--- a/third_party/bundle/gaia_spdlog_setup/include/gaia_spdlog_setup/details/third_party/cpptoml.h
+++ b/third_party/bundle/gaia_spdlog_setup/include/gaia_spdlog_setup/details/third_party/cpptoml.h
@@ -1155,7 +1155,7 @@ class table : public base {
 //         } catch (const std::out_of_range &) {
 //             return {};
 //         }
-        // The code above make ASAN complain. This workaround fixes it.
+        // The code above makes ASAN complain. This workaround fixes it.
         // Fixes https://gaiaplatform.atlassian.net/browse/GAIAPLAT-2142
         if (contains(key))
         {


### PR DESCRIPTION
Calling gaia::system::initialize with ASAN makes the program crash. This fix also prevents throwing exceptions that are usually caught by the debugger during debug sessions.

I'm doing this now because it is interfering with running the benchmarks linking against `libgaia.so`.