### PR TITLE
Add a type_registry_t check to update_payload()

### DIFF
--- a/production/db/core/src/gaia_ptr_api.cpp
+++ b/production/db/core/src/gaia_ptr_api.cpp
@@ -330,12 +330,14 @@ void auto_connect(
     {
         return;
     }
+
     field_position_list_t candidate_fields;
     gaia_id_t table_id = type_id_mapping_t::instance().get_table_id(type);
     for (auto field_view : catalog_core::list_fields(table_id))
     {
         candidate_fields.push_back(field_view.position());
     }
+
     auto_connect(id, type, table_id, references, payload, candidate_fields);
 }
 
@@ -414,13 +416,17 @@ void update_payload(gaia_ptr_t& obj, size_t data_size, const void* data)
 
     field_position_list_t changed_fields = compute_payload_diff(obj.type(), old_data, new_data);
 
-    auto_connect(
-        obj.id(),
-        obj.type(),
-        type_id_mapping_t::instance().get_table_id(obj.type()),
-        obj.references(),
-        new_data,
-        changed_fields);
+    const type_metadata_t& metadata = type_registry_t::instance().get(obj.type());
+    if (metadata.has_value_linked_relationship())
+    {
+        auto_connect(
+            obj.id(),
+            obj.type(),
+            type_id_mapping_t::instance().get_table_id(obj.type()),
+            obj.references(),
+            new_data,
+            changed_fields);
+    }
 
     obj.finalize_update(old_offset);
 


### PR DESCRIPTION
I just noticed that `create()` had a check to avoid calling `auto_connect()` - this change adds the same check in the `update_payload()` call. I am noticing very small improvements, which is expected, given that this only avoids a quick-returning call to `auto_connect()`, but I think it's still worth making this change to have parity between how the two calls (insert/update) operate.