### PR TITLE
Change db_shared_data_client internal checks into debug assertions

### DIFF
--- a/production/db/core/src/db_shared_data_client.cpp
+++ b/production/db/core/src/db_shared_data_client.cpp
@@ -12,10 +12,7 @@ const bool gaia::db::c_is_running_on_client = true;
 
 gaia::db::locators_t* gaia::db::get_locators()
 {
-    if (!gaia::db::client_t::s_private_locators.is_set())
-    {
-        throw no_open_transaction_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_private_locators.is_set(), "Locators segments is unmapped!");
 
     // REVIEW: Callers of this method should probably never be able to observe
     // the locators segment in an unmapped state (i.e., outside a transaction),
@@ -33,72 +30,52 @@ gaia::db::locators_t* gaia::db::get_locators_for_allocator()
     return gaia::db::get_locators();
 }
 
+// Since we don't use this accessor in the client itself, we can assert that
+// it is always non-null (since callers should never be able to observe it
+// in its null state, i.e., with the counters segment unmapped).
 gaia::db::counters_t* gaia::db::get_counters()
 {
-    // Since we don't use this accessor in the client itself, we can assert that
-    // it is always non-null (since callers should never be able to observe it
-    // in its null state, i.e., with the counters segment unmapped).
-
-    if (!gaia::db::client_t::s_shared_counters.is_set())
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_shared_counters.is_set(), "Counters segment is unmapped!");
 
     return gaia::db::client_t::s_shared_counters.data();
 }
 
+// Since we don't use this accessor in the client itself, we can assert that
+// it is always non-null (since callers should never be able to observe it
+// in its null state, i.e., with the data segment unmapped).
 gaia::db::data_t* gaia::db::get_data()
 {
-    // Since we don't use this accessor in the client itself, we can assert that
-    // it is always non-null (since callers should never be able to observe it
-    // in its null state, i.e., with the data segment unmapped).
-
-    if (!gaia::db::client_t::s_shared_data.is_set())
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_shared_data.is_set(), "Data segment is unmapped!");
 
     return gaia::db::client_t::s_shared_data.data();
 }
 
+// Since we don't use this accessor in the client itself, we can assert that
+// it is always non-null (since callers should never be able to observe it
+// in its null state, i.e., with the data segment unmapped).
 gaia::db::logs_t* gaia::db::get_logs()
 {
-    // Since we don't use this accessor in the client itself, we can assert that
-    // it is always non-null (since callers should never be able to observe it
-    // in its null state, i.e., with the data segment unmapped).
-
-    if (!gaia::db::client_t::s_shared_logs.is_set())
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_shared_logs.is_set(), "Log segment is unmapped!");
 
     return gaia::db::client_t::s_shared_logs.data();
 }
 
+// Since we don't use this accessor in the client itself, we can assert that
+// it is always non-null (since callers should never be able to observe it
+// in its null state, i.e., with the id_index segment unmapped).
 gaia::db::id_index_t* gaia::db::get_id_index()
 {
-    // Since we don't use this accessor in the client itself, we can assert that
-    // it is always non-null (since callers should never be able to observe it
-    // in its null state, i.e., with the id_index segment unmapped).
-
-    if (!gaia::db::client_t::s_shared_id_index.is_set())
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_shared_id_index.is_set(), "Id index segment is unmapped!");
 
     return gaia::db::client_t::s_shared_id_index.data();
 }
 
+// Since we don't use this accessor in the client itself, we can assert that
+// it is always non-null (since callers should never be able to observe it
+// in its null state, i.e., with the type_index segment unmapped).
 gaia::db::type_index_t* gaia::db::get_type_index()
 {
-    // Since we don't use this accessor in the client itself, we can assert that
-    // it is always non-null (since callers should never be able to observe it
-    // in its null state, i.e., with the type_index segment unmapped).
-
-    if (!gaia::db::client_t::s_shared_type_index.is_set())
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_shared_type_index.is_set(), "Type index segment is unmapped!");
 
     return gaia::db::client_t::s_shared_type_index.data();
 }
@@ -125,9 +102,7 @@ gaia::db::memory_manager::chunk_manager_t* gaia::db::get_chunk_manager()
 
 gaia::db::txn_log_t* gaia::db::get_txn_log()
 {
-    if (gaia::db::client_t::s_txn_log_offset == gaia::db::c_invalid_log_offset)
-    {
-        throw no_open_session_internal();
-    }
+    DEBUG_ASSERT_PRECONDITION(gaia::db::client_t::s_txn_log_offset.is_valid(), "Transaction log is uninitialized!");
+
     return gaia::db::get_txn_log_from_offset(gaia::db::client_t::s_txn_log_offset);
 }

--- a/production/db/core/tests/test_db_client.cpp
+++ b/production/db/core/tests/test_db_client.cpp
@@ -133,7 +133,7 @@ TEST_F(db_client_test, early_session_termination)
     rollback_transaction();
 }
 
-TEST_F(db_client_test, gaia_ptr_no_transaction_fail)
+TEST_F(db_client_test, DISABLED_gaia_ptr_no_transaction_fail)
 {
     begin_transaction();
     gaia_ptr_t node1 = gaia_ptr_t::from_gaia_id(node1_id);


### PR DESCRIPTION
Turned out that there was a test relying on the old behavior of checking and throwing exceptions. I disabled it for now - let me know what you want me to do with it, @senderista .