### PR TITLE
Update assert performance test

### DIFF
--- a/production/common/tests/test_assert.cpp
+++ b/production/common/tests/test_assert.cpp
@@ -169,5 +169,22 @@ TEST(common, assert_perf)
 
     cout << ">>> Time Elapsed: " << elapsed << "ms." << endl;
 
+    // Test inline asserts with a static assertion message.
+    start = g_timer_t::get_time_point();
+
+    for (size_t i = 0; i < c_count_iterations; ++i)
+    {
+        for (int32_t number : numbers)
+        {
+            ASSERT_PRECONDITION(
+                number >= 0,
+                "check_number() was called with a negative number!");
+        }
+    }
+
+    elapsed = g_timer_t::ns_to_ms(g_timer_t::get_duration(start));
+
+    cout << ">>> Time Elapsed (inline): " << elapsed << "ms." << endl;
+
     cout << endl;
 }


### PR DESCRIPTION
Here are the changes in this PR:

- adds more test scenarios besides testing an assert directly. I added a few inline helper methods that perform an assertion and a trivial operation on their argument. These helpers perform different types of assertions: debug assertions, assertions with an spdlog formatted message, and assertions with a static message. I also kept the original test of the assert and added one test that just performs the assert condition and increments a count if that fails.
- adds a number of iterations to allow running the test for longer without taking more memory for the arguments.

Typical output on my machine with 1M numbers and 1K iterations:

```
4: >>> Time Elapsed (condition): 279.312ms.
4: >>> Time Elapsed (DEBUG): 3.1e-05ms.
4: >>> Time Elapsed (gaia_fmt::format): 240.395ms.
4: >>> Time Elapsed: 215.68ms.
4: >>> Time Elapsed (inline): 215.168ms.
```