### PR TITLE
Make db_test_base_t to terminate the logger in TearDownTestSuite()

### DIFF
--- a/production/common/src/logger.cpp
+++ b/production/common/src/logger.cpp
@@ -45,6 +45,11 @@ void shutdown()
     logger_manager_t::get().stop_logging();
 }
 
+bool is_initialized()
+{
+    return logger_manager_t::get().is_logging_initialized();
+}
+
 logger_t& sys()
 {
     return logger_manager_t::get().sys_logger();

--- a/production/common/src/logger_manager.cpp
+++ b/production/common/src/logger_manager.cpp
@@ -87,6 +87,11 @@ bool logger_manager_t::stop_logging()
     return true;
 }
 
+bool logger_manager_t::is_logging_initialized()
+{
+    return m_is_log_initialized;
+}
+
 void logger_manager_t::create_log_dir_if_not_exists(const char* log_file_path)
 {
     fs::path path(log_file_path);

--- a/production/inc/gaia_internal/common/logger.hpp
+++ b/production/inc/gaia_internal/common/logger.hpp
@@ -76,6 +76,11 @@ void initialize(const std::string& config_path);
  */
 void shutdown();
 
+/**
+ * Returns true if the logger is initialized;
+ */
+bool is_initialized();
+
 /*
  * Exposed loggers. Filled in by initialize and destroyed on shutdown.
  */

--- a/production/inc/gaia_internal/common/logger_manager.hpp
+++ b/production/inc/gaia_internal/common/logger_manager.hpp
@@ -110,6 +110,7 @@ public:
 
     bool init_logging(const std::string& config_path);
     bool stop_logging();
+    bool is_logging_initialized();
 
 private:
     logger_manager_t() = default;

--- a/production/inc/gaia_internal/db/db_test_base.hpp
+++ b/production/inc/gaia_internal/db/db_test_base.hpp
@@ -85,6 +85,11 @@ protected:
         s_server_instance.start();
     }
 
+    static void TearDownTestSuite()
+    {
+        gaia_log::shutdown();
+    }
+
     // Since ctest always launches each gtest in a new process, there is no point
     // to defining separate SetUpTestSuite/TearDownTestSuite methods.  However, tests
     // that need to do one-time initialization when running outside ctest

--- a/production/rules/event_manager/src/rule_thread_pool.cpp
+++ b/production/rules/event_manager/src/rule_thread_pool.cpp
@@ -102,7 +102,13 @@ void rule_thread_pool_t::shutdown()
     m_threads.clear();
 
     int64_t shutdown_duration = gaia::common::timer_t::get_duration(start_shutdown_time);
-    gaia_log::rules().trace("shutdown took {:.2f} ms", gaia::common::timer_t::ns_to_ms(shutdown_duration));
+
+    // This method is called automatically at the rule_engine shutdown. It could happen that the logger
+    // has already been destroyed, hence a call to the logger may throw an exception.
+    if (gaia_log::is_initialized())
+    {
+        gaia_log::rules().trace("shutdown took {:.2f} ms", gaia::common::timer_t::ns_to_ms(shutdown_duration));
+    }
 }
 
 void rule_thread_pool_t::execute_immediate()


### PR DESCRIPTION
- Make db_test_base_t to terminate the logger in TearDownTestSuite()
- Add `gaia_log::is_initialized()` to check if the logger is intialized.

Extracting this out of https://github.com/gaia-platform/GaiaPlatform/pull/1524