### PR TITLE
Add links to platform information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 GaiaPlatform - Main repository
 
+## Gaia Platform Overview
+
+For an introduction to Gaia Platform, see: https://gaia-platform.github.io/gaia-platform-docs.io/index.html
+
+If the above link is not available, the source HTML can also be retrieved from https://github.com/gaia-platform/gaia-platform-docs.io/blob/main/index.html.
+
 ## Repository Guidelines
 
 To maintain a healthy codebase, we have a collection of guidelines to use when authoring code.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GaiaPlatform - Main repository
 
 ## Gaia Platform Overview
 
-For an introduction to Gaia Platform, see: https://gaia-platform.github.io/gaia-platform-docs.io/index.html
+For an introduction to Gaia Platform, see: https://gaia-platform.github.io/gaia-platform-docs.io/index.html.
 
 If the above link is not available, the source HTML can also be retrieved from https://github.com/gaia-platform/gaia-platform-docs.io/blob/main/index.html.
 


### PR DESCRIPTION
Just a small change to provide pointers for an introduction to the platform in the main README file.