### PR TITLE
Fix rocks_wrapper and gaia_db_persistence CMake dependencies

### DIFF
--- a/production/db/core/CMakeLists.txt
+++ b/production/db/core/CMakeLists.txt
@@ -115,6 +115,7 @@ target_include_directories(rocks_wrapper SYSTEM PRIVATE "${FLATBUFFERS_INC}")
 target_include_directories(rocks_wrapper SYSTEM PRIVATE "${GEN_DIR}")
 # The client is required to create gaia objects on recovery.
 target_link_libraries(rocks_wrapper PUBLIC rocksdb gaia_common)
+add_dependencies(rocks_wrapper ${FBS_SOURCE_FILENAMES})
 
 # Liburing
 # Choose static version of the library.
@@ -144,7 +145,7 @@ target_include_directories(gaia_db_persistence SYSTEM PRIVATE "${GEN_DIR}")
 target_include_directories(gaia_db_persistence SYSTEM PRIVATE "${LIBURING_INCLUDE_DIR}")
 # Only need util, not all of rocks.
 target_link_libraries(gaia_db_persistence PUBLIC rocksdb "${LIBURING_LIBRARY}")
-add_dependencies(gaia_db_persistence gaia_common)
+add_dependencies(gaia_db_persistence gaia_common ${FBS_SOURCE_FILENAMES})
 
 set(GAIA_DB_SERVER_SOURCES
   src/catalog_core.cpp

--- a/production/db/core/src/log_io.cpp
+++ b/production/db/core/src/log_io.cpp
@@ -38,7 +38,6 @@
 #include "memory_helpers.hpp"
 #include "memory_types.hpp"
 #include "persistence_types.hpp"
-#include "txn_metadata.hpp"
 
 using namespace gaia::common;
 using namespace gaia::db::memory_manager;

--- a/production/db/core/src/persistent_store_manager.cpp
+++ b/production/db/core/src/persistent_store_manager.cpp
@@ -18,7 +18,6 @@
 
 #include "db_helpers.hpp"
 #include "db_internal_types.hpp"
-#include "db_shared_data.hpp"
 #include "rdb_object_converter.hpp"
 #include "rdb_wrapper.hpp"
 

--- a/production/db/core/src/rdb_object_converter.cpp
+++ b/production/db/core/src/rdb_object_converter.cpp
@@ -8,10 +8,7 @@
 
 #include "rdb_object_converter.hpp"
 
-#include "db_helpers.hpp"
-#include "db_internal_types.hpp"
 #include "db_object_helpers.hpp"
-#include "persistent_store_manager.hpp"
 
 using namespace gaia::common;
 using namespace gaia::db;


### PR DESCRIPTION
- Fix `rocks_wrapper` and `gaia_db_persistence` CMake dependencies, that would cause build failure with a clean build.
- Cleanup some used headers