### PR TITLE
Make debug assertion failure exception inherit from assertion failure exception

### DIFF
--- a/production/inc/gaia_internal/common/debug_assert.hpp
+++ b/production/inc/gaia_internal/common/debug_assert.hpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <string>
 
-#include "gaia/exception.hpp"
+#include "assert.hpp"
 
 namespace gaia
 {
@@ -61,11 +61,11 @@ namespace common
 /**
  * Thrown when a debug assert check has failed.
  */
-class debug_assertion_failure : public gaia_exception
+class debug_assertion_failure : public assertion_failure
 {
 public:
     explicit debug_assertion_failure(const std::string& message)
-        : gaia_exception(message)
+        : assertion_failure(message)
     {
     }
 };


### PR DESCRIPTION
This change is actually addressing a functional issue that I introduced with the addition of debug failure exceptions: the rules engine is trying to handle assertion failures specially, but doesn't handle the new type of exception. While this would only be an issue in debug builds, this change fixes that problem by making the debug exception inherit from the regular exception