### PR TITLE
Move some session cleanup in the destructor of session_context

### DIFF
--- a/production/db/core/src/server_contexts.cpp
+++ b/production/db/core/src/server_contexts.cpp
@@ -5,6 +5,8 @@
 
 #include "server_contexts.hpp"
 
+#include "gaia_internal/common/assert.hpp"
+#include "gaia_internal/common/fd_helpers.hpp"
 #include "gaia_internal/common/socket_helpers.hpp"
 
 namespace gaia
@@ -19,6 +21,23 @@ void server_transaction_context_t::clear()
 
 void server_session_context_t::clear()
 {
+    if (session_shutdown_eventfd != -1)
+    {
+        // Signal all session-owned threads to terminate.
+        common::signal_eventfd_multiple_threads(session_shutdown_eventfd);
+
+        // Wait for all session-owned threads to terminate.
+        for (auto& thread : session_owned_threads)
+        {
+            ASSERT_INVARIANT(thread.joinable(), "Thread must be joinable!");
+            thread.join();
+        }
+
+        // All session-owned threads have received the session shutdown
+        // notification, so we can close the eventfd.
+        common::close_fd(session_shutdown_eventfd);
+    }
+
     // We can rely on close_fd() to perform the equivalent of
     // shutdown(SHUT_RDWR), because we hold the only fd pointing to this
     // socket. That should allow the client to read EOF if they're in a


### PR DESCRIPTION
Just some cleanup that can be moved from a scope guard into the session context cleanup method.