### PR TITLE
Additional assert perf test updates

### DIFF
--- a/production/common/tests/test_assert.cpp
+++ b/production/common/tests/test_assert.cpp
@@ -135,9 +135,32 @@ TEST(common, assert_perf)
         }
     }
 
-    auto elapsed = g_timer_t::ns_to_ms(g_timer_t::get_duration(start));
+    double elapsed = g_timer_t::get_duration(start);
 
-    cout << ">>> Time Elapsed (DEBUG): " << elapsed << "ms." << endl;
+    cout << ">>> Time Elapsed (helper with DEBUG_ASSERT): " << g_timer_t::ns_to_ms(elapsed) << "ms." << endl;
+    cout << ">>> Average time: " << elapsed / (c_count_numbers * c_count_iterations) << "ns." << endl;
+
+    // Test the assert condition itself.
+    start = g_timer_t::get_time_point();
+
+    size_t count_condition_failures = 0;
+    for (size_t i = 0; i < c_count_iterations; ++i)
+    {
+        for (int32_t number : numbers)
+        {
+            if (number < 0)
+            {
+                ++count_condition_failures;
+            }
+        }
+    }
+
+    ASSERT_EQ(0, count_condition_failures);
+
+    elapsed = g_timer_t::get_duration(start);
+
+    cout << ">>> Time Elapsed (condition): " << g_timer_t::ns_to_ms(elapsed) << "ms." << endl;
+    cout << ">>> Average time: " << elapsed / (c_count_numbers * c_count_iterations) << "ns." << endl;
 
     // Test regular asserts with a formatted assertion message.
     start = g_timer_t::get_time_point();
@@ -150,9 +173,10 @@ TEST(common, assert_perf)
         }
     }
 
-    elapsed = g_timer_t::ns_to_ms(g_timer_t::get_duration(start));
+    elapsed = g_timer_t::get_duration(start);
 
-    cout << ">>> Time Elapsed (gaia_fmt::format): " << elapsed << "ms." << endl;
+    cout << ">>> Time Elapsed (helper with gaia_fmt::format): " << g_timer_t::ns_to_ms(elapsed) << "ms." << endl;
+    cout << ">>> Average time: " << elapsed / (c_count_numbers * c_count_iterations) << "ns." << endl;
 
     // Test regular asserts with a static assertion message.
     start = g_timer_t::get_time_point();
@@ -165,9 +189,10 @@ TEST(common, assert_perf)
         }
     }
 
-    elapsed = g_timer_t::ns_to_ms(g_timer_t::get_duration(start));
+    elapsed = g_timer_t::get_duration(start);
 
-    cout << ">>> Time Elapsed: " << elapsed << "ms." << endl;
+    cout << ">>> Time Elapsed (helper with static message): " << g_timer_t::ns_to_ms(elapsed) << "ms." << endl;
+    cout << ">>> Average time: " << elapsed / (c_count_numbers * c_count_iterations) << "ns." << endl;
 
     // Test inline asserts with a static assertion message.
     start = g_timer_t::get_time_point();
@@ -182,9 +207,10 @@ TEST(common, assert_perf)
         }
     }
 
-    elapsed = g_timer_t::ns_to_ms(g_timer_t::get_duration(start));
+    elapsed = g_timer_t::get_duration(start);
 
-    cout << ">>> Time Elapsed (inline): " << elapsed << "ms." << endl;
+    cout << ">>> Time Elapsed (inline with static message): " << g_timer_t::ns_to_ms(elapsed) << "ms." << endl;
+    cout << ">>> Average time: " << elapsed / (c_count_numbers * c_count_iterations) << "ns." << endl;
 
     cout << endl;
 }


### PR DESCRIPTION
I missed pushing a commit to the previous PR, so this new one adds that as well as the requested feature of displaying the average individual time taken by an assert. The new output looks like this:

``` 
4: >>> Time Elapsed (helper with DEBUG_ASSERT): 8.2e-05ms.
4: >>> Average time: 8.2e-08ns.
4: >>> Time Elapsed (condition): 234.919ms.
4: >>> Average time: 0.234919ns.
4: >>> Time Elapsed (helper with gaia_fmt::format): 238.122ms.
4: >>> Average time: 0.238122ns.
4: >>> Time Elapsed (helper with static message): 216.151ms.
4: >>> Average time: 0.216151ns.
4: >>> Time Elapsed (inline with static message): 212.756ms.
4: >>> Average time: 0.212756ns.
```