### PR TITLE
Add version info to gaia_db_extract tool

### DIFF
--- a/production/tools/gaia_db_extract/src/main.cpp
+++ b/production/tools/gaia_db_extract/src/main.cpp
@@ -13,6 +13,8 @@
 #include "gaia/db/db.hpp"
 #include "gaia/exceptions.hpp"
 
+#include "gaia_internal/common/gaia_version.hpp"
+
 #include "gaia_db_extract.hpp"
 
 using namespace gaia::common;
@@ -26,13 +28,14 @@ constexpr char c_database_string[] = "database";
 constexpr char c_table_string[] = "table";
 constexpr char c_link_name_string[] = "link-name";
 constexpr char c_link_row_string[] = "link-row";
+constexpr char c_version_string[] = "version";
 
 // Command-line usage.
 static void usage()
 {
     cerr << "OVERVIEW: Outputs a JSON representation of either the table schema, or selected rows within a database and table." << endl
          << endl;
-    cerr << "USAGE: gaia_db_extract [--" << c_help_string << "] [--" << c_database_string << "=<databasename> --" << c_table_string
+    cerr << "USAGE: gaia_db_extract [--" << c_help_string << "] [--" << c_version_string << "] [--" << c_database_string << "=<databasename> --" << c_table_string
          << "=<tablename> [--" << c_row_limit_string << "=N] [--" << c_start_after_string << "=ID]]" << endl
          << endl;
     cerr << "NO OPTIONS: extract table schema information only." << endl
@@ -55,6 +58,12 @@ static void usage()
     exit(EXIT_FAILURE);
 }
 
+static void version()
+{
+    cerr << "Gaia Database Extraction Tool " << gaia_full_version() << "\nCopyright (c) Gaia Platform Authors\n";
+    exit(EXIT_SUCCESS);
+}
+
 // Break a command-line parameter into its pieces.
 static void parse_arg(int argc, char* argv[], int& arg, string& key, string& value)
 {
@@ -69,6 +78,11 @@ static void parse_arg(int argc, char* argv[], int& arg, string& key, string& val
     if (!key.compare(c_help_string))
     {
         usage();
+    }
+
+    if (!key.compare(c_version_string))
+    {
+        version();
     }
 
     auto pos = key.find('=');


### PR DESCRIPTION
Add support for `--version` command line argument to `gaia_db_extract` tool.