### PR TITLE
Change db helper assert into debug assert

### DIFF
--- a/production/db/core/src/chunk_manager.cpp
+++ b/production/db/core/src/chunk_manager.cpp
@@ -122,7 +122,6 @@ gaia_offset_t chunk_manager_t::allocate(
     slot_offset_t allocated_slot = m_metadata->max_allocated_slot_offset();
     mark_slot_allocated(allocated_slot);
 
-    // This is an expensive check in a hot path.
     DEBUG_ASSERT_INVARIANT(
         is_slot_allocated(allocated_slot),
         "Slot just marked allocated must be visible as allocated!");
@@ -139,7 +138,6 @@ void chunk_manager_t::deallocate(gaia_offset_t offset)
 
     slot_offset_t deallocated_slot = slot_from_offset(offset);
 
-    // This is an expensive check in a hot path.
     // It is illegal to deallocate the same object twice.
     DEBUG_ASSERT_PRECONDITION(
         is_slot_allocated(deallocated_slot),
@@ -184,7 +182,6 @@ void chunk_manager_t::mark_slot(slot_offset_t slot_offset, bool is_allocating)
         slot_offset >= c_first_slot_offset && slot_offset <= c_last_slot_offset,
         "Slot offset passed to mark_slot() is out of bounds");
 
-    // This is an expensive check in a hot path.
     // is_slot_allocated() also checks that the deallocation bit is not set if
     // the allocation bit is not set.
     DEBUG_ASSERT_PRECONDITION(

--- a/production/db/core/src/gaia_ptr_client.cpp
+++ b/production/db/core/src/gaia_ptr_client.cpp
@@ -120,7 +120,6 @@ gaia_ptr_t gaia_ptr_t::create_no_txn(gaia_id_t id, gaia_type_t type, reference_o
         throw duplicate_object_id_internal(id);
     }
 
-    // This is an expensive check in a hot path.
     DEBUG_ASSERT_INVARIANT(id_to_locator(id) == locator, "Cannot find locator for just-inserted ID!");
 
     allocate_object(locator, total_payload_size);

--- a/production/db/inc/core/db_helpers.hpp
+++ b/production/db/inc/core/db_helpers.hpp
@@ -33,7 +33,6 @@ inline common::gaia_id_t allocate_id()
     counters_t* counters = gaia::db::get_counters();
     auto new_id = ++(counters->last_id);
 
-    // This is an expensive check in a hot path.
     DEBUG_ASSERT_INVARIANT(
         new_id <= std::numeric_limits<common::gaia_id_t::value_type>::max(),
         "Gaia ID exceeds allowed range!");
@@ -46,7 +45,6 @@ inline gaia_txn_id_t allocate_txn_id()
     counters_t* counters = gaia::db::get_counters();
     auto new_txn_id = ++(counters->last_txn_id);
 
-    // This is an expensive check in a hot path.
     DEBUG_ASSERT_INVARIANT(
         new_txn_id < (1UL << transactions::txn_metadata_entry_t::c_txn_ts_bit_width),
         "Transaction ID exceeds allowed range!");
@@ -84,7 +82,6 @@ inline gaia_locator_t get_last_locator()
     counters_t* counters = gaia::db::get_counters();
     auto last_locator_value = counters->last_locator.load();
 
-    // This is an expensive check in a hot path.
     DEBUG_ASSERT_INVARIANT(
         last_locator_value <= c_max_locators,
         "Largest locator value exceeds allowed range!");


### PR DESCRIPTION
I came across this assert while stepping through the code. Other asserts in its file had been changed into debug asserts already, but not this one, for some reason. Its check is less trivial than most asserts, so it looked like a good candidate for turning it into a debug assert. Most tests showed a bit of improvement with this assert disabled (i.e. changed into a debug assert), hence this PR.

If anyone knows of a good reason to keep this as is, let me know and I'll just add a comment to explain that.