### PR TITLE
Add LICENSE files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
 # Gaia Platform License
 
-Gaia Platform code is provided unde the [MIT License](LICENSE.txt), except portions that are provided under the licenses referenced in [Third-Party Licenses](production/licenses/LICENSE.third-party.txt).
+The Gaia Platform code is provided unde the [MIT License](LICENSE.txt), except portions that are provided under the licenses referenced in [Third-Party Licenses](production/licenses/LICENSE.third-party.txt).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+# Gaia Platform License
+
+Gaia Platform code is provided unde the [MIT License](LICENSE.txt), except portions that are provided under the licenses referenced in [Third-Party Licenses](production/licenses/LICENSE.third-party.txt).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright 2019-2022 Gaia Platform LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Typically, projects also contain their license in their root folder, but we forgot to add one even after we started using the MIT license. So I just added a file for the MIT license (text copied from the MIT license site and edited to include our name) and I also added a markdown file to mention that the MIT license applies to all our code, except for the third party components as mentioned in our other file collecting all third-party licenses.