### PR TITLE
Add YAML frontmatter validation workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,6 +350,17 @@ jobs:
           job-name: ${{ github.job }}
           github-token: ${{ secrets.API_TOKEN_GITHUB }}
 
+  YAML_Frontmatter_Validation:
+    needs:
+      - Lint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@main
+
+      - name: Run YAML Frontmatter Validation
+        run: ./.github/workflows/yaml-frontmatter-validation.yml
+
   Final:
     needs:
       - Core
@@ -361,6 +372,7 @@ jobs:
 #      - Performance_Tests
       - Integration_Samples
 #      - Documentation
+      - YAML_Frontmatter_Validation
     runs-on: ubuntu-20.04
     steps:
       - uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/yaml-frontmatter-validation.yml
+++ b/.github/workflows/yaml-frontmatter-validation.yml
@@ -1,0 +1,51 @@
+name: YAML Frontmatter Validation
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+
+jobs:
+  validate_yaml:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: List Markdown files
+        run: |
+          echo "Files to be validated:"
+          ls -l **/*.md || echo "No Markdown files found."
+
+      - name: Validate YAML frontmatter
+        uses: cschleiden/actions-linter@v1
+        with:
+          file-glob: '**/*.md'
+          schema: |
+            type: object
+            required:
+              - title
+              - status
+              - version
+              - date
+              - domain
+              - author
+              - repo
+              - compliance
+            properties:
+              title:
+                type: string
+              status:
+                enum: ['Draft A1', 'Review', 'Approved', 'Released']
+              version:
+                type: string
+              date:
+                format: date
+              domain:
+                type: string
+              author:
+                type: string
+              repo:
+                type: string
+              compliance:
+                enum: ['Pending Review', 'Compliant', 'Non-Compliant']

--- a/README.md
+++ b/README.md
@@ -154,3 +154,30 @@ Note that Clion expects a `CMakeLists.txt` at the root of the project. We don't 
    - Press the play button on the left of each test.
 4. Modify
    - Add `EXPECT_EQ(true, false)` to any test, press the play button, observe the test being compiled, executed and the obvious failure.
+
+## YAML Frontmatter Validation Workflow
+
+This repository includes a GitHub Actions workflow to validate the YAML frontmatter in Markdown files. The workflow ensures that every Markdown file contains a complete and valid YAML frontmatter block that adheres to the specified schema.
+
+### How to Use the Workflow
+
+The workflow is triggered automatically on push events for Markdown files (`**/*.md`). It validates the YAML frontmatter in the changed Markdown files against the defined schema.
+
+### Interpreting the Results
+
+If the YAML frontmatter in a Markdown file does not match the schema, the workflow will fail, and the details of the validation errors will be displayed in the workflow logs. You can use this information to identify and fix the issues in the YAML frontmatter.
+
+### Example of a Valid YAML Frontmatter Block
+
+```yaml
+---
+title: "Example Title"
+status: "Draft A1"
+version: "1.0"
+date: "2023-01-01"
+domain: "example-domain"
+author: "Author Name"
+repo: "example-repo"
+compliance: "Pending Review"
+---
+```


### PR DESCRIPTION
Add a new GitHub Actions workflow for YAML frontmatter validation.

* **.github/workflows/yaml-frontmatter-validation.yml**
  - Add a new workflow file named `yaml-frontmatter-validation.yml`.
  - Configure the workflow to trigger on push events for Markdown files (`**/*.md`).
  - Define a job named `validate_yaml` that runs on `ubuntu-latest`.
  - Add steps to checkout the repository, list Markdown files, and validate YAML frontmatter using the provided schema.

* **.github/workflows/main.yml**
  - Add a new job named `YAML_Frontmatter_Validation` to the existing workflow.
  - Set the job to run on `ubuntu-20.04`.
  - Add steps to checkout the repository and run the `yaml-frontmatter-validation.yml` workflow.
  - Ensure the new job runs after the `Lint` job.

* **README.md**
  - Add a section explaining the new YAML frontmatter validation workflow.
  - Provide instructions on how to use the workflow and interpret the results.
  - Include an example of a valid YAML frontmatter block.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gaia-platform/GaiaPlatform/pull/1554?shareId=cf3f192e-2851-4ac6-8c25-532aa286ce55).